### PR TITLE
Ticket #4670: customize error message when `known_hosts` file cannot …

### DIFF
--- a/src/vfs/sftpfs/connection.c
+++ b/src/vfs/sftpfs/connection.c
@@ -273,6 +273,14 @@ sftpfs_read_known_hosts (struct vfs_s_super *super, GError **mcerror)
 
     sftpfs_super->known_hosts_file =
         mc_build_filename (mc_config_get_home_dir (), ".ssh", "known_hosts", (char *) NULL);
+
+    if (!exist_file (sftpfs_super->known_hosts_file))
+    {
+        mc_propagate_error (mcerror, 0, _ ("sftp: cannot open %s:\n%s"),
+                            sftpfs_super->known_hosts_file, unix_error_string (errno));
+        return FALSE;
+    }
+
     rc = libssh2_knownhost_readfile (sftpfs_super->known_hosts, sftpfs_super->known_hosts_file,
                                      LIBSSH2_KNOWNHOST_FILE_OPENSSH);
     if (rc > 0)


### PR DESCRIPTION
…be opened

## Proposed changes

I suggest adding a custom error message before trying to access `known_hosts`, because the stuff coming from `libssh2` is too cryptic.

Resolves: #4670
