### PR TITLE
Syntax highlighting of `meson_options.txt` as `meson.build`

### DIFF
--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -96,7 +96,7 @@ include makefile.syntax
 file (CMakeLists.txt|.\*.cmake)$ CMake
 include cmake.syntax
 
-file meson\\.build$ Meson\sBuild\sFile
+file (meson\\.build|meson_options\\.txt)$ Meson\sBuild\sFile
 include meson.syntax
 
 file ..\*\\.(?i:pas|dpr|inc)$ Pascal\sProgram


### PR DESCRIPTION
Meson's keywords in `meson_options.txt` isn't highlighted in `mcedit`.

## Checklist

- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)