### PR TITLE
Ticket #4683: add menu item to toggle right margin

### DIFF
--- a/src/editor/editmenu.c
+++ b/src/editor/editmenu.c
@@ -154,6 +154,7 @@ create_command_menu (void)
         g_list_prepend (entries, menu_entry_new (_ ("Go to matching &bracket"), CK_MatchBracket));
     entries = g_list_prepend (entries,
                               menu_entry_new (_ ("Toggle s&yntax highlighting"), CK_SyntaxOnOff));
+    entries = g_list_prepend (entries, menu_entry_new (_ ("Togg&le right margin"), CK_ShowMargin));
     entries = g_list_prepend (entries, menu_separator_new ());
     entries = g_list_prepend (entries, menu_entry_new (_ ("&Find declaration"), CK_Find));
     entries = g_list_prepend (entries, menu_entry_new (_ ("Back from &declaration"), CK_FilePrev));


### PR DESCRIPTION
## Proposed changes

In ticket #1514 a function was introduced to show the right margin in the text editor. The option is only accessible through the INI-file. No menu entry or editor option was added to access it from the TUI.

In ticket #2920, it was commented that this hidden option should be taken into account when designing skins.

Many years have passed. I suggest adding a menu entry, just like for other toggle options. I understand that the concern at the time was to avoid an explosion of menus and options, but a hidden feature is not helpful.

We can take this into account when we rebuild the menu/options dialog one day, until then at least this option will be directly usable.