### PR TITLE
Ticket #4707: fix `patchfs` for Z, xz, zst compressed diffs

### DIFF
--- a/src/vfs/extfs/helpers/patchfs.in
+++ b/src/vfs/extfs/helpers/patchfs.in
@@ -91,13 +91,13 @@ sub myin
 	return "$lzma -dc $qfname";
     } elsif (/^'*lzo/) {
 	return "$lzo -dc $qfname";
-    } elsif (/^'*xz/) {
+    } elsif (/^'*xz/i) {
 	return "$xz -dc $qfname";
-    } elsif (/^'*zst/) {
+    } elsif (/^'*zst/i) {
 	return "$zstd -dc $qfname";
     } elsif (/^'*bzip/) {
 	return "$bzip -dc $qfname";
-    } elsif (/^'*gzip/) {
+    } elsif (/^'*(gzip|compress'd data)/) {
 	return "$gzip -dc $qfname";
     } else {
 	return "cat $qfname";
@@ -119,13 +119,13 @@ sub myout
 	return "$lzma -c $sep $qfname";
     } elsif (/^'*lzo/) {
 	return "$lzo -c $sep $qfname";
-    } elsif (/^'*xz/) {
+    } elsif (/^'*xz/i) {
 	return "$xz -c $sep $qfname";
-    } elsif (/^'*zst/) {
+    } elsif (/^'*zst/i) {
 	return "$zstd -c $sep $qfname";
     } elsif (/^'*bzip/) {
 	return "$bzip -c $sep $qfname";
-    } elsif (/^'*gzip/) {
+    } elsif (/^'*(gzip|compress'd data)/) {
 	return "$gzip -c $sep $qfname";
     } else {
 	return "cat $sep $qfname";


### PR DESCRIPTION
Unfortunately, support for these formats was introduced mechanically and was never actually tested, so I don't believe it ever worked. I suggest using case-insensitive matching for `xz` and `zstd`, and adding a signature for `Z` (= `gz`).

Resolves: #4707

Working:

```
zaytsev@fedora$ file -b test.patch.gz
gzip compressed data, was "test.patch"
```

Not working:

```
zaytsev@fedora$ file -b test.patch.Z
compress'd data 16 bits

zaytsev@fedora$ file -b test.patch.zst
Zstandard compressed data (v0.8+), Dictionary ID: None

zaytsev@fedora$ file -b test.patch.xz
XZ compressed data, checksum CRC64
```
