### PR TITLE
Ticket #4691: fix `\e` handling in `man2hlp` converter

### DIFF
--- a/src/man2hlp/man2hlp.in
+++ b/src/man2hlp/man2hlp.in
@@ -305,6 +305,12 @@ sub print_string($)
                         $backslash_flag = 0;
                         next;
                     }
+                    if ($_ eq 'e' && $backslash_flag)
+                    {
+                        print $f_out '\\';
+                        $backslash_flag = 0;
+                        next;
+                    }
                     if ($_ eq '\\' && !$backslash_flag)
                     {
                         $backslash_flag = 1;


### PR DESCRIPTION
The online help got broken in 801fbad when fixing the manual page syntax (replacing invalid `\\` with `\e`). Unfortunately, our `man2hlp` converter does not handle `\e` correctly. This commit should fix this.

Resolves: #4691.
