### PR TITLE
Ticket #4684: various fixes to shipped skins

### DIFF
--- a/misc/skins/dark.ini
+++ b/misc/skins/dark.ini
@@ -140,12 +140,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/dark.ini
+++ b/misc/skins/dark.ini
@@ -136,8 +136,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/dark.ini
+++ b/misc/skins/dark.ini
@@ -133,17 +133,17 @@
     sort-down-char = ↓
     hiddenfiles-show-char = •
     hiddenfiles-hide-char = ○
-    history-prev-item-char = ←
-    history-next-item-char = →
+    history-prev-item-char = ‹
+    history-next-item-char = ›
     history-show-list-char = ↓
     filename-scroll-left-char = «
     filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 

--- a/misc/skins/darkfar.ini
+++ b/misc/skins/darkfar.ini
@@ -136,8 +136,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❰
+    filename-scroll-right-char = ❱
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/darkfar.ini
+++ b/misc/skins/darkfar.ini
@@ -140,12 +140,12 @@
     filename-scroll-right-char = ❱
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/darkfar.ini
+++ b/misc/skins/darkfar.ini
@@ -133,17 +133,17 @@
     sort-down-char = ↓
     hiddenfiles-show-char = •
     hiddenfiles-hide-char = ○
-    history-prev-item-char = ←
-    history-next-item-char = →
+    history-prev-item-char = ‹
+    history-next-item-char = ›
     history-show-list-char = ↓
     filename-scroll-left-char = «
     filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 

--- a/misc/skins/default.ini
+++ b/misc/skins/default.ini
@@ -140,12 +140,12 @@
     filename-scroll-right-char = }
 
 [widget-scrollbar]
-    first-vert-char = ^
-    last-vert-char = v
-    first-horiz-char = <
-    last-horiz-char = >
-    current-char = *
-    background-char = X
+    up-char = ^
+    down-char = v
+    left-char = <
+    right-char = >
+    thumb-char = *
+    track-char = X
 
 [widget-editor]
     window-state-char = *

--- a/misc/skins/default.ini
+++ b/misc/skins/default.ini
@@ -131,8 +131,21 @@
 [widget-panel]
     sort-up-char = '
     sort-down-char = .
+    hiddenfiles-show-char = .
+    hiddenfiles-hide-char = .
+    history-prev-item-char = <
+    history-next-item-char = >
+    history-show-list-char = ^
     filename-scroll-left-char = {
     filename-scroll-right-char = }
+
+[widget-scrollbar]
+    first-vert-char = ^
+    last-vert-char = v
+    first-horiz-char = <
+    last-horiz-char = >
+    current-char = *
+    background-char = X
 
 [widget-editor]
     window-state-char = *

--- a/misc/skins/double-lines.ini
+++ b/misc/skins/double-lines.ini
@@ -140,12 +140,12 @@
     filename-scroll-right-char = }
 
 [widget-scrollbar]
-    first-vert-char = ^
-    last-vert-char = v
-    first-horiz-char = <
-    last-horiz-char = >
-    current-char = *
-    background-char = X
+    up-char = ^
+    down-char = v
+    left-char = <
+    right-char = >
+    thumb-char = *
+    track-char = X
 
 [widget-editor]
     window-state-char = *

--- a/misc/skins/double-lines.ini
+++ b/misc/skins/double-lines.ini
@@ -131,8 +131,21 @@
 [widget-panel]
     sort-up-char = '
     sort-down-char = .
+    hiddenfiles-show-char = .
+    hiddenfiles-hide-char = .
+    history-prev-item-char = <
+    history-next-item-char = >
+    history-show-list-char = ^
     filename-scroll-left-char = {
     filename-scroll-right-char = }
+
+[widget-scrollbar]
+    first-vert-char = ^
+    last-vert-char = v
+    first-horiz-char = <
+    last-horiz-char = >
+    current-char = *
+    background-char = X
 
 [widget-editor]
     window-state-char = *

--- a/misc/skins/featured-plus.ini
+++ b/misc/skins/featured-plus.ini
@@ -137,9 +137,17 @@
     hiddenfiles-hide-char = •
     history-prev-item-char = «
     history-next-item-char = »
-    history-show-list-char = ^
+    history-show-list-char = ⇊
     filename-scroll-left-char = «
     filename-scroll-right-char = »
+
+[widget-scrollbar]
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
+    current-char = ■
+    background-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/featured-plus.ini
+++ b/misc/skins/featured-plus.ini
@@ -142,12 +142,12 @@
     filename-scroll-right-char = ❱
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/featured-plus.ini
+++ b/misc/skins/featured-plus.ini
@@ -138,8 +138,8 @@
     history-prev-item-char = «
     history-next-item-char = »
     history-show-list-char = ⇊
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❰
+    filename-scroll-right-char = ❱
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/featured.ini
+++ b/misc/skins/featured.ini
@@ -137,9 +137,17 @@
     hiddenfiles-hide-char = •
     history-prev-item-char = «
     history-next-item-char = »
-    history-show-list-char = ^
+    history-show-list-char = ⇊
     filename-scroll-left-char = «
     filename-scroll-right-char = »
+
+[widget-scrollbar]
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
+    current-char = ■
+    background-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/featured.ini
+++ b/misc/skins/featured.ini
@@ -142,12 +142,12 @@
     filename-scroll-right-char = ❱
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/featured.ini
+++ b/misc/skins/featured.ini
@@ -138,8 +138,8 @@
     history-prev-item-char = «
     history-next-item-char = »
     history-show-list-char = ⇊
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❰
+    filename-scroll-right-char = ❱
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/gotar.ini
+++ b/misc/skins/gotar.ini
@@ -138,12 +138,12 @@
     filename-scroll-right-char = }
 
 [widget-scrollbar]
-    first-vert-char = ^
-    last-vert-char = v
-    first-horiz-char = <
-    last-horiz-char = >
-    current-char = *
-    background-char = X
+    up-char = ^
+    down-char = v
+    left-char = <
+    right-char = >
+    thumb-char = *
+    track-char = X
 
 [widget-editor]
     window-state-char = *

--- a/misc/skins/gotar.ini
+++ b/misc/skins/gotar.ini
@@ -127,8 +127,23 @@
     error = white;red
 
 [widget-panel]
+    sort-up-char = '
+    sort-down-char = .
+    hiddenfiles-show-char = .
+    hiddenfiles-hide-char = .
+    history-prev-item-char = <
+    history-next-item-char = >
+    history-show-list-char = ^
     filename-scroll-left-char = {
     filename-scroll-right-char = }
+
+[widget-scrollbar]
+    first-vert-char = ^
+    last-vert-char = v
+    first-horiz-char = <
+    last-horiz-char = >
+    current-char = *
+    background-char = X
 
 [widget-editor]
     window-state-char = *

--- a/misc/skins/gray-green-purple256.ini
+++ b/misc/skins/gray-green-purple256.ini
@@ -149,12 +149,12 @@
     filename-scroll-right-char = ▸
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/gray-green-purple256.ini
+++ b/misc/skins/gray-green-purple256.ini
@@ -149,10 +149,10 @@
     filename-scroll-right-char = ▸
 
 [widget-scrollbar]
-    first-vert-char = ▴
-    last-vert-char = ▾
-    first-horiz-char = ◂
-    last-horiz-char = ▸
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 

--- a/misc/skins/gray-orange-blue256.ini
+++ b/misc/skins/gray-orange-blue256.ini
@@ -149,12 +149,12 @@
     filename-scroll-right-char = ▸
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/gray-orange-blue256.ini
+++ b/misc/skins/gray-orange-blue256.ini
@@ -149,10 +149,10 @@
     filename-scroll-right-char = ▸
 
 [widget-scrollbar]
-    first-vert-char = ▴
-    last-vert-char = ▾
-    first-horiz-char = ◂
-    last-horiz-char = ▸
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 

--- a/misc/skins/julia256.ini
+++ b/misc/skins/julia256.ini
@@ -141,8 +141,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/julia256.ini
+++ b/misc/skins/julia256.ini
@@ -145,12 +145,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/julia256.ini
+++ b/misc/skins/julia256.ini
@@ -138,16 +138,20 @@
     sort-down-char = ↓
     hiddenfiles-show-char = •
     hiddenfiles-hide-char = ○
-    history-prev-item-char = ←
-    history-next-item-char = →
+    history-prev-item-char = ‹
+    history-next-item-char = ›
     history-show-list-char = ↓
     filename-scroll-left-char = «
     filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/julia256root.ini
+++ b/misc/skins/julia256root.ini
@@ -141,8 +141,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/julia256root.ini
+++ b/misc/skins/julia256root.ini
@@ -145,12 +145,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/julia256root.ini
+++ b/misc/skins/julia256root.ini
@@ -138,16 +138,20 @@
     sort-down-char = ↓
     hiddenfiles-show-char = •
     hiddenfiles-hide-char = ○
-    history-prev-item-char = ←
-    history-next-item-char = →
+    history-prev-item-char = ‹
+    history-next-item-char = ›
     history-show-list-char = ↓
     filename-scroll-left-char = «
     filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/mc46.ini
+++ b/misc/skins/mc46.ini
@@ -131,12 +131,12 @@
     filename-scroll-right-char = }
 
 [widget-scrollbar]
-    first-vert-char = ^
-    last-vert-char = v
-    first-horiz-char = <
-    last-horiz-char = >
-    current-char = *
-    background-char = X
+    up-char = ^
+    down-char = v
+    left-char = <
+    right-char = >
+    thumb-char = *
+    track-char = X
 
 [widget-editor]
     window-state-char = *

--- a/misc/skins/mc46.ini
+++ b/misc/skins/mc46.ini
@@ -122,8 +122,21 @@
 [widget-panel]
     sort-up-char = '
     sort-down-char = .
+    hiddenfiles-show-char = .
+    hiddenfiles-hide-char = .
+    history-prev-item-char = <
+    history-next-item-char = >
+    history-show-list-char = ^
     filename-scroll-left-char = {
     filename-scroll-right-char = }
+
+[widget-scrollbar]
+    first-vert-char = ^
+    last-vert-char = v
+    first-horiz-char = <
+    last-horiz-char = >
+    current-char = *
+    background-char = X
 
 [widget-editor]
     window-state-char = *

--- a/misc/skins/modarcon16-defbg-thin.ini
+++ b/misc/skins/modarcon16-defbg-thin.ini
@@ -164,21 +164,25 @@
     removed = color8;color0
     error = color15;color1
 
-[widget-common]
-    sort-sign-up = ↑
-    sort-sign-down = ↓
-
 [widget-panel]
-    hiddenfiles-sign-show = •
-    hiddenfiles-sign-hide = ○
-    history-prev-item-sign = «
-    history-next-item-sign = »
-    history-show-list-sign = ^
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
-[widget-scollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+[widget-scrollbar]
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarcon16-defbg-thin.ini
+++ b/misc/skins/modarcon16-defbg-thin.ini
@@ -176,12 +176,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarcon16-defbg-thin.ini
+++ b/misc/skins/modarcon16-defbg-thin.ini
@@ -172,8 +172,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarcon16-defbg.ini
+++ b/misc/skins/modarcon16-defbg.ini
@@ -178,12 +178,12 @@
     filename-scroll-right-char = ❱
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarcon16-defbg.ini
+++ b/misc/skins/modarcon16-defbg.ini
@@ -174,8 +174,8 @@
     history-prev-item-char = «
     history-next-item-char = »
     history-show-list-char = ⇊
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❰
+    filename-scroll-right-char = ❱
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarcon16-defbg.ini
+++ b/misc/skins/modarcon16-defbg.ini
@@ -173,16 +173,18 @@
     hiddenfiles-hide-char = ○
     history-prev-item-char = «
     history-next-item-char = »
-    history-show-list-char = ^
+    history-show-list-char = ⇊
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 
 [widget-editor]
-    window-state-char = *
-    window-close-char = X
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarcon16-thin.ini
+++ b/misc/skins/modarcon16-thin.ini
@@ -164,21 +164,25 @@
     removed = color8;color0
     error = color15;color1
 
-[widget-common]
-    sort-sign-up = ↑
-    sort-sign-down = ↓
-
 [widget-panel]
-    hiddenfiles-sign-show = •
-    hiddenfiles-sign-hide = ○
-    history-prev-item-sign = «
-    history-next-item-sign = »
-    history-show-list-sign = ^
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
-[widget-scollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+[widget-scrollbar]
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarcon16-thin.ini
+++ b/misc/skins/modarcon16-thin.ini
@@ -176,12 +176,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarcon16-thin.ini
+++ b/misc/skins/modarcon16-thin.ini
@@ -172,8 +172,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarcon16.ini
+++ b/misc/skins/modarcon16.ini
@@ -178,12 +178,12 @@
     filename-scroll-right-char = ❱
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarcon16.ini
+++ b/misc/skins/modarcon16.ini
@@ -174,8 +174,8 @@
     history-prev-item-char = «
     history-next-item-char = »
     history-show-list-char = ⇊
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❰
+    filename-scroll-right-char = ❱
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarcon16.ini
+++ b/misc/skins/modarcon16.ini
@@ -173,16 +173,18 @@
     hiddenfiles-hide-char = ○
     history-prev-item-char = «
     history-next-item-char = »
-    history-show-list-char = ^
+    history-show-list-char = ⇊
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 
 [widget-editor]
-    window-state-char = *
-    window-close-char = X
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarcon16root-defbg-thin.ini
+++ b/misc/skins/modarcon16root-defbg-thin.ini
@@ -164,21 +164,25 @@
     removed = color8;color0
     error = color15;color1
 
-[widget-common]
-    sort-sign-up = ↑
-    sort-sign-down = ↓
-
 [widget-panel]
-    hiddenfiles-sign-show = •
-    hiddenfiles-sign-hide = ○
-    history-prev-item-sign = «
-    history-next-item-sign = »
-    history-show-list-sign = ^
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
-[widget-scollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+[widget-scrollbar]
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarcon16root-defbg-thin.ini
+++ b/misc/skins/modarcon16root-defbg-thin.ini
@@ -176,12 +176,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarcon16root-defbg-thin.ini
+++ b/misc/skins/modarcon16root-defbg-thin.ini
@@ -172,8 +172,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarcon16root-defbg.ini
+++ b/misc/skins/modarcon16root-defbg.ini
@@ -178,12 +178,12 @@
     filename-scroll-right-char = ❱
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarcon16root-defbg.ini
+++ b/misc/skins/modarcon16root-defbg.ini
@@ -174,8 +174,8 @@
     history-prev-item-char = «
     history-next-item-char = »
     history-show-list-char = ⇊
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❰
+    filename-scroll-right-char = ❱
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarcon16root-defbg.ini
+++ b/misc/skins/modarcon16root-defbg.ini
@@ -173,16 +173,18 @@
     hiddenfiles-hide-char = ○
     history-prev-item-char = «
     history-next-item-char = »
-    history-show-list-char = ^
+    history-show-list-char = ⇊
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 
 [widget-editor]
-    window-state-char = *
-    window-close-char = X
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarcon16root-thin.ini
+++ b/misc/skins/modarcon16root-thin.ini
@@ -164,21 +164,25 @@
     removed = color8;color0
     error = color15;color1
 
-[widget-common]
-    sort-sign-up = ↑
-    sort-sign-down = ↓
-
 [widget-panel]
-    hiddenfiles-sign-show = •
-    hiddenfiles-sign-hide = ○
-    history-prev-item-sign = «
-    history-next-item-sign = »
-    history-show-list-sign = ^
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
-[widget-scollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+[widget-scrollbar]
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarcon16root-thin.ini
+++ b/misc/skins/modarcon16root-thin.ini
@@ -176,12 +176,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarcon16root-thin.ini
+++ b/misc/skins/modarcon16root-thin.ini
@@ -172,8 +172,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarcon16root.ini
+++ b/misc/skins/modarcon16root.ini
@@ -178,12 +178,12 @@
     filename-scroll-right-char = ❱
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarcon16root.ini
+++ b/misc/skins/modarcon16root.ini
@@ -174,8 +174,8 @@
     history-prev-item-char = «
     history-next-item-char = »
     history-show-list-char = ⇊
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❰
+    filename-scroll-right-char = ❱
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarcon16root.ini
+++ b/misc/skins/modarcon16root.ini
@@ -173,16 +173,18 @@
     hiddenfiles-hide-char = ○
     history-prev-item-char = «
     history-next-item-char = »
-    history-show-list-char = ^
+    history-show-list-char = ⇊
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 
 [widget-editor]
-    window-state-char = *
-    window-close-char = X
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarin256-defbg-thin.ini
+++ b/misc/skins/modarin256-defbg-thin.ini
@@ -164,21 +164,25 @@
     removed = ;color234
     error = color231;color160
 
-[widget-common]
-    sort-sign-up = ↑
-    sort-sign-down = ↓
-
 [widget-panel]
-    hiddenfiles-sign-show = •
-    hiddenfiles-sign-hide = ○
-    history-prev-item-sign = «
-    history-next-item-sign = »
-    history-show-list-sign = ^
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
-[widget-scollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+[widget-scrollbar]
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarin256-defbg-thin.ini
+++ b/misc/skins/modarin256-defbg-thin.ini
@@ -176,12 +176,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarin256-defbg-thin.ini
+++ b/misc/skins/modarin256-defbg-thin.ini
@@ -172,8 +172,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarin256-defbg.ini
+++ b/misc/skins/modarin256-defbg.ini
@@ -178,12 +178,12 @@
     filename-scroll-right-char = ❱
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarin256-defbg.ini
+++ b/misc/skins/modarin256-defbg.ini
@@ -174,8 +174,8 @@
     history-prev-item-char = «
     history-next-item-char = »
     history-show-list-char = ⇊
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❰
+    filename-scroll-right-char = ❱
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarin256-defbg.ini
+++ b/misc/skins/modarin256-defbg.ini
@@ -173,16 +173,18 @@
     hiddenfiles-hide-char = ○
     history-prev-item-char = «
     history-next-item-char = »
-    history-show-list-char = ^
+    history-show-list-char = ⇊
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 
 [widget-editor]
-    window-state-char = *
-    window-close-char = X
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarin256-thin.ini
+++ b/misc/skins/modarin256-thin.ini
@@ -176,12 +176,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarin256-thin.ini
+++ b/misc/skins/modarin256-thin.ini
@@ -164,21 +164,25 @@
     removed = ;color235
     error = color231;color160
 
-[widget-common]
-    sort-sign-up = ↑
-    sort-sign-down = ↓
-
 [widget-panel]
-    hiddenfiles-sign-show = •
-    hiddenfiles-sign-hide = ○
-    history-prev-item-sign = «
-    history-next-item-sign = »
-    history-show-list-sign = ^
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarin256-thin.ini
+++ b/misc/skins/modarin256-thin.ini
@@ -172,8 +172,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarin256.ini
+++ b/misc/skins/modarin256.ini
@@ -178,12 +178,12 @@
     filename-scroll-right-char = ❱
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarin256.ini
+++ b/misc/skins/modarin256.ini
@@ -174,8 +174,8 @@
     history-prev-item-char = «
     history-next-item-char = »
     history-show-list-char = ⇊
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❰
+    filename-scroll-right-char = ❱
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarin256.ini
+++ b/misc/skins/modarin256.ini
@@ -173,16 +173,18 @@
     hiddenfiles-hide-char = ○
     history-prev-item-char = «
     history-next-item-char = »
-    history-show-list-char = ^
+    history-show-list-char = ⇊
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 
 [widget-editor]
-    window-state-char = *
-    window-close-char = X
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarin256root-defbg-thin.ini
+++ b/misc/skins/modarin256root-defbg-thin.ini
@@ -164,21 +164,25 @@
     removed = ;color234
     error = color231;color160
 
-[widget-common]
-    sort-sign-up = ↑
-    sort-sign-down = ↓
-
 [widget-panel]
-    hiddenfiles-sign-show = •
-    hiddenfiles-sign-hide = ○
-    history-prev-item-sign = «
-    history-next-item-sign = »
-    history-show-list-sign = ^
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
-[widget-scollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+[widget-scrollbar]
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarin256root-defbg-thin.ini
+++ b/misc/skins/modarin256root-defbg-thin.ini
@@ -176,12 +176,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarin256root-defbg-thin.ini
+++ b/misc/skins/modarin256root-defbg-thin.ini
@@ -172,8 +172,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarin256root-defbg.ini
+++ b/misc/skins/modarin256root-defbg.ini
@@ -178,12 +178,12 @@
     filename-scroll-right-char = ❱
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarin256root-defbg.ini
+++ b/misc/skins/modarin256root-defbg.ini
@@ -174,8 +174,8 @@
     history-prev-item-char = «
     history-next-item-char = »
     history-show-list-char = ⇊
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❰
+    filename-scroll-right-char = ❱
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarin256root-defbg.ini
+++ b/misc/skins/modarin256root-defbg.ini
@@ -173,16 +173,18 @@
     hiddenfiles-hide-char = ○
     history-prev-item-char = «
     history-next-item-char = »
-    history-show-list-char = ^
+    history-show-list-char = ⇊
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 
 [widget-editor]
-    window-state-char = *
-    window-close-char = X
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarin256root-thin.ini
+++ b/misc/skins/modarin256root-thin.ini
@@ -176,12 +176,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarin256root-thin.ini
+++ b/misc/skins/modarin256root-thin.ini
@@ -164,21 +164,25 @@
     removed = ;color235
     error = color231;color160
 
-[widget-common]
-    sort-sign-up = ↑
-    sort-sign-down = ↓
-
 [widget-panel]
-    hiddenfiles-sign-show = •
-    hiddenfiles-sign-hide = ○
-    history-prev-item-sign = «
-    history-next-item-sign = »
-    history-show-list-sign = ^
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/modarin256root-thin.ini
+++ b/misc/skins/modarin256root-thin.ini
@@ -172,8 +172,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarin256root.ini
+++ b/misc/skins/modarin256root.ini
@@ -178,12 +178,12 @@
     filename-scroll-right-char = ❱
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/modarin256root.ini
+++ b/misc/skins/modarin256root.ini
@@ -174,8 +174,8 @@
     history-prev-item-char = «
     history-next-item-char = »
     history-show-list-char = ⇊
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❰
+    filename-scroll-right-char = ❱
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/modarin256root.ini
+++ b/misc/skins/modarin256root.ini
@@ -173,16 +173,18 @@
     hiddenfiles-hide-char = ○
     history-prev-item-char = «
     history-next-item-char = »
-    history-show-list-char = ^
+    history-show-list-char = ⇊
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 
 [widget-editor]
-    window-state-char = *
-    window-close-char = X
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/nicedark.ini
+++ b/misc/skins/nicedark.ini
@@ -140,12 +140,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/nicedark.ini
+++ b/misc/skins/nicedark.ini
@@ -133,11 +133,19 @@
     sort-down-char = ↓
     hiddenfiles-show-char = •
     hiddenfiles-hide-char = ○
-    history-prev-item-char = «
-    history-next-item-char = »
-    history-show-list-char = ^
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
     filename-scroll-left-char = «
     filename-scroll-right-char = »
+
+[widget-scrollbar]
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
+    current-char = ■
+    background-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/nicedark.ini
+++ b/misc/skins/nicedark.ini
@@ -136,8 +136,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/sand256.ini
+++ b/misc/skins/sand256.ini
@@ -194,8 +194,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/sand256.ini
+++ b/misc/skins/sand256.ini
@@ -198,12 +198,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/sand256.ini
+++ b/misc/skins/sand256.ini
@@ -191,17 +191,17 @@
     sort-down-char = ↓
     hiddenfiles-show-char = •
     hiddenfiles-hide-char = ○
-    history-prev-item-char = «
-    history-next-item-char = »
-    history-show-list-char = ^
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
     filename-scroll-left-char = «
     filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 

--- a/misc/skins/seasons-autumn16M.ini
+++ b/misc/skins/seasons-autumn16M.ini
@@ -202,12 +202,12 @@
     filename-scroll-right-char = ▸
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/seasons-autumn16M.ini
+++ b/misc/skins/seasons-autumn16M.ini
@@ -202,10 +202,10 @@
     filename-scroll-right-char = ▸
 
 [widget-scrollbar]
-    first-vert-char = ▴
-    last-vert-char = ▾
-    first-horiz-char = ◂
-    last-horiz-char = ▸
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 

--- a/misc/skins/seasons-spring16M.ini
+++ b/misc/skins/seasons-spring16M.ini
@@ -202,12 +202,12 @@
     filename-scroll-right-char = ▸
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/seasons-spring16M.ini
+++ b/misc/skins/seasons-spring16M.ini
@@ -202,10 +202,10 @@
     filename-scroll-right-char = ▸
 
 [widget-scrollbar]
-    first-vert-char = ▴
-    last-vert-char = ▾
-    first-horiz-char = ◂
-    last-horiz-char = ▸
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 

--- a/misc/skins/seasons-summer16M.ini
+++ b/misc/skins/seasons-summer16M.ini
@@ -202,12 +202,12 @@
     filename-scroll-right-char = ▸
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/seasons-summer16M.ini
+++ b/misc/skins/seasons-summer16M.ini
@@ -202,10 +202,10 @@
     filename-scroll-right-char = ▸
 
 [widget-scrollbar]
-    first-vert-char = ▴
-    last-vert-char = ▾
-    first-horiz-char = ◂
-    last-horiz-char = ▸
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 

--- a/misc/skins/seasons-winter16M.ini
+++ b/misc/skins/seasons-winter16M.ini
@@ -202,12 +202,12 @@
     filename-scroll-right-char = ▸
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/seasons-winter16M.ini
+++ b/misc/skins/seasons-winter16M.ini
@@ -202,10 +202,10 @@
     filename-scroll-right-char = ▸
 
 [widget-scrollbar]
-    first-vert-char = ▴
-    last-vert-char = ▾
-    first-horiz-char = ◂
-    last-horiz-char = ▸
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 

--- a/misc/skins/xoria256-thin.ini
+++ b/misc/skins/xoria256-thin.ini
@@ -153,17 +153,17 @@
     sort-down-char = ↓
     hiddenfiles-show-char = •
     hiddenfiles-hide-char = ○
-    history-prev-item-char = «
-    history-next-item-char = »
-    history-show-list-char = ^
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
     filename-scroll-left-char = «
     filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 

--- a/misc/skins/xoria256-thin.ini
+++ b/misc/skins/xoria256-thin.ini
@@ -156,8 +156,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/xoria256-thin.ini
+++ b/misc/skins/xoria256-thin.ini
@@ -160,12 +160,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/xoria256.ini
+++ b/misc/skins/xoria256.ini
@@ -160,12 +160,12 @@
     filename-scroll-right-char = ❱
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/xoria256.ini
+++ b/misc/skins/xoria256.ini
@@ -156,8 +156,8 @@
     history-prev-item-char = «
     history-next-item-char = »
     history-show-list-char = ⇊
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❰
+    filename-scroll-right-char = ❱
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/xoria256.ini
+++ b/misc/skins/xoria256.ini
@@ -155,15 +155,15 @@
     hiddenfiles-hide-char = ○
     history-prev-item-char = «
     history-next-item-char = »
-    history-show-list-char = ^
+    history-show-list-char = ⇊
     filename-scroll-left-char = «
     filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 

--- a/misc/skins/xoria256root-thin.ini
+++ b/misc/skins/xoria256root-thin.ini
@@ -153,17 +153,17 @@
     sort-down-char = ↓
     hiddenfiles-show-char = •
     hiddenfiles-hide-char = ○
-    history-prev-item-char = «
-    history-next-item-char = »
-    history-show-list-char = ^
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
     filename-scroll-left-char = «
     filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = «
-    last-horiz-char = »
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
 

--- a/misc/skins/xoria256root-thin.ini
+++ b/misc/skins/xoria256root-thin.ini
@@ -156,8 +156,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/xoria256root-thin.ini
+++ b/misc/skins/xoria256root-thin.ini
@@ -160,12 +160,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/yadt256-defbg.ini
+++ b/misc/skins/yadt256-defbg.ini
@@ -141,8 +141,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲

--- a/misc/skins/yadt256-defbg.ini
+++ b/misc/skins/yadt256-defbg.ini
@@ -145,12 +145,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/yadt256-defbg.ini
+++ b/misc/skins/yadt256-defbg.ini
@@ -138,14 +138,20 @@
     sort-down-char = ↓
     hiddenfiles-show-char = •
     hiddenfiles-hide-char = ○
-    history-prev-item-char = <
-    history-next-item-char = >
-    history-show-list-char = ^
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = <
-    last-horiz-char = >
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/yadt256.ini
+++ b/misc/skins/yadt256.ini
@@ -137,14 +137,20 @@
     sort-down-char = ↓
     hiddenfiles-show-char = •
     hiddenfiles-hide-char = ○
-    history-prev-item-char = <
-    history-next-item-char = >
-    history-show-list-char = ^
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = «
+    filename-scroll-right-char = »
 
 [widget-scrollbar]
-    first-vert-char = ↑
-    last-vert-char = ↓
-    first-horiz-char = <
-    last-horiz-char = >
+    first-vert-char = ▲
+    last-vert-char = ▼
+    first-horiz-char = ◀
+    last-horiz-char = ▶
     current-char = ■
     background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/yadt256.ini
+++ b/misc/skins/yadt256.ini
@@ -144,12 +144,12 @@
     filename-scroll-right-char = ❭
 
 [widget-scrollbar]
-    first-vert-char = ▲
-    last-vert-char = ▼
-    first-horiz-char = ◀
-    last-horiz-char = ▶
-    current-char = ■
-    background-char = ▒
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
 
 [widget-editor]
     window-state-char = ↕

--- a/misc/skins/yadt256.ini
+++ b/misc/skins/yadt256.ini
@@ -140,8 +140,8 @@
     history-prev-item-char = ‹
     history-next-item-char = ›
     history-show-list-char = ↓
-    filename-scroll-left-char = «
-    filename-scroll-right-char = »
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
 
 [widget-scrollbar]
     first-vert-char = ▲


### PR DESCRIPTION
## Proposed changes

Here are various fixes to the shipped skins:

1. Added `[widget-panel]` and `[widget-scrollbar]` defaults to make sure that these sections are present when the new skin is developed based on the default skin
2. For consistency, use single chevrons in single line skins and double chevrons in double line skins for `history-prev-item-char` / `history-next-item-char`
3. Fix `[widget-scrollbar]` to use TurboVision defaults, currently not used anyway - see #1483
4. Use double arrow for `history-show-list-char` in skins that use double lines
5. Fix broken `modarin` skin variants

These changes are needed for skins to display properly in the skin editor:

https://github.com/phplego/mc

I fixed it and will also submit a PR to the author. I think we should make this an official `mc` project.

## Question

I cannot seem to be able to get `mc` to show `filename-scroll-left-char` / `filename-scroll-right-char`. How can I do that?
