### PR TITLE
maint: explicitly compare preset issue type names in labeler workflow

### DIFF
--- a/.github/workflows/process-incoming-issues.yml
+++ b/.github/workflows/process-incoming-issues.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/github-script@v7
         id: set-issue-type
-        if: ${{ ! steps.get-issue-type.outputs.result.repository.issue.issueType }}
+        if: ${{ steps.get-issue-type.outputs.result.repository.issue.issueType.name != "Bug" && steps.get-issue-type.outputs.result.repository.issue.issueType.name != "Feature" }}
         with:
           script: |
             return github.graphql(`


### PR DESCRIPTION
## Proposed changes

Should hopefully fix mislabelling like in #4661.

## Checklist

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [ ] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
