### PR TITLE
Ticket #4678: `usqfs` parser ignored first 4 lines of the file listing

### DIFF
--- a/src/vfs/extfs/helpers/usqfs.in
+++ b/src/vfs/extfs/helpers/usqfs.in
@@ -2,7 +2,7 @@
 #
 # Squash file system
 #
-# tested to comply with unsquashfs version 4.2 (2011/02/28)'s output
+# tested to comply with the output of unsquashfs version 4.6.1 (2023/03/25)
 
 SQUASHFS="${MC_TEST_EXTFS_LIST_CMD:-unsquashfs}"
 AWK="@AWK@"
@@ -13,8 +13,6 @@ mcsqfs_list ()
 {
   $SQUASHFS -d "" -lls "$1" | $AWK '
     {
-      if (NR < 5)
-        next
       split($2, a, "/")
       file_type=substr($1,1,1)
       file_size=file_type == "c" || file_type == "b" ? 0 : $3

--- a/tests/src/vfs/extfs/helpers-list/data/usqfs.output
+++ b/tests/src/vfs/extfs/helpers-list/data/usqfs.output
@@ -1,3 +1,7 @@
+drwxr-xr-x   1        235 2024-09-23 14:34:00 
+drwxr-xr-x   1        778 2024-09-23 14:34:00 /bin
+lrwxrwxrwx   1          7 2024-09-23 14:34:00 /bin/ash -> busybox
+-rwxr-xr-x   1        205 2024-09-23 14:34:00 /bin/board_detect
 -rwxr-xr-x   1     327717 2024-09-23 14:34:00 /bin/busybox
 lrwxrwxrwx   1          7 2024-09-23 14:34:00 /bin/cat -> busybox
 lrwxrwxrwx   1          7 2024-09-23 14:34:00 /bin/chgrp -> busybox


### PR DESCRIPTION
## Proposed changes

Resolves: #4678

## Checklist

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
