### PR TITLE
Show size in 'bsize' format for dirs if's computed

### DIFF
--- a/doc/man/mc.1.in
+++ b/doc/man/mc.1.in
@@ -810,7 +810,8 @@ displays the file size.
 is an alternative form of the
 .B size
 format. It displays the size of the files and for directories it just
-shows SUB\-DIR or UP\-\-DIR.
+shows SUB\-DIR or UP\-\-DIR unless the directory size is computed by the
+"Show directory sizes" command.
 .TP
 .B type
 displays a one character wide type field.  This character is similar to

--- a/src/filemanager/panel.c
+++ b/src/filemanager/panel.c
@@ -424,7 +424,8 @@ string_file_size_brief (const file_entry_t *fe, int len)
     if (S_ISLNK (fe->st.st_mode) && !link_isdir (fe))
         return _ ("SYMLINK");
 
-    if ((S_ISDIR (fe->st.st_mode) || link_isdir (fe)) && !DIR_IS_DOTDOT (fe->fname->str))
+    if ((S_ISDIR (fe->st.st_mode) || link_isdir (fe)) && !fe->f.dir_size_computed
+        && !DIR_IS_DOTDOT (fe->fname->str))
         return _ ("SUB-DIR");
 
     return string_file_size (fe, len);


### PR DESCRIPTION
This patch makes `bsize` listing format show real directory size if it's computed by "Show directory sizes" command (ctrl-space) instead of `SUB-DIR`.