### PR TITLE
Add SortByVersion keymap

### DIFF
--- a/lib/keybind.c
+++ b/lib/keybind.c
@@ -238,6 +238,7 @@ static name_keymap_t command_names[] = {
     ADD_KEYMAP_NAME (SortPrev),
     ADD_KEYMAP_NAME (SortReverse),
     ADD_KEYMAP_NAME (SortByName),
+    ADD_KEYMAP_NAME (SortByVersion),
     ADD_KEYMAP_NAME (SortByExt),
     ADD_KEYMAP_NAME (SortBySize),
     ADD_KEYMAP_NAME (SortByMTime),

--- a/lib/keybind.h
+++ b/lib/keybind.h
@@ -203,6 +203,7 @@ enum
     CK_SortPrev,
     CK_SortReverse,
     CK_SortByName,
+    CK_SortByVersion,
     CK_SortByExt,
     CK_SortBySize,
     CK_SortByMTime,

--- a/misc/mc.default.keymap
+++ b/misc/mc.default.keymap
@@ -124,6 +124,7 @@ Bottom = alt-gt; end; c1
 # SortNext =
 # SortReverse =
 # SortByName =
+# SortByVersion =
 # SortByExt =
 # SortBySize =
 # SortByMTime =

--- a/misc/mc.emacs.keymap
+++ b/misc/mc.emacs.keymap
@@ -124,6 +124,7 @@ Bottom = alt-gt; end; c1
 # SortNext =
 # SortReverse =
 # SortByName =
+# SortByVersion =
 # SortByExt =
 # SortBySize =
 # SortByMTime =

--- a/misc/mc.vim.keymap
+++ b/misc/mc.vim.keymap
@@ -124,6 +124,7 @@ Bottom = alt-gt; end; c1
 # SortNext =
 # SortReverse =
 # SortByName =
+# SortByVersion =
 # SortByExt =
 # SortBySize =
 # SortByMTime =

--- a/src/filemanager/panel.c
+++ b/src/filemanager/panel.c
@@ -3645,6 +3645,9 @@ panel_execute_cmd (WPanel *panel, long command)
     case CK_SortByName:
         panel_set_sort_type_by_id (panel, "name");
         break;
+    case CK_SortByVersion:
+        panel_set_sort_type_by_id (panel, "version");
+        break;
     case CK_SortByExt:
         panel_set_sort_type_by_id (panel, "extension");
         break;


### PR DESCRIPTION
MC already has `SortByName`, `SortByExt`, etc. but a keymap for sorting by version is missing. This patch adds it.