### PR TITLE
Ticket #4704: add about box for `mc` and move display info there

### DIFF
--- a/lib/global.c
+++ b/lib/global.c
@@ -114,6 +114,8 @@ mc_global_t mc_global =
 
 };
 
+const char PACKAGE_COPYRIGHT[] = N_ ("Copyright (C) 1996-2025 the Free Software Foundation");
+
 #undef SUBSHELL_USE
 
 /*** file scope macro definitions ****************************************************************/

--- a/lib/global.h
+++ b/lib/global.h
@@ -224,6 +224,7 @@ typedef struct
 /*** global variables defined in .c file *********************************************************/
 
 extern mc_global_t mc_global;
+extern const char PACKAGE_COPYRIGHT[];
 
 /*** declarations of public functions ************************************************************/
 

--- a/maint/update-years.sh
+++ b/maint/update-years.sh
@@ -21,8 +21,8 @@ for i in $SOURCES; do
 done
 
 # special case
-${SED-sed} -e "/$LINE/s/-[0-9]\{4\} the/-$YEAR the/" src/editor/editwidget.c > src/editor/editwidget.c.tmp && \
-  mv -f src/editor/editwidget.c.tmp src/editor/editwidget.c
+${SED-sed} -e "/$LINE/s/-[0-9]\{4\} the/-$YEAR the/" lib/global.c > lib/global.c.tmp && \
+  mv -f lib/global.c.tmp lib/global.c
 
 # restore permissions
 chmod 755 tests/src/vfs/extfs/helpers-list/test_all

--- a/po/af.po
+++ b/po/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Afrikaans (http://app.transifex.com/mc/mc/language/af/)\n"
@@ -46,6 +46,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -725,7 +728,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -791,23 +794,16 @@ msgstr ""
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -876,15 +872,16 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr ""
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Diff:"
@@ -894,12 +891,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -917,7 +916,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -928,11 +929,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -949,7 +948,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -963,11 +964,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1012,7 +1012,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1072,7 +1076,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1508,12 +1512,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1642,13 +1644,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1674,7 +1676,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1707,22 +1710,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1736,6 +1742,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1814,15 +1832,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2019,7 +2028,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2112,13 +2120,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2223,11 +2237,15 @@ msgid "Link"
 msgstr ""
 
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2249,6 +2267,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2298,11 +2322,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2342,10 +2370,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2354,7 +2379,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2364,7 +2389,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2421,23 +2446,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2449,7 +2470,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2469,19 +2490,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2490,13 +2521,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2506,37 +2537,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2545,43 +2580,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2590,37 +2625,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2638,31 +2673,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2680,19 +2715,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3017,10 +3054,7 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3514,11 +3548,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3554,6 +3586,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3656,8 +3695,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4307,8 +4347,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4357,10 +4398,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4381,16 +4419,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Arabic (http://app.transifex.com/mc/mc/language/ar/)\n"
@@ -47,6 +47,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -726,7 +729,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -792,23 +795,16 @@ msgstr ""
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -877,15 +873,16 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr ""
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Diff:"
@@ -895,12 +892,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -918,7 +917,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -929,11 +930,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -950,7 +949,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -964,11 +965,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1013,7 +1013,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1073,7 +1077,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1509,12 +1513,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1643,13 +1645,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1675,7 +1677,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1708,22 +1711,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1737,6 +1743,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1815,15 +1833,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2020,7 +2029,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2113,13 +2121,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2224,11 +2238,15 @@ msgid "Link"
 msgstr ""
 
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2250,6 +2268,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2299,11 +2323,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2343,10 +2371,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2355,7 +2380,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2365,7 +2390,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2422,23 +2447,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2450,7 +2471,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2470,19 +2491,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2491,13 +2522,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2507,37 +2538,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2546,43 +2581,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2591,37 +2626,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2639,31 +2674,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2681,19 +2716,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3022,10 +3059,7 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3531,11 +3565,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3571,6 +3603,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3673,8 +3712,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4324,8 +4364,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4374,10 +4415,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4398,16 +4436,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/az.po
+++ b/po/az.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Slava Zanko <slavazanko@gmail.com>, 2011\n"
 "Language-Team: Azerbaijani (http://app.transifex.com/mc/mc/language/az/)\n"
@@ -47,6 +47,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -728,7 +731,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -794,24 +797,22 @@ msgstr "Axtar"
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
 msgid "&Fastest (Assume large files)"
 msgstr ""
@@ -879,16 +880,17 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr "Çıx"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
+
+msgid "Quit"
+msgstr "Çıx"
 
 msgid "Diff:"
 msgstr ""
@@ -896,15 +898,17 @@ msgstr ""
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"%s\n"
+"is a directory"
+msgstr "qovluq"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat\n"
 "%s"
-msgstr ""
+msgstr "Daraya bilmədim :"
 
 msgid "Diff viewer: invalid mode"
 msgstr ""
@@ -919,9 +923,13 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#, c-format
-msgid "Cannot open %s for reading"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
+"%s\n"
+"tar arxivini aça bilmədim"
 
 msgid "Load file"
 msgstr ""
@@ -931,11 +939,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -951,9 +957,13 @@ msgstr "Xəbərdarlıq"
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
+"%s faylını yazmaq üçün aça bilmədim :\n"
+"%s\n"
 
 msgid "File has hard-links. Detach before saving?"
 msgstr ""
@@ -965,13 +975,14 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
-msgstr ""
+"%s faylını yazmaq üçün aça bilmədim :\n"
+"%s\n"
 
 msgid "The file you are saving does not end with a newline."
 msgstr ""
@@ -1015,7 +1026,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1075,7 +1090,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1511,12 +1526,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1645,13 +1658,15 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+"%s\n"
+"tar arxivini aça bilmədim"
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1677,7 +1692,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1710,22 +1726,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
-msgstr "Təzədən &sına"
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1740,6 +1759,20 @@ msgstr ""
 
 msgid "Stopped"
 msgstr "Dayandırılıb"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Tərcüməsiz >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Giriş / ekran kod səhifəsi:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "Heç bir vax&t"
@@ -1818,17 +1851,6 @@ msgstr ""
 
 msgid "Configure options"
 msgstr "Seçənəkləri quraşdır"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Tərcüməsiz >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Giriş / ekran kod səhifəsi:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr ""
@@ -2021,12 +2043,11 @@ msgstr "&Öldür"
 msgid "Background jobs"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
-msgstr ""
+msgstr "Xəbərdarlıq : %s'ye keçə bilmədim .\n"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2115,17 +2136,25 @@ msgstr "Seçilanləri T&əmizlə"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
-msgstr ""
+"Cannot chattr\n"
+"%sn%s"
+msgstr "Daraya bilmədim :"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"%s\n"
+"tar arxivini aça bilmədim"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Daraya bilmədim :"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2227,12 +2256,18 @@ msgstr ""
 msgid "Link"
 msgstr ""
 
-#, c-format
-msgid "link: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2255,6 +2290,12 @@ msgstr " Təzə Qovluq yarat"
 
 msgid "Enter directory name:"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr " Təzə Qovluq yarat"
 
 msgid "Extension file edit"
 msgstr "Uzantılar faylı düzəldilməsi"
@@ -2303,11 +2344,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2347,10 +2392,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2359,7 +2401,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2369,7 +2411,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2424,27 +2466,29 @@ msgstr "fayllar/qovluqlar"
 msgid " with source mask:"
 msgstr " qaynaq maskalı: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
+"%s\n"
+"tar arxivini aça bilmədim"
 
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
+"%s\n"
+"tar arxivini aça bilmədim"
 
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
@@ -2452,11 +2496,13 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
 #, c-format
 msgid ""
@@ -2474,160 +2520,212 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
 msgstr ""
 
+msgid "&Retry"
+msgstr "Təzədən &sına"
+
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 msgid "Non&e"
 msgstr "heç&biri"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot remove directory\n"
+"%s"
+msgstr ""
+"%s\n"
+"cpio arxivini aça bilmədim"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot enter into directory\n"
+"%s"
+msgstr ""
+"%s\n"
+"cpio arxivini aça bilmədim"
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot overwrite file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
+"%s\n"
+"tar arxivini aça bilmədim"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
+"%s\n"
+"tar arxivini aça bilmədim"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
+"%s\n"
+"cpio arxivini aça bilmədim"
 
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
 
 msgid "(stalled)"
 msgstr "(stalled)"
@@ -2641,33 +2739,39 @@ msgstr "&Saxla"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
+"%s\n"
+"cpio arxivini aça bilmədim"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot close target file\n"
+"%s"
+msgstr ""
+"%s\n"
+"tar arxivini aça bilmədim"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot set ext2 attributes for target file\n"
+"%s"
+msgstr ""
+"%s faylına yaza bilmirəm:\n"
+"%s\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat source directory\n"
+"%s"
+msgstr " Təzə Qovluq yarat"
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot stat source directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2685,21 +2789,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
-msgstr ""
+msgstr " Təzə Qovluq yarat"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
+"%s\n"
+"tar arxivini aça bilmədim"
 
 #, c-format
 msgid "Directories: %zu, total size: %s"
@@ -3022,10 +3130,7 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3520,11 +3625,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3562,6 +3665,13 @@ msgstr "\"%s\"'yi buraya daşı :"
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3678,8 +3788,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4348,8 +4459,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4398,10 +4510,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4422,18 +4531,20 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
-msgid "Cannot view: not a regular file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
+"%s\n"
+"tar arxivini aça bilmədim"
 
 msgid "Search done"
 msgstr ""

--- a/po/be.po
+++ b/po/be.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2019,2025\n"
 "Language-Team: Belarusian (http://app.transifex.com/mc/mc/language/be/)\n"
@@ -63,6 +63,9 @@ msgstr "Не ўдалося стварыць групу падзей \"%s\"!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Не ўдалося стварыць падзею \"%s\"!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -807,10 +810,10 @@ msgstr "файл1 файл2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[гэты_каталог] [каталог_іншай_панэлі]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -881,28 +884,23 @@ msgstr "Пошук"
 msgid "Search is disabled"
 msgstr "Пошук адключаны"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Немагчыма стварыць часовы файл адрозненняў\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Немагчыма стварыць файл рэзервовай копіі\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Немагчыма стварыць часовы файл аб’яднання\n"
 "%s"
@@ -973,18 +971,19 @@ msgstr "Параметры"
 msgid "ButtonBar|Quit"
 msgstr "Выйсці"
 
-msgid "Quit"
-msgstr "Выйсці"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Файл(ы) змянілі. Захаваць і выйсці?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "\"Midnight Commander\" будзе выключаны.\n"
 "Захаваць зменены(я) файл(ы)?"
+
+msgid "Quit"
+msgstr "Выйсці"
 
 msgid "Diff:"
 msgstr "Адрозненні:"
@@ -992,13 +991,15 @@ msgstr "Адрозненні:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" — каталог"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Немагчыма атрымаць уласцівасці \"%s\"\n"
@@ -1017,9 +1018,13 @@ msgstr "Загрузка: %3d%%"
 msgid "Loading..."
 msgstr "Загрузка..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Немагчыма адкрыць \"%s\" для чытання"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Немагчыма адкрыць \"%s\"\n"
+"%s"
 
 msgid "Load file"
 msgstr "Загрузіць файл"
@@ -1028,12 +1033,10 @@ msgstr "Загрузіць файл"
 msgid "Error reading %s"
 msgstr "Не ўдалося прачытаць \"%s\""
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Немагчыма атрымаць памер або правы доступу да файла \"%s\""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" не ёсць звычайным файлам"
 
 #, c-format
@@ -1051,8 +1054,10 @@ msgstr "Увага"
 msgid "Error reading from pipe: %s"
 msgstr "Не ўдалося прачытаць з канала: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Не ўдалося адкрыць канал для чытання: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1065,12 +1070,11 @@ msgstr "Іншая праграма змяніла файл. Перазапіс�
 msgid "Error writing to pipe: %s"
 msgstr "Не ўдалося запісаць у канал: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Не ўдалося адкрыць канал для запісу: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Не ўдалося адкрыць файл для запісу: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1115,8 +1119,12 @@ msgstr "Праверка пераводу радка ў канцы файла(&P
 msgid "Edit Save Mode"
 msgstr "Рэдагаваць спосаб захавання"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Немагчыма захаваць: мэтавы элемент не выглядае як звычайны файл"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Немагчыма праглядзець: незвычайны файл"
 
 msgid "A file already exists with this name"
 msgstr "Файл з такой назвай ўжо існуе"
@@ -1173,9 +1181,9 @@ msgstr "Файл \"%s\" быў зменены? Захаваць перад ты�
 msgid "Close file"
 msgstr "Закрыць файл"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander закрываецца.\n"
@@ -1618,15 +1626,13 @@ msgstr "Замяніць?"
 msgid "%ld replacements made"
 msgstr "Зроблена замен: %ld"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Зручны тэкставы рэдактар,\n"
 "напісаны для Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Пра праграму"
@@ -1754,16 +1760,14 @@ msgstr "< Аўтаматычна >"
 msgid "< Reload Current Syntax >"
 msgstr "< Перазагрузіць бягучы сінтаксіс >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Немагчыма адкрыць файл \"%s\""
+
 msgid "Load syntax file"
 msgstr "Загрузіць файл сінтаксісу"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Немагчыма адкрыць файл \"%s\"\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1794,7 +1798,8 @@ msgstr ""
 "Не кансоль xterm або Linux;\n"
 "немагчыма пераключыць абалонку."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Каб вярнуцца ў Midnight Commander, увядзіце \"exit\""
 
 msgid "Set &all"
@@ -1825,26 +1830,33 @@ msgstr "Правы доступу (васьмерычныя): %o"
 msgid "Chown advanced command"
 msgstr "Пашыраная каманда \"chown\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Немагчыма скарыстацца chmod \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Немагчыма скарыстацца chown \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Немагчыма скарыстацца chmod \"%s\"\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "Не зважаць(&I)"
-
-msgid "Ignore &all"
-msgstr "Не зважаць ні на што(&A)"
-
-msgid "&Retry"
-msgstr "Паўтарыць(&R)"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Немагчыма скарыстацца chown \"%s\"\n"
@@ -1861,6 +1873,20 @@ msgstr "Выконваецца"
 
 msgid "Stopped"
 msgstr "Спынена"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < No translation >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Кадаванне ўводу/вываду:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "Ніколі(&N)"
@@ -1939,17 +1965,6 @@ msgstr "Аўтаматычна захоўваць налады(&U)"
 
 msgid "Configure options"
 msgstr "Наладзіць параметры"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < No translation >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Кадаванне ўводу/вываду:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Графічная абалонка:"
@@ -2146,10 +2161,9 @@ msgstr "Забіць(&K)"
 msgid "Background jobs"
 msgstr "Фонавыя задачы"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "Немагчыма перайсці ў каталог\n"
@@ -2243,19 +2257,29 @@ msgstr "Прыбраць пазначэнне(&L)"
 msgid "Chattr command"
 msgstr "Каманда \"Chattr\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Немагчыма скарыстацца \"chattr\" \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Немагчыма адкрыць архіў tar\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Немагчыма скарыстацца \"chattr\" \"%s\"\n"
+"%s"
 
 msgid "set &user ID on execution"
 msgstr "вызначыць user ID для запуску(&U)"
@@ -2357,13 +2381,19 @@ msgstr "Стварыць спасылку \"%s\" на:"
 msgid "Link"
 msgstr "Спасылка"
 
-#, c-format
-msgid "link: %s"
-msgstr "спасылка: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Немагчыма стварыць мэтавую спасылку \"%s\"\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "сімвалічная спасылка: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr "Немагчыма скапіяваць цыклічную сімвалічную спасылку \"%s\""
 
 msgid "View file"
 msgstr "Праглядзець файл"
@@ -2385,6 +2415,12 @@ msgstr "Стварыць каталог"
 
 msgid "Enter directory name:"
 msgstr "Увядзіце назву каталога:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Немагчыма стварыць каталог \"%s\""
 
 msgid "Extension file edit"
 msgstr "Рэдагаваць файл пашырэння"
@@ -2432,12 +2468,16 @@ msgstr "Сімвалічная спасылка \"%s\" спасылаецца н
 msgid "Edit symlink"
 msgstr "Рэдагаваць спасылку"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "спасылка адкрытая ў рэдактары, немагчыма выдаліць %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "рэдагаваць спасылку: %s"
 
 msgid "FTP to machine"
@@ -2479,10 +2519,8 @@ msgstr "На нелакальных файлавых сістэмах нельг
 msgid "Parameter"
 msgstr "Параметр"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Немагчыма стварыць часовы камандны файл\n"
 "%s"
@@ -2490,23 +2528,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Хібны канал"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "Ваш файл %s састарэлы.\n"
 "Midnight Commander зараз выкарыстоўвае файл %s.\n"
 "Калі ласка скапіюйце змены са старога файла ў новы."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "Фармат файла\n"
 "%s%s\n"
@@ -2572,29 +2610,23 @@ msgstr "файлы альбо каталогі"
 msgid " with source mask:"
 msgstr " з зыходным шаблонам:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Немагчыма вызначыць зыходны файл жорсткай спасылкі \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Немагчыма стварыць мэтавую жорсткую спасылку \"%s\"\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Немагчыма стварыць мэтавую жорсткую спасылку \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Немагчыма прачытаць спасылку на крыніцу \"%s\"\n"
@@ -2610,9 +2642,9 @@ msgstr ""
 "\n"
 "Параметр \"Устойлівыя сімвалічныя спасылкі\" будзе адключаны"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Немагчыма стварыць мэтавую спасылку \"%s\"\n"
@@ -2642,21 +2674,31 @@ msgstr ""
 "\"%s\"\n"
 "адзін і той жа файл"
 
+msgid "&Ignore"
+msgstr "Не зважаць(&I)"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "Паўтарыць(&R)"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Каталог \"%s\" не пусты.\n"
 "Выдаліць рэкурсіўна?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Фонавы працэс:\n"
@@ -2666,17 +2708,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Нічога(&E)"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Немагчыма выдаліць файл «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Немагчыма атрымаць уласцівасці файла \"%s\"\n"
@@ -2686,102 +2728,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Немагчыма перазапісаць каталог \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Немагчыма перамясціць файл \"%s\" у \"%s\"\n"
+"Немагчыма выдаліць файл «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Немагчыма выдаліць каталог \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Немагчыма перазапісаць каталог \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Немагчыма перазапісаць каталог \"%s\"\n"
-"%s"
+msgstr "Немагчыма перазапісаць каталог \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Немагчыма перазапісаць файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Немагчыма перамясціць каталог \"%s\" у \"%s\"\n"
+"Немагчыма выдаліць каталог \"%s\"\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Немагчыма выканаць на \"..\"!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Немагчыма атрымаць уласцівасці зыходнага файла \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Немагчыма вызначыць зыходны файл жорсткай спасылкі \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Немагчыма атрымаць уласцівасці мэтавага файла \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Немагчыма стварыць адмысловы файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Немагчыма выканаць \"chown\" мэтавага файла \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Немагчыма выканаць \"chmod\" для мэтавага файла \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Немагчыма адкрыць зыходны файл \"%s\"\n"
@@ -2790,49 +2838,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Не ўдалося нанова спампаваць, будзе перазапісана"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Немагчыма атрымаць уласцівасці зыходнага файла \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Немагчыма стварыць мэтавы файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Немагчыма атрымаць уласцівасці мэтавага файла \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Немагчыма зарэзерваваць прастору для мэтавага файла \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Немагчыма прачытаць зыходны файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Немагчыма запісаць мэтавы файл \"%s\"\n"
@@ -2850,41 +2898,45 @@ msgstr "Пакінуць(&K)"
 msgid "&Continue copy"
 msgstr "Працягнуць капіяванне(&C)"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Немагчыма закрыць зыходны файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Немагчыма закрыць мэтавы файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Немагчыма зарэзерваваць прастору для мэтавага файла \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Немагчыма атрымаць уласцівасці зыходнага каталога \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Немагчыма атрымаць уласцівасці зыходнага каталога \"%s\"\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2900,25 +2952,27 @@ msgid ""
 "\"%s\""
 msgstr "Немагчыма скапіяваць цыклічную сімвалічную спасылку \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Па мэтавым шляху \"%s\" мусіць быць каталог\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Немагчыма стварыць мэтавы каталог \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Немагчыма выканаць \"chown\" для мэтавага каталога \"%s\"\n"
@@ -3248,11 +3302,9 @@ msgstr[1] "Вы адкрылі %zu экраны. Усё адно выйсці?"
 msgstr[2] "Вы адкрылі %zu экранаў. Усё адно выйсці?"
 msgstr[3] "Вы адкрылі %zu экраны. Усё адно выйсці?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Сапраўды выйсці з \"Midnight Commander\"?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Сапраўды выканаць?"
 
 msgid "&Above"
 msgstr "Верхняя панэль(&A)"
@@ -3758,11 +3810,10 @@ msgstr ""
 "На панэль з іншай праграмы:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "На панэль з іншай праграмы:\n"
 "не ўдалося прачытаць даныя з даччынага stdout:\n"
@@ -3807,6 +3858,15 @@ msgid ""
 "%s"
 msgstr ""
 "Немагчыма атрымаць уласцівасці мэтавага элемента\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Па мэтавым шляху \"%s\" мусіць быць каталог\n"
 "%s"
 
 #, c-format
@@ -3928,8 +3988,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Шлях да хатняга каталога не абсалютны"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4646,8 +4707,9 @@ msgstr "Файл быў зменены. Захаваць і выйсці?"
 msgid "&Cancel quit"
 msgstr "Не выходзіць(&С)"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "\"Midnight Commander\" закрываецца.\n"
@@ -4698,10 +4760,8 @@ msgstr "Нефарматавана"
 msgid "ButtonBar|Format"
 msgstr "Фарматаванне"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Не ўдалося прачытаць даныя з нашчадка stdout:\n"
 "%s"
@@ -4727,20 +4787,18 @@ msgstr ""
 msgid "View: "
 msgstr "Праглядзець: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Немагчыма адкрыць \"%s\"\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Немагчыма праглядзець: незвычайны файл"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Немагчыма адкрыць \"%s\" у рэжыме аналізу\n"
@@ -4754,6 +4812,78 @@ msgstr "Працягваць ад пачатку?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Немагчыма атрымаць лакальную копію /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Сапраўды выйсці з \"Midnight Commander\"?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Немагчыма адкрыць \"%s\" для чытання"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Немагчыма атрымаць памер або правы доступу да файла \"%s\""
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Не ўдалося адкрыць канал для запісу: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Немагчыма захаваць: мэтавы элемент не выглядае як звычайны файл"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Немагчыма адкрыць файл \"%s\"\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Не зважаць ні на што(&A)"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "спасылка: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "сімвалічная спасылка: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Немагчыма стварыць мэтавую жорсткую спасылку \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Немагчыма перамясціць файл \"%s\" у \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Немагчыма перазапісаць каталог \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Немагчыма перамясціць каталог \"%s\" у \"%s\"\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Іншае 8-бітавае"

--- a/po/bg.po
+++ b/po/bg.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2017,2020,2025\n"
 "Language-Team: Bulgarian (http://app.transifex.com/mc/mc/language/bg/)\n"
@@ -53,6 +53,9 @@ msgstr "Не може да се създаде група „%s“ за съби
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Не може да се създаде събитие „%s“!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -768,10 +771,10 @@ msgstr "файл_1 файл_2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[тази_дир-я] [дир-я_на_другия_панел]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -843,28 +846,23 @@ msgstr "Търсене"
 msgid "Search is disabled"
 msgstr "Търсенето е изключено"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Не може да се създаде временен diff файл\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Не може да се създаде резервен файл\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Не може да се създаде временен обединяващ файл\n"
 "%s"
@@ -935,18 +933,19 @@ msgstr "Настройки"
 msgid "ButtonBar|Quit"
 msgstr "Изход"
 
-msgid "Quit"
-msgstr "Изход"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Файл(ове) беше редактиран. Запис при изход?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander се изключва.\n"
 "Записване на редактирания файл(ове)?"
+
+msgid "Quit"
+msgstr "Изход"
 
 msgid "Diff:"
 msgstr "Разлика:"
@@ -954,13 +953,15 @@ msgstr "Разлика:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "„%s“ е директория"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Не може да се stat-не „%s“\n"
@@ -979,9 +980,13 @@ msgstr "Зареждане: %3d%%"
 msgid "Loading..."
 msgstr "Зареждане…"
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Грешка при отваряне на %s за четене"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Не може да се отвори „%s“\n"
+"%s"
 
 msgid "Load file"
 msgstr "Зареждане на файл"
@@ -990,12 +995,10 @@ msgstr "Зареждане на файл"
 msgid "Error reading %s"
 msgstr "Грешка при четене на %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Не може да се получи размера/правата за %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "„%s“ не е обикновен файл"
 
 #, c-format
@@ -1013,8 +1016,10 @@ msgstr "Предупреждение"
 msgid "Error reading from pipe: %s"
 msgstr "Грешка при четене от канал: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Не може да се отвори канал за четене: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1027,12 +1032,11 @@ msgstr "Файлът е бил променен междувременно. Да
 msgid "Error writing to pipe: %s"
 msgstr "Грешка при писане към канал: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Не може да се отвори канал за писане: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Не може да се отвори файл за писане: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1077,8 +1081,12 @@ msgstr "Проверка за &POSIX нов ред"
 msgid "Edit Save Mode"
 msgstr "Редактиране Режим Запис"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Не може да се запише: крайния файл не обикновен файл"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Не може да се разгледа: не е обикновен файл"
 
 msgid "A file already exists with this name"
 msgstr "Вече съществува файл с такова име"
@@ -1137,9 +1145,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Затваряне на файл"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander се изключва.\n"
@@ -1582,15 +1590,13 @@ msgstr "Потвърждаване замяната"
 msgid "%ld replacements made"
 msgstr "направени са %ld замѐни "
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Удобен текстови редактор\n"
 "за Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Относно"
@@ -1718,16 +1724,14 @@ msgstr "< Автоматично >"
 msgid "< Reload Current Syntax >"
 msgstr "< Презареждане на сегашния синтаксис >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Файлът %s не може да бъде отворен"
+
 msgid "Load syntax file"
 msgstr "Зареждане на файл със синтаксис"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Не може да се отвори файл %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1758,7 +1762,8 @@ msgstr ""
 "Не е xterm или конзола на Linux.\n"
 "Не може да се превключи подобвивка."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Напишете „exit“, за да се върнете в Midnight Commander"
 
 msgid "Set &all"
@@ -1789,26 +1794,33 @@ msgstr "Права (8-чни): %o"
 msgid "Chown advanced command"
 msgstr "Разширена команда chown"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Не може да се изпълни chmod „%s“\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Не може да се изпълни chown „%s“\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Не може да се изпълни chmod „%s“\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Прескачане"
-
-msgid "Ignore &all"
-msgstr "Прескачане на &всички"
-
-msgid "&Retry"
-msgstr "&Отново"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Не може да се изпълни chown „%s“\n"
@@ -1825,6 +1837,20 @@ msgstr "Изпълнява се"
 
 msgid "Stopped"
 msgstr "Спрян"
+
+#, fuzzy
+msgid "No translation"
+msgstr "—  < Без преобразуване >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Кодова страница:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Никога"
@@ -1903,17 +1929,6 @@ msgstr "Автоматично записване на настро&йки"
 
 msgid "Configure options"
 msgstr "Настройки"
-
-#, fuzzy
-msgid "No translation"
-msgstr "—  < Без преобразуване >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Кодова страница:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Тема:"
@@ -2110,12 +2125,13 @@ msgstr "&Убиване"
 msgid "Background jobs"
 msgstr "Фонови задачи"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"Не може да се изпълни chown върху целевата директория „%s“\n"
+"%s"
 
 msgid "Secure deletion"
 msgstr "Надеждно изтриване"
@@ -2204,19 +2220,29 @@ msgstr "&Изчистване на избрано"
 msgid "Chattr command"
 msgstr "Команда chattr"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Неуспешно изпълнение на chattr „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Не може да се отвори архивът tar\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Неуспешно изпълнение на chattr „%s“\n"
+"%s"
 
 msgid "set &user ID on execution"
 msgstr "изпълнение с UID на &собственика"
@@ -2318,13 +2344,21 @@ msgstr "Връзка на %s към:"
 msgid "Link"
 msgstr "Връзка"
 
-#, c-format
-msgid "link: %s"
-msgstr "връзка: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Не може да се създаде целевата символна връзка „%s“\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "символна връзка: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Не може да се копира зациклената символна връзка\n"
+"„%s“"
 
 msgid "View file"
 msgstr "Преглед на файл"
@@ -2346,6 +2380,12 @@ msgstr "Нова директория"
 
 msgid "Enter directory name:"
 msgstr "Име на директория:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Не може да се създаде директория „%s“"
 
 msgid "Extension file edit"
 msgstr "Редактиране на файл с разширения"
@@ -2395,12 +2435,16 @@ msgstr "Символната връзка „%s“ сочи към:"
 msgid "Edit symlink"
 msgstr "Редактиране на символна връзка"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "редактиране на символна връзка, не може да се изтрие %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "редактиране на символна връзка: %s"
 
 msgid "FTP to machine"
@@ -2442,10 +2486,8 @@ msgstr "Не може да се изпълняват команди на нел�
 msgid "Parameter"
 msgstr "Параметър"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Не може да се създаде временен команден файл\n"
 "%s"
@@ -2456,7 +2498,7 @@ msgstr "Неуспешен канал"
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2466,7 +2508,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2521,29 +2563,23 @@ msgstr "файла/директории"
 msgid " with source mask:"
 msgstr " с маска:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Не може да се изпълни stat върху източника на твърдата връзка „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Не може да се създаде целевата твърда връзка „%s“\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Не може да се създаде целевата твърда връзка „%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Не може да се прочете изходната връзка „%s“\n"
@@ -2559,9 +2595,9 @@ msgstr ""
 "\n"
 "Опцията за стабилни символни връзки ще бъде деактивирана"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Не може да се създаде целевата символна връзка „%s“\n"
@@ -2591,21 +2627,31 @@ msgstr ""
 "„%s“\n"
 "са един и същи файл"
 
+msgid "&Ignore"
+msgstr "&Прескачане"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "&Отново"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Непразна директория „%s“.\n"
 "Рекурсивно изтриване?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Фонов процес:\n"
@@ -2615,17 +2661,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Н&яма"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Не може да се изтрие файла „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Не може да се изпълни stat върху изходния файл „%s“\n"
@@ -2635,102 +2681,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Не може да се презапише директорията „%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Не може да се премести файл „%s“ в „%s“\n"
+"Не може да се изтрие файла „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Не може да се изтрие директорията „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Не може да се презапише директорията „%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Не може да се презапише директорията „%s“\n"
-"%s"
+msgstr "Не може да се презапише директорията „%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Не може да се презапише файлът „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Не може да се премести директорията „%s“ в „%s“\n"
+"Не може да се изтрие директорията „%s“\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Не може да работи върху „..“!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Не може да се изпълни stat върху изходния файл „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Не може да се изпълни stat върху източника на твърдата връзка „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Не може да се изпълни fstat върху целевия файл „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Не може да се създаде специалният файл „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Не може да се изпълни chown върху целевия файл „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Не може да се изпълни chmod върху целевия файл „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Не може да се отвори изходният файл \"%s\"\n"
@@ -2739,49 +2791,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Неуспешно повторно изтегляне, файлът ще бъде презаписан"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Не може да се изпълни fstat върху изходния файл „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Не може да се създаде целевият файл „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Не може да се изпълни fstat върху целевия файл „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Не може да се запази пространство за целевия файл „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Не може да се прочете изходният файл „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Не може да се пише в целевия файл „%s“\n"
@@ -2799,41 +2851,45 @@ msgstr "&Запазване"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Не може да се затвори изходният файл „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Не може да се затвори целевият файл „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Не може да се запази пространство за целевия файл „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Не може да се изпълне stat върху изходната директория „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Не може да се изпълне stat върху изходната директория „%s“\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2851,25 +2907,27 @@ msgstr ""
 "Не може да се копира зациклената символна връзка\n"
 "„%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Целта „%s“ трябва да е директория\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Не може да се създаде целева директория „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Не може да се изпълни chown върху целевата директория „%s“\n"
@@ -3197,11 +3255,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "Имате %zu отворен прозорец. Изход все пак?"
 msgstr[1] "Имате %zu отворени прозорци. Изход все пак?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Наистина ли искате да напуснете Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Наистина ли искате да изпълните това?"
 
 msgid "&Above"
 msgstr "От&горе"
@@ -3700,11 +3756,10 @@ msgstr ""
 "Външен панел:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Външен панел:\n"
 "неуспешно четене от стандартния изход на процес:\n"
@@ -3747,6 +3802,15 @@ msgid ""
 "%s"
 msgstr ""
 "Не може да се изпълни stat върху целта\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Целта „%s“ трябва да е директория\n"
 "%s"
 
 #, c-format
@@ -3868,8 +3932,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Пътят до домашната папка не е абсолютен"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4579,8 +4644,9 @@ msgstr "Файлът е променен. Да се запази ли при и�
 msgid "&Cancel quit"
 msgstr "&Отказ от изход"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Изход на Midnight Commander.\n"
@@ -4631,10 +4697,8 @@ msgstr "Без форматиране"
 msgid "ButtonBar|Format"
 msgstr "Форматиране"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Неуспех при четене на информация от изхода на процес:\n"
 "%s"
@@ -4660,20 +4724,18 @@ msgstr ""
 msgid "View: "
 msgstr "Преглед:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Не може да се отвори „%s“\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Не може да се разгледа: не е обикновен файл"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Не може да се отвори „%s“ в режим с анализ\n"
@@ -4687,6 +4749,78 @@ msgstr "Да се продължи ли от началото?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Не може да се изтегли локално копие на „/ftp://some.host/editme.txt“"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Наистина ли искате да напуснете Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Грешка при отваряне на %s за четене"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Не може да се получи размера/правата за %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Не може да се отвори канал за писане: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Не може да се запише: крайния файл не обикновен файл"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не може да се отвори файл %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Прескачане на &всички"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "връзка: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "символна връзка: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не може да се създаде целевата твърда връзка „%s“\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не може да се премести файл „%s“ в „%s“\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не може да се презапише директорията „%s“\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не може да се премести директорията „%s“ в „%s“\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Други 8 бита"

--- a/po/br.po
+++ b/po/br.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Irriep Nala Novram <per.morvan.bzh29@gmail.com>, 2017-2018\n"
 "Language-Team: Breton (http://app.transifex.com/mc/mc/language/br/)\n"
@@ -51,6 +51,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -730,7 +733,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -796,23 +799,16 @@ msgstr "Klask"
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -881,16 +877,17 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr "Kuitaat"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
+
+msgid "Quit"
+msgstr "Kuitaat"
 
 msgid "Diff:"
 msgstr ""
@@ -899,12 +896,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -922,7 +921,9 @@ msgid "Loading..."
 msgstr "O kargañ..."
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -933,11 +934,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -954,7 +953,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -968,11 +969,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1017,7 +1017,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1077,7 +1081,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1513,12 +1517,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1647,13 +1649,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1679,7 +1681,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1712,22 +1715,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1741,6 +1747,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1819,15 +1837,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2024,7 +2033,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2117,13 +2125,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2228,11 +2242,15 @@ msgid "Link"
 msgstr "Liamm"
 
 #, c-format
-msgid "link: %s"
-msgstr "liamm: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2254,6 +2272,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2303,11 +2327,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2347,10 +2375,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2359,7 +2384,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2369,7 +2394,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2426,23 +2451,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2454,7 +2475,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2474,19 +2495,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2495,13 +2526,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2511,37 +2542,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2550,43 +2585,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2595,37 +2630,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2643,31 +2678,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2685,19 +2720,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3025,10 +3062,7 @@ msgstr[2] ""
 msgstr[3] ""
 msgstr[4] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3531,11 +3565,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3571,6 +3603,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3673,8 +3712,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4324,8 +4364,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4374,10 +4415,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4398,16 +4436,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 
@@ -4419,3 +4457,7 @@ msgstr ""
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "liamm: %s"

--- a/po/ca.po
+++ b/po/ca.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Catalan (http://app.transifex.com/mc/mc/language/ca/)\n"
@@ -57,6 +57,9 @@ msgstr "No s'ha pogut crear el grup «%s» pels esdeveniments!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "No s'ha pogut crear l'esdeveniment «%s»!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr "Copyright (C) 1996-2025 la Free Software Foundation"
 
 #, c-format
 msgid ""
@@ -803,10 +806,10 @@ msgstr "fitxer_1 fitxer_2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[aquest_dir] [altre_plafó_dir]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -878,28 +881,23 @@ msgstr "Cerca"
 msgid "Search is disabled"
 msgstr "La cerca està inhabilitada"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "No s'ha pogut crear el fitxer de diff temporal\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "No s'ha pogut crear el fitxer de còpia de seguretat\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "No s'ha pogut crear el fitxer de fusionat temporal\n"
 "%s"
@@ -970,18 +968,19 @@ msgstr "ButtonBar|Opcions"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Surt"
 
-msgid "Quit"
-msgstr "Surt"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "El/s fitxer/s ha/n estat modificat/s. Voleu desar abans de sortir?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "S'està sortint del Midnight Commander.\n"
 "Voleu desar abans de sortir?"
+
+msgid "Quit"
+msgstr "Surt"
 
 msgid "Diff:"
 msgstr "Diferència:"
@@ -989,13 +988,15 @@ msgstr "Diferència:"
 msgid "File name is empty!"
 msgstr "El nom del fitxer és buit!"
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "«%s» és un directori"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "No s'ha pogut veure l'estat de «%s»\n"
@@ -1014,9 +1015,13 @@ msgstr "S'està carregant: %3d%%"
 msgid "Loading..."
 msgstr "S'està carregant..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "No s'ha pogut obrir %s per a lectura"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"No s'ha pogut obrir «%s»\n"
+"%s"
 
 msgid "Load file"
 msgstr "Carrega el fitxer"
@@ -1025,12 +1030,10 @@ msgstr "Carrega el fitxer"
 msgid "Error reading %s"
 msgstr "S'ha produït un error en llegir %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "No s'han pogut obtenir els atributs de %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "«%s» no és un fitxer normal"
 
 #, c-format
@@ -1048,8 +1051,10 @@ msgstr "Avís"
 msgid "Error reading from pipe: %s"
 msgstr "Error en llegir des de la canonada: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "No s'ha pogut obrir la canonada per a lectura: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1063,12 +1068,11 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr "Error en escriure a la canonada: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "No s'ha pogut obrir la canonada per a escriptura: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "No s'ha pogut obrir el fitxer per a escriptura: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1113,8 +1117,12 @@ msgstr "Comprova la línia nova &POSIX"
 msgid "Edit Save Mode"
 msgstr "Edita el mode de desament"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "No s'ha pogut desar: la destinació no és un fitxer normal"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "No es pot visualitzar: no es tracta d'un fitxer normal"
 
 msgid "A file already exists with this name"
 msgstr "Ja existeix un fitxer amb aquest nom"
@@ -1173,9 +1181,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Tanca el fitxer"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "S'està sortint del Midnight Commander.\n"
@@ -1618,15 +1626,13 @@ msgstr "Consigna la substitució"
 msgid "%ld replacements made"
 msgstr "S'han fet %ld substitucions"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Un editor de text fàcil d'emprar\n"
 "escrit per al Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr "Copyright (C) 1996-2025 la Free Software Foundation"
 
 msgid "About"
 msgstr "Quant a"
@@ -1754,16 +1760,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Torna a carregar la sintaxi actual >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "No s'ha pogut obrir el fitxer %s"
+
 msgid "Load syntax file"
 msgstr "Carrega el fitxer de sintaxi"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"No s'ha pogut obrir el fitxer %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1794,7 +1798,8 @@ msgstr ""
 "No és una consola «xterm» o Linux;\n"
 "no es pot alternar el subintèrpret d'ordres."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Escriviu «exit» per a tornar al Midnight Commander"
 
 msgid "Set &all"
@@ -1825,26 +1830,33 @@ msgstr "Permisos (octal): %o"
 msgid "Chown advanced command"
 msgstr "Ordre del canvi avançat del propietari"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"No s'ha pogut fer chmod a «%s»\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"No s'ha pogut fer chown a «%s»\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "No s'ha pogut fer chmod a «%s»\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignora"
-
-msgid "Ignore &all"
-msgstr "Ignor&a-ho tot"
-
-msgid "&Retry"
-msgstr "&Reintenta"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "No s'ha pogut fer chown a «%s»\n"
@@ -1861,6 +1873,20 @@ msgstr "S'està executant"
 
 msgid "Stopped"
 msgstr "Aturat"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Cap traducció >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Pàgina de codis d'entrada / pantalla:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Mai"
@@ -1939,17 +1965,6 @@ msgstr "Desa &automàticament la configuració"
 
 msgid "Configure options"
 msgstr "Opcions de configuració"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Cap traducció >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Pàgina de codis d'entrada / pantalla:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Tema:"
@@ -2146,10 +2161,9 @@ msgstr "A&caba"
 msgid "Background jobs"
 msgstr "Tasques en segon pla"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "No s'ha pogut canviar el directori a\n"
@@ -2243,20 +2257,28 @@ msgstr "&Esborra els marcats"
 msgid "Chattr command"
 msgstr "Ordre «chattr»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "No s'ha pogut fer chattr «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 "No es poden obtenir els atributs ext2 de «%s»\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"No s'ha pogut fer chattr «%s»\n"
 "%s"
 
 msgid "set &user ID on execution"
@@ -2359,13 +2381,21 @@ msgstr "Enllaça %s a:"
 msgid "Link"
 msgstr "Enllaça"
 
-#, c-format
-msgid "link: %s"
-msgstr "enllaç: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"No s'ha pogut crear l'enllaç simbòlic de destinació «%s»\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "enllaç simbòlic: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"No es pot copiar un enllaç simbòlic cíclic\n"
+"«%s»"
 
 msgid "View file"
 msgstr "Veure el fitxer"
@@ -2387,6 +2417,12 @@ msgstr "Crea un directori nou"
 
 msgid "Enter directory name:"
 msgstr "Introduïu el nom del directori:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "No s'ha pogut crear el directori %s"
 
 msgid "Extension file edit"
 msgstr "Edita el fitxer d'extensions"
@@ -2436,12 +2472,16 @@ msgstr "L'enllaç simbòlic «%s» apunta a:"
 msgid "Edit symlink"
 msgstr "Edita l'enllaç simbòlic"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "editeu l'enllaç simbòlic, no s'ha pogut eliminar %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "edita l'enllaç simbòlic: %s"
 
 msgid "FTP to machine"
@@ -2483,10 +2523,8 @@ msgstr "No es poden executar ordres en sistemes de fitxers no locals"
 msgid "Parameter"
 msgstr "Paràmetre"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "No s'ha pogut crear el fitxer d'ordre temporal\n"
 "%s"
@@ -2494,23 +2532,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Ha fallat la canonada"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "Teniu un fitxer obsolet %s.\n"
 "El Midnight Commander ara utilitza el fitxer %s.\n"
 "Copieu les vostres modificacions des del fitxer antic al nou."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "El format del\n"
 "%s%s\n"
@@ -2576,29 +2614,23 @@ msgstr "fitxers/directoris"
 msgid " with source mask:"
 msgstr " amb màscara d'origen:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "No s'ha pogut visualitzar el fitxer d'origen de l'enllaç dur «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"No s'ha pogut crear l'enllaç dur de destinació «%s»\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "No s'ha pogut crear l'enllaç dur de destinació «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "No s'ha pogut llegir l'enllaç d'origen «%s»\n"
@@ -2614,9 +2646,9 @@ msgstr ""
 "\n"
 "L'opció per a enllaços simbòlics estables serà inhabilitada"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "No s'ha pogut crear l'enllaç simbòlic de destinació «%s»\n"
@@ -2646,21 +2678,31 @@ msgstr ""
 "«%s»\n"
 "són el mateix fitxer"
 
+msgid "&Ignore"
+msgstr "&Ignora"
+
 msgid "Ignore a&ll"
 msgstr "I&gnorar-ho tot"
 
-#, c-format
+msgid "&Retry"
+msgstr "&Reintenta"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "El directori «%s» no està buit.\n"
 "Voleu suprimir-lo de forma recursiva?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Procés en segon pla:\n"
@@ -2670,17 +2712,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Ca&p"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "No s'ha pogut eliminar el fitxer «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "No s'ha pogut fer estat al fitxer «%s»\n"
@@ -2690,108 +2732,110 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "No s'ha pogut sobreescriure el directori «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"No s'ha pogut moure el fitxer «%s» cap a «%s»\n"
+"No s'ha pogut eliminar el fitxer «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "No s'ha pogut eliminar el directori «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 "No s'ha pogut entrar al directori «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"No s'ha pogut sobreescriure el directori «%s»\n"
-"%s"
+msgstr "No s'ha pogut sobreescriure el directori «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "No s'ha pogut sobreescriure el fitxer «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"No s'ha pogut moure el directori «%s» a «%s»\n"
+"No s'ha pogut eliminar el directori «%s»\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "No es pot operar a «..»!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "No s'ha pogut fer estat al fitxer d'origen «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 "No es poden obtenir els atributs ext2 del fitxer font «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 "No es poden establir els atributs ext2 del fitxer de destinació «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "No s'ha pogut crear el fitxer especial «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "No s'ha pogut fer chown al fitxer de destinació «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "No s'ha pogut fer chmod al fitxer de destinació «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "No s'ha pogut obrir el fitxer d'origen «%s»\n"
@@ -2800,49 +2844,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Reprendre ha fallat, se sobreescriurà el fitxer"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "No s'ha pogut fer fstat al fitxer d'origen «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "No s'ha pogut crear el fitxer de destinació «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "No s'ha pogut fer estat al fitxer de destinació «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "No s'ha pogut reservar espai pel fitxer de destinació «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "No s'ha pogut llegir el fitxer d'origen «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "No s'ha pogut escriure al fitxer de destinació «%s»\n"
@@ -2860,41 +2904,41 @@ msgstr "&Conserva'l"
 msgid "&Continue copy"
 msgstr "&Continua la còpia"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "No s'ha pogut tancar el fitxer d'origen «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "No s'ha pogut tancar el fitxer de destinació «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 "No es poden obtenir els atributs ext2 per al fitxer de destinació «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "No s'ha pogut veure l'estat del directori d'origen «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 "No es poden obtenir els atributs ext2 del fitxer de destinació «%s»\n"
@@ -2916,25 +2960,27 @@ msgstr ""
 "No es pot copiar un enllaç simbòlic cíclic\n"
 "«%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "La destinació «%s» ha de ser un directori\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "No s'ha pogut crear el directori de destinació «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "No s'ha pogut canviar el propietari del directori de destinació «%s»\n"
@@ -3262,11 +3308,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "Teniu oberta %zu pantalla. Voleu sortir igualment?"
 msgstr[1] "Teniu obertes %zu pantalles. Voleu sortir igualment?"
 
-msgid "The Midnight Commander"
-msgstr "El Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Segur que voleu sortir del Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Realment el voleu executar?"
 
 msgid "&Above"
 msgstr "Qu&ant al"
@@ -3767,11 +3811,10 @@ msgstr ""
 "Quadre de cerca extern:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Quadre de cerca extern:\n"
 "Ha fallat en llegir les dades des de la sortida estàndard filla:\n"
@@ -3816,6 +3859,15 @@ msgid ""
 "%s"
 msgstr ""
 "No s'ha pogut fer estat a la destinació\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"La destinació «%s» ha de ser un directori\n"
 "%s"
 
 #, c-format
@@ -3940,8 +3992,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "El camí del directori d'inici no és absolut"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4667,8 +4720,9 @@ msgstr "El fitxer ha estat modificat. Voleu desar-lo abans de sortir?"
 msgid "&Cancel quit"
 msgstr "&Cancel·la la sortida"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "S'està sortint del Midnight Commander.\n"
@@ -4719,10 +4773,8 @@ msgstr "ButtonBar|Treu form"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Format"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Ha fallat en llegir les dades des de la sortida estàndard filla:\n"
 "%s"
@@ -4748,20 +4800,18 @@ msgstr ""
 msgid "View: "
 msgstr "Visualitza: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"No s'ha pogut obrir «%s»\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "No es pot visualitzar: no es tracta d'un fitxer normal"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "No s'ha pogut obrir «%s» en el mode d'anàlisi\n"
@@ -4776,6 +4826,78 @@ msgstr "Voleu continuar des del començament?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
 "No s'ha pogut obtenir una còpia local de /ftp://algun.amfitrió/editam.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "El Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Segur que voleu sortir del Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "No s'ha pogut obrir %s per a lectura"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "No s'han pogut obtenir els atributs de %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "No s'ha pogut obrir la canonada per a escriptura: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "No s'ha pogut desar: la destinació no és un fitxer normal"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "No s'ha pogut obrir el fitxer %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignor&a-ho tot"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "enllaç: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "enllaç simbòlic: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "No s'ha pogut crear l'enllaç dur de destinació «%s»\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "No s'ha pogut moure el fitxer «%s» cap a «%s»\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "No s'ha pogut sobreescriure el directori «%s»\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "No s'ha pogut moure el directori «%s» a «%s»\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Altres 8 bits"

--- a/po/cs.po
+++ b/po/cs.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Czech (http://app.transifex.com/mc/mc/language/cs/)\n"
@@ -57,6 +57,9 @@ msgstr "Nedaří se vytvořit skupinu „%s“ pro události!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Nedaří vytvořit událost „%s“!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -773,10 +776,10 @@ msgstr "soubor1 soubor2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[aktuální_složka] [složka_druhého_panelu]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -847,28 +850,23 @@ msgstr "Hledat"
 msgid "Search is disabled"
 msgstr "Hledání je vypnuto"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Nedaří se vytvořit dočasný rozdílový soubor\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Nedaří se vytvořit záložní soubor\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Nedaří se vytvořit dočasný spojovací soubor\n"
 "%s"
@@ -939,18 +937,19 @@ msgstr "ButtonBar|Nastav"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Konec"
 
-msgid "Quit"
-msgstr "Ukončit"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Soubory byl upraveny. Uložit před ukončením?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander se ukončuje.\n"
 "Uložit upravené soubory?"
+
+msgid "Quit"
+msgstr "Ukončit"
 
 msgid "Diff:"
 msgstr "Rozdíl:"
@@ -958,13 +957,15 @@ msgstr "Rozdíl:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "„%s“ je složka"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Na „%s“ nelze provést stat\n"
@@ -983,9 +984,13 @@ msgstr "Načítání: %3d%%"
 msgid "Loading..."
 msgstr "Načítání…"
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Nepodařilo se otevřít %s pro čtení"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"„%s“ se nedaří otevřít\n"
+"%s"
 
 msgid "Load file"
 msgstr "Načíst soubor"
@@ -994,12 +999,10 @@ msgstr "Načíst soubor"
 msgid "Error reading %s"
 msgstr "Chyba při čtení %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Nedaří se zjistit velikost/práva k souboru %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "„%s“ není normální soubor"
 
 #, c-format
@@ -1017,8 +1020,10 @@ msgstr "Varování"
 msgid "Error reading from pipe: %s"
 msgstr "Chyba při čtení z roury: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Nelze otevřít rouru pro čtení: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1031,12 +1036,11 @@ msgstr "Soubor byl mezitím změněn. Opravdu uložit?"
 msgid "Error writing to pipe: %s"
 msgstr "Chyba při zápisu do roury: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Nedaří se otevřít rouru pro zápis: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Nedaří se otevřít soubor pro zápis: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1081,8 +1085,12 @@ msgstr "Kontrolovat nový řádek &POSIX"
 msgid "Edit Save Mode"
 msgstr "Upravit ukládací režim"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Nelze uložit: cíl není běžným souborem"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Není možné prohlížet: nejedná se o běžný soubor"
 
 msgid "A file already exists with this name"
 msgstr "Takto nazvaný soubor už existuje"
@@ -1141,9 +1149,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Zavřít soubor"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander se ukončuje.\n"
@@ -1584,15 +1592,13 @@ msgstr "Potvrdit nahrazení"
 msgid "%ld replacements made"
 msgstr "Provedeno %ld nahrazení"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Uživatelsky přívětivý textový editor\n"
 "napsaný pro Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "O programu"
@@ -1720,16 +1726,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Znovu načíst aktuální syntaxi >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Nedaří se otevřít soubor %s"
+
 msgid "Load syntax file"
 msgstr "Načíst soubor se syntaxí"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Nedaří se otevřít soubor %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1761,7 +1765,8 @@ msgstr ""
 "Nejedná se o xterm nebo linuxovou konzoli;\n"
 "podshell není možné přepnout."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Do Midnight Commander se vrátíte zadáním příkazu „exit“"
 
 msgid "Set &all"
@@ -1792,26 +1797,33 @@ msgstr "Oprávnění (osmičkově): %o"
 msgid "Chown advanced command"
 msgstr "Rozšířená změna vlastníka"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Práva „%s“ se nedaří změnit\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Nedaří se změnit vlastníka souboru „%s“\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Práva „%s“ se nedaří změnit\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignorovat"
-
-msgid "Ignore &all"
-msgstr "Ignorov&at vše"
-
-msgid "&Retry"
-msgstr "&Zkusit znovu"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Nedaří se změnit vlastníka souboru „%s“\n"
@@ -1828,6 +1840,20 @@ msgstr "Spuštěné"
 
 msgid "Stopped"
 msgstr "Zastaveno"
+
+#, fuzzy
+msgid "No translation"
+msgstr "–  < Bez převodu >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Znaková sada pro vstup/zobrazení:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Nikdy"
@@ -1906,17 +1932,6 @@ msgstr "A&utomatické ukládání parametrů"
 
 msgid "Configure options"
 msgstr "Změna nastavení"
-
-#, fuzzy
-msgid "No translation"
-msgstr "–  < Bez převodu >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Znaková sada pro vstup/zobrazení:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Schéma vzhledu:"
@@ -2113,10 +2128,9 @@ msgstr "Vynutit u&končení"
 msgid "Background jobs"
 msgstr "Úlohy na pozadí"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "Nedaří se přejít do složky\n"
@@ -2210,19 +2224,29 @@ msgstr "&Smazat označené"
 msgid "Chattr command"
 msgstr "Příkaz chattr"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Není možné chattr „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+".tar archiv se nedaří otevřít\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Není možné chattr „%s“\n"
+"%s"
 
 msgid "set &user ID on execution"
 msgstr "při spouštění nastavit identifikátor &uživatele"
@@ -2324,13 +2348,21 @@ msgstr "Odkaz %s do:"
 msgid "Link"
 msgstr "Odkaz"
 
-#, c-format
-msgid "link: %s"
-msgstr "odkaz: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Nelze vytvořit cílový symbolický odkaz „%s“\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "symbolický odkaz: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Nelze kopírovat cyklický symbolický odkaz\n"
+"„%s“"
 
 msgid "View file"
 msgstr "Prohlížet soubor"
@@ -2352,6 +2384,12 @@ msgstr "Vytvořit novou složku"
 
 msgid "Enter directory name:"
 msgstr "Zadejte název složky:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Nedaří se vytvořit složku %s"
 
 msgid "Extension file edit"
 msgstr "Upravit akce k příponám"
@@ -2401,12 +2439,16 @@ msgstr "Symbolický odkaz „%s“ vede na:"
 msgid "Edit symlink"
 msgstr "Upravit symbolický odkaz"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "upravte symbolický odkaz, %s není možné odstranit: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "upravit symbolický odkaz: %s"
 
 msgid "FTP to machine"
@@ -2450,10 +2492,8 @@ msgstr ""
 msgid "Parameter"
 msgstr "Parametr"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Nedaří se vytvořit dočasný příkazový soubor\n"
 "%s"
@@ -2461,23 +2501,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "pipe() se nezdařilo"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "Máte zastaralý soubor %s.\n"
 "Midnight Commander nyní používá soubor %s.\n"
 "Zkopírujte si své úpravy původního souboru do toho nového."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "Formát souboru\n"
 "%s%s\n"
@@ -2543,29 +2583,23 @@ msgstr "souborů/složek"
 msgid " with source mask:"
 msgstr " vyhovující masce:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Nedaří se provést stat na zdrojovém souboru pevného odkazu „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Nedaří se vytvořit cílový hardlink „%s“\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Nedaří se vytvořit cílový hardlink „%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Nedaří se číst zdrojový odkaz „%s“\n"
@@ -2581,9 +2615,9 @@ msgstr ""
 "\n"
 "Možnost  stabilních symbolických odkazů bude zakázána"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Nelze vytvořit cílový symbolický odkaz „%s“\n"
@@ -2613,21 +2647,31 @@ msgstr ""
 "„%s“\n"
 "jsou stejný soubor"
 
+msgid "&Ignore"
+msgstr "&Ignorovat"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "&Zkusit znovu"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Složka „%s“ není prázdná.\n"
 "Smazat rekurzivně?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Proces na pozadí:\n"
@@ -2637,17 +2681,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Žá&dné"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Nelze smazat soubor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Na souboru „%s“ nelze provést stat\n"
@@ -2657,102 +2701,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Nedaří se přepsat složku „%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Nelze přesunout soubor „%s“ na „%s“\n"
+"Nelze smazat soubor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Nelze smazat složku „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Nedaří se přepsat složku „%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Nelze přepsat složku „%s“\n"
-"%s"
+msgstr "Nedaří se přepsat složku „%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Nelze přepsat soubor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Nelze přesunout složku „%s“ na „%s“\n"
+"Nelze smazat složku „%s“\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Nelze pracovat s „..“!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Na zdrojovém souboru „%s“ nelze provést stat\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Nedaří se provést stat na zdrojovém souboru pevného odkazu „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Nelze provést fstat cílového souboru „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Nelze vytvořit speciální soubor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Nelze provést změnu vlastníka cílového souboru „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Nelze změnit práva cílového souboru „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Nelze otevřít zdrojový soubor „%s“\n"
@@ -2761,49 +2811,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Reget se nezdařilo, soubor bude přepsán"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Nelze provést fstat zdrojového souboru „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Nelze vytvořit cílový soubor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Nelze provést fstat cílového souboru „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Nelze předem přiřadit místo pro cílový soubor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Nelze číst zdrojový soubor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Nelze psát do cílového souboru „%s“\n"
@@ -2821,41 +2871,45 @@ msgstr "&Ponechat"
 msgid "&Continue copy"
 msgstr "&Pokračovat v kopírování"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Nelze zavřít zdrojový soubor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Nelze zavřít cílový soubor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Nelze předem přiřadit místo pro cílový soubor „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Na zdrojovém adresáři „%s“ nelze provést stat\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Na zdrojovém adresáři „%s“ nelze provést stat\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2873,25 +2927,27 @@ msgstr ""
 "Nelze kopírovat cyklický symbolický odkaz\n"
 "„%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Je třeba, aby cíl „%s“ byla složka\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Nelze vytvořit cílovou složku „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Nelze změnit práva cílové složky „%s“\n"
@@ -3221,11 +3277,9 @@ msgstr[1] "Máte %zu otevřené obrazovky. Ukončit i tak?"
 msgstr[2] "Máte otevřeno %zu obrazovek. Ukončit i tak?"
 msgstr[3] "Máte otevřeno %zu obrazovek. Ukončit i tak?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Opravdu chcete Midnight Commander ukončit?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Opravdu chcete spustit?"
 
 msgid "&Above"
 msgstr "N&ad"
@@ -3730,11 +3784,10 @@ msgstr ""
 "Externí panelizace:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Externí panelizace:\n"
 "nepodařilo se číst data ze std. výstupu podříz. procesu:\n"
@@ -3777,6 +3830,15 @@ msgid ""
 "%s"
 msgstr ""
 "Na cíli nelze provést stat\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Je třeba, aby cíl „%s“ byla složka\n"
 "%s"
 
 #, c-format
@@ -3899,8 +3961,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Popis umístění domovské složky není zadaný od té kořenové"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4613,8 +4676,9 @@ msgstr "Soubor byl změněn. Uložit při ukončování?"
 msgid "&Cancel quit"
 msgstr "&Zrušit ukončování"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander je ukončován.\n"
@@ -4665,10 +4729,8 @@ msgstr "ButtonBar|Odform"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Formát"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Nepodařilo se načíst data ze standardního vstupu podřízeného procesu:\n"
 "%s"
@@ -4694,20 +4756,18 @@ msgstr ""
 msgid "View: "
 msgstr "Prohlížet: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"„%s“ se nedaří otevřít\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Není možné prohlížet: nejedná se o běžný soubor"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "„%s\" se nedaří otevřít v režimu pro zpracování (parse)\n"
@@ -4721,6 +4781,78 @@ msgstr "Pokračovat od začátku?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Nedaří získat místní kopii souboru /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Opravdu chcete Midnight Commander ukončit?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Nepodařilo se otevřít %s pro čtení"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Nedaří se zjistit velikost/práva k souboru %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Nedaří se otevřít rouru pro zápis: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Nelze uložit: cíl není běžným souborem"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nedaří se otevřít soubor %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignorov&at vše"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "odkaz: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "symbolický odkaz: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nedaří se vytvořit cílový hardlink „%s“\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nelze přesunout soubor „%s“ na „%s“\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nelze přepsat složku „%s“\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nelze přesunout složku „%s“ na „%s“\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Ostatní 8 bitů"

--- a/po/da.po
+++ b/po/da.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Danish (http://app.transifex.com/mc/mc/language/da/)\n"
@@ -54,6 +54,9 @@ msgstr "Kan ikke oprette gruppen '%s' for hændelser!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Kan ikke oprette hændelsen '%s'!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -768,10 +771,10 @@ msgstr "fil1 fil2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[denne_mappe] [andet_panel_mappe]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -842,28 +845,23 @@ msgstr "Søg"
 msgid "Search is disabled"
 msgstr "Søgning er deaktiveret"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Kan ikke oprette midlertidig forskelsfil\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Kan ikke oprette sikkerhedskopi\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Kan ikke oprette midlertidig flettefil\n"
 "%s"
@@ -934,18 +932,19 @@ msgstr "Indstillinger"
 msgid "ButtonBar|Quit"
 msgstr "Afslut"
 
-msgid "Quit"
-msgstr "Afslut"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Filer blev ændret. Gem ved afslut?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander bliver lukket ned.\n"
 "Gem ændrede filer?"
+
+msgid "Quit"
+msgstr "Afslut"
 
 msgid "Diff:"
 msgstr "Forskel:"
@@ -953,13 +952,15 @@ msgstr "Forskel:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "»%s« er en mappe"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Kan ikke stat »%s«\n"
@@ -978,9 +979,13 @@ msgstr "Indlæser: %3d%%"
 msgid "Loading..."
 msgstr "Indlæser..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Kan ikke åbne %s til læsning"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Kan ikke åbne »%s«\n"
+"%s"
 
 msgid "Load file"
 msgstr "Indlæs fil"
@@ -989,12 +994,10 @@ msgstr "Indlæs fil"
 msgid "Error reading %s"
 msgstr "Fejl under læsning af %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Kan ikke indhente størrelse/tilladelser for %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "»%s« er ikke en almindelig fil"
 
 #, c-format
@@ -1012,8 +1015,10 @@ msgstr "Advarsel"
 msgid "Error reading from pipe: %s"
 msgstr "Der opstod en fejl under læsning fra datakanal: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Kan ikke åbne datakanal til læsning: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1026,12 +1031,11 @@ msgstr "Filen er blevet ændret i mellemtiden. Gem alligevel?"
 msgid "Error writing to pipe: %s"
 msgstr "Der opstod en fejl under skriving til datakanal: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Kan ikke åbne datakanal til skrivning: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Kan ikke åbne fil til skrivning: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1076,8 +1080,12 @@ msgstr "Tjek &POSIX-linjeskift"
 msgid "Edit Save Mode"
 msgstr "Rediger gemtilstand"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Kan ikke gemme: destination er ikke en almindelig fil"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Kan ikke vise: Ikke en almindelig fil"
 
 msgid "A file already exists with this name"
 msgstr "En fil findes allerede med dette navn"
@@ -1136,9 +1144,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Luk fil"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander bliver lukket ned.\n"
@@ -1580,15 +1588,13 @@ msgstr "Bekræft erstatning"
 msgid "%ld replacements made"
 msgstr "%ld erstatninger foretaget"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "En brugervenlig teksteditor\n"
 "skrevet til Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Om"
@@ -1716,16 +1722,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Genindlæs aktuel syntaks >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Kan ikke åbne fil %s"
+
 msgid "Load syntax file"
 msgstr "Indlæs syntaksfil"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Kan ikke åbne fil %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1756,7 +1760,8 @@ msgstr ""
 "Ikke en xterm eller Linuxkonsol;\n"
 "underskallen kan ikke skiftes."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Skriv 'exit' for at vende tilbage til Midnight Commander"
 
 msgid "Set &all"
@@ -1787,26 +1792,33 @@ msgstr "Rettigheder (oktal): %o"
 msgid "Chown advanced command"
 msgstr "Avancerede kommando til chown"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Kan ikke chmod »%s«\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Kan ikke chown »%s«\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Kan ikke chmod »%s«\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignorer"
-
-msgid "Ignore &all"
-msgstr "Ignorer &alle"
-
-msgid "&Retry"
-msgstr "&Prøv igen"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Kan ikke chown »%s«\n"
@@ -1823,6 +1835,20 @@ msgstr "Kører"
 
 msgid "Stopped"
 msgstr "Stoppet"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Ingen oversættelse >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Tegnsæt for inddata/visning:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Aldrig"
@@ -1901,17 +1927,6 @@ msgstr "Opsætning for a&utomatisk gemning"
 
 msgid "Configure options"
 msgstr "Konfigurer indstillinger"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Ingen oversættelse >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Tegnsæt for inddata/visning:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Tema:"
@@ -2109,12 +2124,13 @@ msgstr "&Dræb"
 msgid "Background jobs"
 msgstr "Baggrundsjobs"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"Kan ikke chown målmappe »%s«\n"
+"%s"
 
 msgid "Secure deletion"
 msgstr "Sikker sletning"
@@ -2203,19 +2219,29 @@ msgstr "F&jern markerede"
 msgid "Chattr command"
 msgstr "Chattr-kommando"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Kan ikke chattr \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Kunne ikke åbne tar-arkiv\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Kan ikke chattr \"%s\"\n"
+"%s"
 
 msgid "set &user ID on execution"
 msgstr "sæt &bruger-id ved eksekvering"
@@ -2317,13 +2343,21 @@ msgstr "Henvis %s til:"
 msgid "Link"
 msgstr "Henvisninger"
 
-#, c-format
-msgid "link: %s"
-msgstr "henvisning: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Kan ikke oprette symbolsk målhenvisning »%s«\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "symbolsk henvisning: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Kan ikke kopiere cyklisk symbolsk henvisning\n"
+"»%s«"
 
 msgid "View file"
 msgstr "Vis fil"
@@ -2345,6 +2379,12 @@ msgstr "Opret en ny mappe"
 
 msgid "Enter directory name:"
 msgstr "Indtast mappenavn:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Kan ikke oprette mappen %s"
 
 msgid "Extension file edit"
 msgstr "Rediger filendelse"
@@ -2394,12 +2434,16 @@ msgstr "Symbolsk henvisning '%s' peger til:"
 msgid "Edit symlink"
 msgstr "Rediger symbolsk henvisning"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "rediger symbolsk henvisning, kan ikke fjerne %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "rediger symbolsk henvisning: %s"
 
 msgid "FTP to machine"
@@ -2441,10 +2485,8 @@ msgstr "Kan ikke køre kommandoer på filsystemer der ikke er lokale"
 msgid "Parameter"
 msgstr "Parameter"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Kan ikke oprette midlertidig kommandofil\n"
 "%s"
@@ -2452,23 +2494,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Datakanal fejlede"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "Du har en forældet %s-fil.\n"
 "Midnight Commander bruger nu %s-fil\n"
 "Kopier dine ændringer i den gamle fil til den nye fil-"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "Formatet på\n"
 "%s%s\n"
@@ -2534,29 +2576,23 @@ msgstr "filer/mapper"
 msgid " with source mask:"
 msgstr " med kildemaske:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Kan ikke stat hårde henvisninger for kildefil \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Kan ikke oprette målets hårde henvisninger for \"%s\"\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Kan ikke oprette målets hårde henvisninger for \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Kan ikke læse kildehenvisning »%s«\n"
@@ -2572,9 +2608,9 @@ msgstr ""
 "\n"
 "Valgmuligheden Stabile symbolske henvisninger deaktiveres"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Kan ikke oprette symbolsk målhenvisning »%s«\n"
@@ -2604,21 +2640,31 @@ msgstr ""
 "»%s«\n"
 "er den samme fil"
 
+msgid "&Ignore"
+msgstr "&Ignorer"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "&Prøv igen"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Mappen \"%s\" er ikke tom.\n"
 "Slet den rekursivt?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Baggrundsproces:\n"
@@ -2628,17 +2674,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Ing&en"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Kan ikke flytte fil »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Kan ikke stat fil »%s«\n"
@@ -2648,102 +2694,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Kan ikke overskrive mappe »%s«"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Kan ikke flytte fil »%s« til »%s«\n"
+"Kan ikke flytte fil »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Kan ikke fjerne mappe »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Kan ikke overskrive mappe »%s«"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Kan ikke overskrive mappe »%s«\n"
-"%s"
+msgstr "Kan ikke overskrive mappe »%s«"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Kan ikke overskrive fil »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Kan ikke flytte mappe »%s« til »%s«\n"
+"Kan ikke fjerne mappe »%s«\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Kan ikke bruge handling på »..«!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Kan ikke stat kildefil »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Kan ikke stat hårde henvisninger for kildefil \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Kan ikke fstat målfil »%s«\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Kan ikke oprette specielfil »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Kan ikke chown målfil »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Kan ikke chmod målfil »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Kan ikke åbne kildefil »%s«\n"
@@ -2752,49 +2804,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Reget fejlede, fil er i færd med at blive overskrevet"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Kan ikke fstat kildefil »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Kan ikke oprette målfil »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Kan ikke fstat målfil »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Kan ikke præallokere plads til målfilen \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Kan ikke læse kildefilen \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Kan ikke skrive målfil »%s«\n"
@@ -2812,41 +2864,45 @@ msgstr "&Behold"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Kan ikke lukke kildefil »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Kan ikke lukke målfil »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Kan ikke præallokere plads til målfilen \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Kan ikke stat kildemappe »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Kan ikke stat kildemappe »%s«\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2864,25 +2920,27 @@ msgstr ""
 "Kan ikke kopiere cyklisk symbolsk henvisning\n"
 "»%s«"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Destination »%s« skal være en mappe\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Kan ikke oprette målmappe »%s«\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Kan ikke chown målmappe »%s«\n"
@@ -3210,11 +3268,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "Du har %zu åben skærm. Afslut alligevel?"
 msgstr[1] "Du har %zu åbne skærme. Afslut alligevel?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Ønsker du virkelig at afslutte Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Ønsker du virkelig at køre?"
 
 msgid "&Above"
 msgstr "&Over"
@@ -3713,11 +3769,10 @@ msgstr ""
 "Ekstern panelisering:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Ekstern panelisering:\n"
 "Kunne ikke læse data fra barneproces' standard-uddata:\n"
@@ -3760,6 +3815,15 @@ msgid ""
 "%s"
 msgstr ""
 "Kan ikke stat destinationen\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Destination »%s« skal være en mappe\n"
 "%s"
 
 #, c-format
@@ -3882,8 +3946,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Hjemmemappesti er ikke absolut"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4591,8 +4656,9 @@ msgstr "Fil blev ændret. Gem under afslutning?"
 msgid "&Cancel quit"
 msgstr "&Afbryd afslut"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander er ved at lukke ned.\n"
@@ -4643,10 +4709,8 @@ msgstr "Fjern format"
 msgid "ButtonBar|Format"
 msgstr "Format"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Kunne ikke læse data fra barne-stdout:\n"
 "%s"
@@ -4672,20 +4736,18 @@ msgstr ""
 msgid "View: "
 msgstr "Vis: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Kan ikke åbne »%s«\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Kan ikke vise: Ikke en almindelig fil"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Kan ikke åbne \"%s\" i fortolkningstilstand\n"
@@ -4699,6 +4761,78 @@ msgstr "Fortsæt fra begyndelsen?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Kan ikke hente en lokal kopi af /ftp://en.vært/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Ønsker du virkelig at afslutte Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Kan ikke åbne %s til læsning"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Kan ikke indhente størrelse/tilladelser for %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Kan ikke åbne datakanal til skrivning: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Kan ikke gemme: destination er ikke en almindelig fil"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kan ikke åbne fil %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignorer &alle"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "henvisning: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "symbolsk henvisning: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kan ikke oprette målets hårde henvisninger for \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kan ikke flytte fil »%s« til »%s«\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kan ikke overskrive mappe »%s«\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kan ikke flytte mappe »%s« til »%s«\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Andre 8-bit"

--- a/po/de.po
+++ b/po/de.po
@@ -23,7 +23,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2016,2025\n"
 "Language-Team: German (http://app.transifex.com/mc/mc/language/de/)\n"
@@ -63,6 +63,9 @@ msgstr "Kann die Ereignisgruppe '%s' nicht erstellen!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Kann das Ereignis '%s' nicht erstellen!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -807,10 +810,10 @@ msgstr "Datei1 Datei2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[dieses_Verzeichnis] [anderes_Panel_Verzeichnis]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -881,28 +884,23 @@ msgstr "Suchen"
 msgid "Search is disabled"
 msgstr "Suche ist deaktiviert"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Kann temporäre Diffdatei nicht erstellen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Kann Sicherungsdatei nicht erstellen\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Kann temporäre Mergedatei nicht erstellen\n"
 "%s"
@@ -973,18 +971,19 @@ msgstr "ButtonBar|Optionen"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Beenden"
 
-msgid "Quit"
-msgstr "Beenden"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Datei(en) wurde(n) geändert. Beim Beenden speichern?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander wird heruntergefahren.\n"
 "Geänderte Datei(en) speichern?"
+
+msgid "Quit"
+msgstr "Beenden"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -992,13 +991,15 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" ist ein Verzeichnis"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Kann \"%s\" nicht untersuchen\n"
@@ -1017,9 +1018,13 @@ msgstr "Ladevorgang: %3d%%"
 msgid "Loading..."
 msgstr "Ladevorgang..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Kann Datei \"%s\" nicht zum Lesen öffnen"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Kann \"%s\" nicht öffnen\n"
+"%s"
 
 msgid "Load file"
 msgstr "Datei laden"
@@ -1028,12 +1033,10 @@ msgstr "Datei laden"
 msgid "Error reading %s"
 msgstr "Fehler beim Lesen %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Kann Größe/Zugriffsrechte der Datei \"%s\" nicht ermitteln"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" ist keine normale Datei"
 
 #, c-format
@@ -1051,8 +1054,10 @@ msgstr "Warnung"
 msgid "Error reading from pipe: %s"
 msgstr "Fehler beim Lesen aus einer Pipe: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Kann Pipe zum Lesen nicht öffnen: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1066,12 +1071,11 @@ msgstr "Die Datei wurde zwischenzeitlich geändert, trotzdem speichern?"
 msgid "Error writing to pipe: %s"
 msgstr "Fehler beim Schreiben auf eine Pipe: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Kann Pipe zum Schreiben nicht öffnen: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Kann die Datei \"%s\" zum Schreiben nicht öffnen"
 
 msgid "The file you are saving does not end with a newline."
@@ -1116,8 +1120,12 @@ msgstr "&POSIX-Zeilenvorschub überprüfen"
 msgid "Edit Save Mode"
 msgstr "Editor-Speichermodus"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Kann nicht speichern: Ziel ist keine normale Datei"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Kann es nicht anzeigen: Keine normale Datei"
 
 msgid "A file already exists with this name"
 msgstr "Es ist bereits eine Datei mit diesem Namen vorhanden"
@@ -1176,9 +1184,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Datei schließen"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander wird beendet.\n"
@@ -1621,15 +1629,13 @@ msgstr "Ersetzen bestätigen"
 msgid "%ld replacements made"
 msgstr "%ld Ersetzung(en) durchgeführt."
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Ein benutzerfreundlicher Texteditor,\n"
 "geschrieben für Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Über"
@@ -1757,16 +1763,14 @@ msgstr "< Automatisch >"
 msgid "< Reload Current Syntax >"
 msgstr "< Aktuelle Hervorhebung neu laden >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Kann Datei %s nicht öffnen"
+
 msgid "Load syntax file"
 msgstr "Syntaxdatei laden"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Kann Datei %s nicht öffnen\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1797,7 +1801,8 @@ msgstr ""
 "Keine xterm- oder Linux-Konsole;\n"
 "die Subshell kann nicht umgeschaltet werden."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Geben Sie 'exit' ein, um zum Midnight Commander zurückzukehren"
 
 msgid "Set &all"
@@ -1828,26 +1833,33 @@ msgstr "Zugriffsrechte (oktal): %o"
 msgid "Chown advanced command"
 msgstr "Erweitertes Kommando chown"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Kann chmod für \"%s\" nicht durchführen\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Kann chown für \"%s\" nicht durchführen\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Kann chmod für \"%s\" nicht durchführen\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignorieren"
-
-msgid "Ignore &all"
-msgstr "&Alles ignorieren"
-
-msgid "&Retry"
-msgstr "Wiede&rholen"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Kann chown für \"%s\" nicht durchführen\n"
@@ -1864,6 +1876,20 @@ msgstr "Läuft"
 
 msgid "Stopped"
 msgstr "Angehalten"
+
+#, fuzzy
+msgid "No translation"
+msgstr "- < Keine Übersetzung >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Codepage eingeben/anzeigen:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Nie"
@@ -1942,17 +1968,6 @@ msgstr "Einstellungen auto&m. speichern"
 
 msgid "Configure options"
 msgstr "Einstellungen"
-
-#, fuzzy
-msgid "No translation"
-msgstr "- < Keine Übersetzung >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Codepage eingeben/anzeigen:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Skin:"
@@ -2148,10 +2163,9 @@ msgstr "&Killen"
 msgid "Background jobs"
 msgstr "Hintergrundaufgaben"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "Kann Verzeichnis nicht wechseln zu\n"
@@ -2245,19 +2259,29 @@ msgstr "Markierte &aufheben"
 msgid "Chattr command"
 msgstr "Chattr-Befehl"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Kann chattr für\"%s\" nicht durchführen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Kann tar-Archiv nicht öffnen\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Kann chattr für\"%s\" nicht durchführen\n"
+"%s"
 
 msgid "set &user ID on execution"
 msgstr "Ben&utzer-ID bei Ausführung setzen"
@@ -2359,13 +2383,21 @@ msgstr "Link %s zu:"
 msgid "Link"
 msgstr "Link"
 
-#, c-format
-msgid "link: %s"
-msgstr "Link: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Kann das Ziel des symbolischen Links \"%s\" nicht erstellen\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "Symbolischer Link: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Kann zyklischen symbolischen Link nicht kopieren\n"
+"\"%s\""
 
 msgid "View file"
 msgstr "Datei anzeigen"
@@ -2387,6 +2419,12 @@ msgstr "Ein neues Verzeichnis anlegen"
 
 msgid "Enter directory name:"
 msgstr "Verzeichnisnamen eingeben:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Kann das Verzeichnis %s nicht erstellen"
 
 msgid "Extension file edit"
 msgstr "Bearbeiten der Erweiterungsdatei"
@@ -2436,12 +2474,16 @@ msgstr "Symbolischer Link '%s' zeigt auf:"
 msgid "Edit symlink"
 msgstr "Symbolischen Link bearbeiten"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "Symbolischen Link bearbeiten, kann %s nicht entfernen: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "Symbolischen Link bearbeiten: %s"
 
 msgid "FTP to machine"
@@ -2483,10 +2525,8 @@ msgstr "Kann Befehle auf nicht-lokalen Dateisystemen nicht ausführen"
 msgid "Parameter"
 msgstr "Parameter"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Kann temporäre Befehlsdatei nicht erstellen\n"
 "%s"
@@ -2494,23 +2534,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Pipe fehlgeschlagen"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "Sie haben eine veraltete Datei %s.\n"
 "Midnight Commander verwendet jetzt eine neue Datei %s.\n"
 "Bitte kopieren Sie Ihre Änderungen der alten Datei in die neue Datei."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "Das Format der Datei\n"
 "%s%s\n"
@@ -2576,29 +2616,23 @@ msgstr "Dateien/Verzeichnisse"
 msgid " with source mask:"
 msgstr " mit Quellmaske:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Kann Quelldatei des harten Links \"%s\" nicht untersuchen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Kann das Ziel des harten Links \"%s\" nicht erstellen\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Kann das Ziel des harten Links \"%s\" nicht erstellen"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Kann Quell-Link \"%s\" nicht lesen\n"
@@ -2614,9 +2648,9 @@ msgstr ""
 "\n"
 "Einstellung 'Stabile symbolische Links' wird deaktiviert"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Kann das Ziel des symbolischen Links \"%s\" nicht erstellen\n"
@@ -2646,21 +2680,31 @@ msgstr ""
 "\"%s\"\n"
 "sind die gleichen Dateien"
 
+msgid "&Ignore"
+msgstr "&Ignorieren"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "Wiede&rholen"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Verzeichnis \"%s\" nicht leer.\n"
 "Rekursiv löschen?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Hintergrundprozess:\n"
@@ -2670,17 +2714,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Kein&e"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Kann Datei \"%s\" nicht löschen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Kann Datei \"%s\" nicht untersuchen\n"
@@ -2690,102 +2734,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Kann Verzeichnis \"%s\" nicht überschreiben"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Kann Datei \"%s\" nicht in \"%s\" umbenennen\n"
+"Kann Datei \"%s\" nicht löschen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Kann Verzeichnis \"%s\" nicht löschen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Kann Verzeichnis \"%s\" nicht überschreiben"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Kann Verzeichnis \"%s\" nicht überschreiben\n"
-"%s"
+msgstr "Kann Verzeichnis \"%s\" nicht überschreiben"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Kann Datei \"%s\" nicht überschreiben\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Kann Verzeichnis \"%s\" nicht in \"%s\" umbenennen\n"
+"Kann Verzeichnis \"%s\" nicht löschen\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Kann nicht auf \"..\" agieren!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Kann Quelldatei \"%s\" nicht untersuchen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Kann Quelldatei des harten Links \"%s\" nicht untersuchen\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Kann Zieldatei \"%s\" nicht untersuchen\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Kann Spezialdatei \"%s\" nicht erstellen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Kann chown nicht auf die Zieldatei \"%s\" anwenden\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Kann chmod nicht auf die Zieldatei \"%s\" anwenden\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Kann Quelldatei \"%s\" nicht öffnen\n"
@@ -2794,49 +2844,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Erneutes Holen fehlgeschlagen, überschreibe Datei"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Kann Quelldatei \"%s\" nicht untersuchen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Kann Zieldatei \"%s\" nicht erstellen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Kann Zieldatei \"%s\" nicht untersuchen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Kann keinen Speicher für Zieldatei \"%s\" reservieren\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Kann Quelldatei \"%s\" nicht lesen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Kann Zieldatei \"%s\" nicht schreiben\n"
@@ -2854,41 +2904,45 @@ msgstr "&Behalten"
 msgid "&Continue copy"
 msgstr "Kopieren &fortsetzen"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Kann Quelldatei \"%s\" nicht schließen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Kann Zieldatei \"%s\" nicht schließen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Kann keinen Speicher für Zieldatei \"%s\" reservieren\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Kann Quellverzeichnis \"%s\" nicht untersuchen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Kann Quellverzeichnis \"%s\" nicht untersuchen\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2906,25 +2960,27 @@ msgstr ""
 "Kann zyklischen symbolischen Link nicht kopieren\n"
 "\"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Ziel \"%s\" muss ein Verzeichnis sein\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Kann Zielverzeichnis \"%s\" nicht erstellen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Kann chown nicht auf das Zielverzeichnis \"%s\" anwenden\n"
@@ -3252,11 +3308,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "Sie haben %zu offenen Bildschirm. Trotzdem beenden?"
 msgstr[1] "Sie haben %zu offene Bildschirme. Trotzdem beenden?"
 
-msgid "The Midnight Commander"
-msgstr "Der Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Möchten Sie den Midnight Commander wirklich verlassen?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Möchten Sie wirklich ausführen?"
 
 msgid "&Above"
 msgstr "&Oben"
@@ -3755,11 +3809,10 @@ msgstr ""
 "Externes Anordnen:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Externe Spaltenanzeige:\n"
 "Fehler beim Lesen der Daten aus einem Kindprozess:\n"
@@ -3803,6 +3856,15 @@ msgid ""
 "%s"
 msgstr ""
 "Kann das Ziel nicht untersuchen\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Ziel \"%s\" muss ein Verzeichnis sein\n"
 "%s"
 
 #, c-format
@@ -3923,8 +3985,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Benutzerverzeichnis-Pfad ist nicht absolut"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4650,8 +4713,9 @@ msgstr "Datei wurde geändert. Beim Beenden speichern?"
 msgid "&Cancel quit"
 msgstr "Doch nicht beenden"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander wird beendet.\n"
@@ -4702,10 +4766,8 @@ msgstr "ButtonBar|Unform"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Format"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Fehler beim Lesen der Daten aus einem Kindprozess:\n"
 "%s"
@@ -4731,20 +4793,18 @@ msgstr ""
 msgid "View: "
 msgstr "Ansicht: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Kann \"%s\" nicht öffnen\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Kann es nicht anzeigen: Keine normale Datei"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Kann \"%s\" nicht im Analysemodus öffnen\n"
@@ -4758,6 +4818,78 @@ msgstr "Am Anfang fortsetzen?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Kann lokale Kopie von /ftp://some.host/editme.txt nicht erstellen"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Der Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Möchten Sie den Midnight Commander wirklich verlassen?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Kann Datei \"%s\" nicht zum Lesen öffnen"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Kann Größe/Zugriffsrechte der Datei \"%s\" nicht ermitteln"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Kann Pipe zum Schreiben nicht öffnen: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Kann nicht speichern: Ziel ist keine normale Datei"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kann Datei %s nicht öffnen\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "&Alles ignorieren"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "Link: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "Symbolischer Link: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kann das Ziel des harten Links \"%s\" nicht erstellen\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kann Datei \"%s\" nicht in \"%s\" umbenennen\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kann Verzeichnis \"%s\" nicht überschreiben\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kann Verzeichnis \"%s\" nicht in \"%s\" umbenennen\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Andere 8 Bit"

--- a/po/de_CH.po
+++ b/po/de_CH.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2015-02-26 09:48+0000\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: German (Switzerland) (http://www.transifex.com/projects/p/mc/"
@@ -47,6 +47,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -726,7 +729,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -792,23 +795,16 @@ msgstr ""
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -877,15 +873,16 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr ""
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Diff:"
@@ -895,12 +892,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -918,7 +917,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -929,11 +930,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -950,7 +949,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -964,11 +965,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1013,7 +1013,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1073,7 +1077,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1509,12 +1513,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1643,13 +1645,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1675,7 +1677,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1708,22 +1711,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1737,6 +1743,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1815,15 +1833,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2020,7 +2029,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2113,13 +2121,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2224,11 +2238,15 @@ msgid "Link"
 msgstr ""
 
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2250,6 +2268,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2299,11 +2323,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2343,10 +2371,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2355,7 +2380,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2365,7 +2390,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2422,23 +2447,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2450,7 +2471,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2470,19 +2491,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2491,13 +2522,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2507,37 +2538,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2546,43 +2581,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2591,37 +2626,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2639,31 +2674,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2681,19 +2716,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3018,10 +3055,7 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3515,11 +3549,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3555,6 +3587,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3657,8 +3696,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4308,8 +4348,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4358,10 +4399,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4382,16 +4420,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Greek (http://app.transifex.com/mc/mc/language/el/)\n"
@@ -53,6 +53,9 @@ msgstr "Αδυναμία δημιουργίας ομάδας '%s' για γεγ�
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Αδυναμία δημιουργίας γεγονότος '%s'!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -737,10 +740,10 @@ msgstr ""
 msgid "[this_dir] [other_panel_dir]"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -811,26 +814,23 @@ msgstr "Αναζήτηση"
 msgid "Search is disabled"
 msgstr "Η αναζήτηση είναι απενεργοποιημένη"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
+"Αδυναμία δημιουργίας προσωρινού αρχείου εντολών\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Αδυναμία δημιουργίας αντιγράφου ασφαλείας\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Αδυναμία δημιουργίας προσωρινού αρχείου συγχώνευσης\n"
 "%s"
@@ -901,16 +901,19 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr "Έξοδος"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
+"Το Midnight Commander τερματίζεται.\n"
+"Αποθήκευση τροποποιημένου αρχείου;"
+
+msgid "Quit"
+msgstr "Έξοδος"
 
 msgid "Diff:"
 msgstr ""
@@ -918,15 +921,19 @@ msgstr ""
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" είναι κατάλογος"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
+"Αδυναμία αποθήκευσης αρχείου:\n"
+"%s"
 
 msgid "Diff viewer: invalid mode"
 msgstr ""
@@ -941,9 +948,13 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Αδύνατο το άνοιγμα του %s για ανάγνωση"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Αδυναμία ανοίγματος \"%s\"\n"
+"%s"
 
 msgid "Load file"
 msgstr "Φόρτωση αρχείου"
@@ -952,12 +963,10 @@ msgstr "Φόρτωση αρχείου"
 msgid "Error reading %s"
 msgstr "Σφάλμα κατά την ανάγνωση του %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Αδυναμία λήψης του μεγέθους/αδειών για το %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "Το \"%s\" δεν είναι συνηθισμένο αρχείο"
 
 #, c-format
@@ -973,9 +982,11 @@ msgstr "Προειδοποίηση"
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
+msgstr "Αδύνατο το άνοιγμα του %s για ανάγνωση"
 
 msgid "File has hard-links. Detach before saving?"
 msgstr ""
@@ -987,12 +998,11 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Αδύνατο το άνοιγμα του αρχείου για εγγραφή: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1037,8 +1047,12 @@ msgstr "Έλεγχος για νέα γραμμή &POSIX"
 msgid "Edit Save Mode"
 msgstr "Επεξεργασία λειτουργίας αποθήκευσης"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Αδυναμία αποθήκευση: ο προορισμός είναι ένα ασυνήθιστο αρχείο"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Αδυναμία προβολής: ασυνήθιστο αρχείο"
 
 msgid "A file already exists with this name"
 msgstr "Υπάρχει ήδη ένα αρχείο με αυτό το όνομα"
@@ -1097,9 +1111,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Κλείσιμο αρχείου"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Το Midnight Commander τερματίζεται.\n"
@@ -1537,12 +1551,10 @@ msgstr "Επιβεβαίωση αντικατάστασης"
 msgid "%ld replacements made"
 msgstr "Έγιναν %ld αντικαταστάσεις"
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1671,16 +1683,14 @@ msgstr "< Αυτόματο >"
 msgid "< Reload Current Syntax >"
 msgstr "< Επαναφόρτωση τρέχοντος συντακτικού >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Αδύνατο το άνοιγμα του αρχείου %s"
+
 msgid "Load syntax file"
 msgstr "Φόρτωμα αρχείου συντακτικού"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Αδυναμία ανοίγματος του αρχείου %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1705,7 +1715,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1736,26 +1747,33 @@ msgstr ""
 msgid "Chown advanced command"
 msgstr "Προχωρημένη εντολή chown"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Αδυναμία chmod \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Αδυναμία chown \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Αδυναμία chmod \"%s\"\n"
 "%s"
 
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
-msgstr "&Επαναπροσπάθεια"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Αδυναμία chown \"%s\"\n"
@@ -1772,6 +1790,19 @@ msgstr "Εκτελείται"
 
 msgid "Stopped"
 msgstr "Σταμάτησε"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Χωρίς μετάφραση >"
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Ποτέ"
@@ -1849,16 +1880,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Χωρίς μετάφραση >"
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2052,12 +2073,13 @@ msgstr "&Σκότωμα"
 msgid "Background jobs"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"Αδυναμία chown στον κατάλογο στόχο \"%s\"\n"
+"%s"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2146,17 +2168,29 @@ msgstr "&Καθαρισμός επιλεγμένων"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
+"Αδυναμία chmod \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Άνοιγμα αρχειοθήκης tar ανεπιτυχές\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Αδυναμία chmod \"%s\"\n"
+"%s"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2258,13 +2292,22 @@ msgstr "Δεσμός %s σε:"
 msgid "Link"
 msgstr "Δεσμός"
 
-#, c-format
-msgid "link: %s"
-msgstr "δεσμός: %s"
-
-#, c-format
-msgid "symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
+"Αδυναμία δημιουργίας ειδικού αρχείου \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Αδυναμία δημιουργίας αντιγράφου ασφαλείας\n"
+"%s%s\n"
+"%s"
 
 msgid "View file"
 msgstr "Προβολή αρχείου"
@@ -2286,6 +2329,12 @@ msgstr "Δημιουργία νέου καταλόγου"
 
 msgid "Enter directory name:"
 msgstr "Εισαγωγή ονόματος καταλόγου:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Αδυναμία δημιουργία καταλόγου %s"
 
 msgid "Extension file edit"
 msgstr "Επεξεργασία αρχείου επέκτασης"
@@ -2334,12 +2383,18 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
+"Αδυναμία ανοίγματος του αρχείου %s\n"
+"%s"
 
 msgid "FTP to machine"
 msgstr "FTP σε μηχάνημα"
@@ -2380,10 +2435,8 @@ msgstr "Αδυναμία εκτέλεσης εντολών σε μη τοπικ�
 msgid "Parameter"
 msgstr "Παράμετρος"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Αδυναμία δημιουργίας προσωρινού αρχείου εντολών\n"
 "%s"
@@ -2394,7 +2447,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2404,7 +2457,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2459,27 +2512,29 @@ msgstr "αρχεία/κατάλογοι"
 msgid " with source mask:"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"Αδυναμία ανοίγματος πηγαίου αρχείου \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
+"Αδυναμία δημιουργίας αρχείου στόχου \"%s\"\n"
+"%s"
 
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
+"Αδυναμία ανοίγματος πηγαίου αρχείου \"%s\"\n"
+"%s"
 
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
@@ -2487,11 +2542,13 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
+"Αδυναμία δημιουργίας αρχείου στόχου \"%s\"\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2517,137 +2574,157 @@ msgstr ""
 "\"%s\"\n"
 "είναι το ίδιο αρχείο"
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
 msgstr ""
 
+msgid "&Retry"
+msgstr "&Επαναπροσπάθεια"
+
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 msgid "Non&e"
 msgstr "&Κανένα"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Αδυναμία αφαίρεσης αρχείου \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
+"Αδυναμία αποθήκευσης αρχείου:\n"
+"%s"
 
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Αδυναμία αντικατάστασης καταλόγου \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Αδυναμία μετακίνησης αρχείου \"%s\" στο \"%s\"\n"
+"Αδυναμία αφαίρεσης αρχείου \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Αδυναμία αφαίρεσης καταλόγου \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Αδυναμία αντικατάστασης καταλόγου \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Αδυναμία αντικατάστασης καταλόγου \"%s\"\n"
-"%s"
+msgstr "Αδυναμία αντικατάστασης καταλόγου \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Αδυναμία αντικατάστασης αρχείου \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Αδυναμία μετακίνησης καταλόγου \"%s\" to \"%s\"\n"
+"Αδυναμία αφαίρεσης καταλόγου \"%s\"\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Αδυναμία λειτουργίας σε \"..\"!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
+"Αδυναμία κλεισίματος πηγαίου αρχείου \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Αδυναμία δημιουργίας προσωρινού αρχείου συγχώνευσης\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Αδυναμία εγγραφής στο αρχείο στόχο \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Αδυναμία δημιουργίας ειδικού αρχείου \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Αδυναμία chown στο αρχείο στόχο \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Αδυναμία chmod στο αρχείο στόχο \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Αδυναμία ανοίγματος πηγαίου αρχείου \"%s\"\n"
@@ -2656,41 +2733,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
+"Αδυναμία κλεισίματος πηγαίου αρχείου \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Αδυναμία δημιουργίας αρχείου στόχου \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
+"Αδυναμία δημιουργίας αρχείου στόχου \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
+"Αδυναμία δημιουργίας αρχείου στόχου \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
+"Αδυναμία ανοίγματος πηγαίου αρχείου \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Αδυναμία εγγραφής στο αρχείο στόχο \"%s\"\n"
@@ -2708,39 +2793,43 @@ msgstr "&Διατήρηση"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Αδυναμία κλεισίματος πηγαίου αρχείου \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Αδυναμία κλεισίματος αρχείου στόχου \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Αδυναμία εγγραφής στο αρχείο στόχο \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
-msgstr ""
+msgstr "Αδυναμία δημιουργία καταλόγου %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Αδυναμία δημιουργίας καταλόγου στόχου \"%s\"\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2756,25 +2845,27 @@ msgid ""
 "\"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Ο προορισμός \"%s\" πρέπει να είναι κατάλογος\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Αδυναμία δημιουργίας καταλόγου στόχου \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Αδυναμία chown στον κατάλογο στόχο \"%s\"\n"
@@ -3101,11 +3192,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr "Το Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Θέλετε στα αλήθεια να τερματίσετε το Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Σίγουρα θέλετε να γίνει εκτέλεση;"
 
 msgid "&Above"
 msgstr "&Πάνω"
@@ -3600,11 +3689,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3643,6 +3730,15 @@ msgid ""
 "Cannot stat the destination\n"
 "%s"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Ο προορισμός \"%s\" πρέπει να είναι κατάλογος\n"
+"%s"
 
 #, c-format
 msgid "Delete %s?"
@@ -3760,8 +3856,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4427,8 +4524,9 @@ msgstr "Το αρχείο τροποποιήθηκε. Αποθήκευση κα�
 msgid "&Cancel quit"
 msgstr "&Ακύρωση εξόδου"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Το Midnight Commander τερματίζεται.\n"
@@ -4479,10 +4577,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4506,22 +4601,22 @@ msgstr ""
 msgid "View: "
 msgstr "Προβολή:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Αδυναμία ανοίγματος \"%s\"\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Αδυναμία προβολής: ασυνήθιστο αρχείο"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
+"Άνοιγμα αρχειοθήκης tar ανεπιτυχές\n"
+"%s"
 
 msgid "Search done"
 msgstr "Η αναζήτηση τελείωσε"
@@ -4531,6 +4626,47 @@ msgstr "Συνέχεια από την αρχή;"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Το Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Θέλετε στα αλήθεια να τερματίσετε το Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Αδυναμία λήψης του μεγέθους/αδειών για το %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Αδυναμία αποθήκευση: ο προορισμός είναι ένα ασυνήθιστο αρχείο"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "δεσμός: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Αδυναμία μετακίνησης αρχείου \"%s\" στο \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Αδυναμία αντικατάστασης καταλόγου \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Αδυναμία μετακίνησης καταλόγου \"%s\" to \"%s\"\n"
+#~ "%s"
 
 #~ msgid "7 &bits"
 #~ msgstr "7 &bits"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: English (United Kingdom) (http://app.transifex.com/mc/mc/"
@@ -50,6 +50,9 @@ msgstr "Unable to create group '%s' for events!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Unable to create event '%s'!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr "Copyright (C) 1996-2025 the Free Software Foundation"
 
 #, c-format
 msgid ""
@@ -785,10 +788,10 @@ msgstr "file1 file2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[this_dir] [other_panel_dir]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -859,28 +862,23 @@ msgstr "Search"
 msgid "Search is disabled"
 msgstr "Search is disabled"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Cannot create temporary diff file\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Cannot create backup file\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Cannot create temporary merge file\n"
 "%s"
@@ -951,18 +949,19 @@ msgstr "ButtonBar|Options"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Quit"
 
-msgid "Quit"
-msgstr "Quit"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "File(s) was modified. Save with exit?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander is being shut down.\n"
 "Save modified file(s)?"
+
+msgid "Quit"
+msgstr "Quit"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -970,13 +969,15 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr "File name is empty!"
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" is a directory"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Cannot stat \"%s\"\n"
@@ -995,9 +996,13 @@ msgstr "Loading: %3d%%"
 msgid "Loading..."
 msgstr "Loading..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Cannot open %s for reading"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Cannot open \"%s\"\n"
+"%s"
 
 msgid "Load file"
 msgstr "Load file"
@@ -1006,12 +1011,10 @@ msgstr "Load file"
 msgid "Error reading %s"
 msgstr "Error reading %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Cannot get size/permissions for %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" is not a regular file"
 
 #, c-format
@@ -1029,8 +1032,10 @@ msgstr "Warning"
 msgid "Error reading from pipe: %s"
 msgstr "Error reading from pipe: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Cannot open pipe for reading: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1043,12 +1048,11 @@ msgstr "The file has been modified in the meantime. Save anyway?"
 msgid "Error writing to pipe: %s"
 msgstr "Error writing to pipe: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Cannot open pipe for writing: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Cannot open file for writing: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1093,8 +1097,12 @@ msgstr "Check &POSIX new line"
 msgid "Edit Save Mode"
 msgstr "Edit Save Mode"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Cannot save: destination is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Cannot view: not a regular file"
 
 msgid "A file already exists with this name"
 msgstr "A file already exists with this name"
@@ -1153,9 +1161,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Close file"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander is being shut down.\n"
@@ -1596,15 +1604,13 @@ msgstr "Confirm replace"
 msgid "%ld replacements made"
 msgstr "%ld replacements made"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "A user friendly text editor\n"
 "written for the Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr "Copyright (C) 1996-2025 the Free Software Foundation"
 
 msgid "About"
 msgstr "About"
@@ -1732,16 +1738,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Reload Current Syntax >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Cannot open file %s"
+
 msgid "Load syntax file"
 msgstr "Load syntax file"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Cannot open file %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1772,7 +1776,8 @@ msgstr ""
 "Not an xterm or Linux console;\n"
 "the subshell cannot be toggled."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Type 'exit' to return to the Midnight Commander"
 
 msgid "Set &all"
@@ -1803,26 +1808,33 @@ msgstr "Permissions (octal): %o"
 msgid "Chown advanced command"
 msgstr "Chown advanced command"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
 "Cannot chmod \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Cannot chown \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Cannot chmod \"%s\"\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignore"
-
-msgid "Ignore &all"
-msgstr "Ignore &all"
-
-msgid "&Retry"
-msgstr "&Retry"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Cannot chown \"%s\"\n"
@@ -1839,6 +1851,20 @@ msgstr "Running"
 
 msgid "Stopped"
 msgstr "Stopped"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < No translation >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Input / display codepage:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Never"
@@ -1917,17 +1943,6 @@ msgstr "A&uto save setup"
 
 msgid "Configure options"
 msgstr "Configure options"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < No translation >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Input / display codepage:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Skin:"
@@ -2124,10 +2139,9 @@ msgstr "&Kill"
 msgid "Background jobs"
 msgstr "Background jobs"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "Cannot change directory to\n"
@@ -2221,20 +2235,28 @@ msgstr "C&lear marked"
 msgid "Chattr command"
 msgstr "Chattr command"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Cannot chattr \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 "Cannot get ext2 attributes of \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Cannot chattr \"%s\"\n"
 "%s"
 
 msgid "set &user ID on execution"
@@ -2337,13 +2359,21 @@ msgstr "Link %s to:"
 msgid "Link"
 msgstr "Link"
 
-#, c-format
-msgid "link: %s"
-msgstr "link: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Cannot create target symlink \"%s\"\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Cannot copy cyclic symbolic link\n"
+"\"%s\""
 
 msgid "View file"
 msgstr "View file"
@@ -2365,6 +2395,12 @@ msgstr "Create a new Directory"
 
 msgid "Enter directory name:"
 msgstr "Enter directory name:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Cannot create %s directory"
 
 msgid "Extension file edit"
 msgstr "Extension file edit"
@@ -2414,12 +2450,16 @@ msgstr "Symlink '%s' points to:"
 msgid "Edit symlink"
 msgstr "Edit symlink"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "edit symlink, unable to remove %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "edit symlink: %s"
 
 msgid "FTP to machine"
@@ -2461,10 +2501,8 @@ msgstr "Cannot execute commands on non-local filesystems"
 msgid "Parameter"
 msgstr "Parameter"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Cannot create temporary command file\n"
 "%s"
@@ -2472,23 +2510,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Pipe failed"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "You have an outdated %s file.\n"
 "Midnight Commander now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "The format of the\n"
 "%s%s\n"
@@ -2554,29 +2592,23 @@ msgstr "files/directories"
 msgid " with source mask:"
 msgstr " with source mask:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Cannot stat hardlink source file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Cannot create target hardlink \"%s\"\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Cannot create target hardlink \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Cannot read source link \"%s\"\n"
@@ -2591,9 +2623,9 @@ msgstr ""
 "\n"
 "Option Stable Symlinks will be disabled"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Cannot create target symlink \"%s\"\n"
@@ -2622,22 +2654,32 @@ msgstr ""
 "and\n"
 "\"%s\"\n"
 "are the same file"
+
+msgid "&Ignore"
+msgstr "&Ignore"
 
 msgid "Ignore a&ll"
 msgstr "Ignore a&ll"
 
-#, c-format
+msgid "&Retry"
+msgstr "&Retry"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Directory \"%s\" not empty.\n"
 "Delete it recursively?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Background process:\n"
@@ -2647,17 +2689,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Non&e"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Cannot remove file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Cannot stat file \"%s\"\n"
@@ -2667,108 +2709,110 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Cannot overwrite directory \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot remove file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
+"Cannot remove directory\n"
+"%s"
+msgstr ""
 "Cannot remove directory \"%s\"\n"
 "%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot enter into directory\n"
+"%s"
+msgstr ""
+"Cannot enter into directory \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot overwrite directory\n"
+"%s"
+msgstr "Cannot overwrite directory \"%s\""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot overwrite file\n"
+"%s"
+msgstr ""
+"Cannot overwrite file \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot move directory\n"
+"%s\n"
+"to\n"
+"%s"
 msgstr ""
 "Cannot remove directory \"%s\"\n"
-"%s"
-
-#, c-format
-msgid ""
-"Cannot enter into directory \"%s\"\n"
-"%s"
-msgstr ""
-"Cannot enter into directory \"%s\"\n"
-"%s"
-
-#, c-format
-msgid ""
-"Cannot overwrite directory \"%s\"\n"
-"%s"
-msgstr ""
-"Cannot overwrite directory \"%s\"\n"
-"%s"
-
-#, c-format
-msgid ""
-"Cannot overwrite file \"%s\"\n"
-"%s"
-msgstr ""
-"Cannot overwrite file \"%s\"\n"
-"%s"
-
-#, c-format
-msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
-"%s"
-msgstr ""
-"Cannot move directory \"%s\" to \"%s\"\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Cannot operate on \"..\"!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Cannot stat source file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 "Cannot get ext2 attributes of source file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 "Cannot set ext2 attributes of target file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Cannot create special file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Cannot chown target file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Cannot chmod target file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Cannot open source file \"%s\"\n"
@@ -2777,49 +2821,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Reget failed, about to overwrite file"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Cannot fstat source file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Cannot create target file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Cannot fstat target file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Cannot preallocate space for target file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Cannot read source file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Cannot write target file \"%s\"\n"
@@ -2837,41 +2881,41 @@ msgstr "&Keep"
 msgid "&Continue copy"
 msgstr "&Continue copy"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Cannot close source file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Cannot close target file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 "Cannot set ext2 attributes for target file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Cannot stat source directory \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 "Cannot get ext2 attributes of source directory \"%s\"\n"
@@ -2893,25 +2937,27 @@ msgstr ""
 "Cannot copy cyclic symbolic link\n"
 "\"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Destination \"%s\" must be a directory\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Cannot create target directory \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Cannot chown target directory \"%s\"\n"
@@ -3239,11 +3285,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "You have %zu opened screen. Quit anyway?"
 msgstr[1] "You have %zu opened screens. Quit anyway?"
 
-msgid "The Midnight Commander"
-msgstr "The Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Do you really want to quit the Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Do you really want to execute?"
 
 msgid "&Above"
 msgstr "&Above"
@@ -3742,11 +3786,10 @@ msgstr ""
 "External panelise:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "External panelise:\n"
 "failed to read data from child stdout:\n"
@@ -3789,6 +3832,15 @@ msgid ""
 "%s"
 msgstr ""
 "Cannot stat the destination\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Destination \"%s\" must be a directory\n"
 "%s"
 
 #, c-format
@@ -3912,8 +3964,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Home directory path is not absolute"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4630,8 +4683,9 @@ msgstr "File was modified. Save with exit?"
 msgid "&Cancel quit"
 msgstr "&Cancel quit"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander is being shut down.\n"
@@ -4682,10 +4736,8 @@ msgstr "ButtonBar|Unform"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Format"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Failed to read data from child stdout:\n"
 "%s"
@@ -4711,20 +4763,18 @@ msgstr ""
 msgid "View: "
 msgstr "View: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Cannot open \"%s\"\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Cannot view: not a regular file"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Cannot open \"%s\" in parse mode\n"
@@ -4738,6 +4788,78 @@ msgstr "Continue from beginning?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Cannot fetch a local copy of /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "The Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Do you really want to quit the Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Cannot open %s for reading"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Cannot get size/permissions for %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Cannot open pipe for writing: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Cannot save: destination is not a regular file"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignore &all"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "link: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "symlink: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Other 8 bit"

--- a/po/eo.po
+++ b/po/eo.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2022,2025\n"
 "Language-Team: Esperanto (http://app.transifex.com/mc/mc/language/eo/)\n"
@@ -49,6 +49,9 @@ msgstr "Ne eblas krei grupon '%s' por eventoj!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Ne eblas krei eventon '%s'!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -785,10 +788,10 @@ msgstr "dosiero1 dosiero2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[ĉi_tiu_flanko] [alia_flanko]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -859,28 +862,23 @@ msgstr "Serĉo"
 msgid "Search is disabled"
 msgstr "Serĉo estas malebligita"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Ne eblas krei provizoran flikaĵo-dosieron\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Ne eblas krei sekurkopion\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Ne eblas krei provizoran kunfandan dosieron\n"
 "%s"
@@ -951,18 +949,19 @@ msgstr "ButtonBar|Agordo"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Eliri"
 
-msgid "Quit"
-msgstr "Eliri"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Dosiero(j) estis modifita(j). Ĉu konservi kun eliro?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander estas elirinta.\n"
 "Ĉu konservi modifita(j)n dosiero(j)n?"
+
+msgid "Quit"
+msgstr "Eliri"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -970,13 +969,15 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" estas dosierujo"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Ne eblas trovi je \"%s\"\n"
@@ -995,9 +996,13 @@ msgstr "Ŝarganta: %3d%%"
 msgid "Loading..."
 msgstr "Ŝarganta..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Ne eblas malfermi je %s por legi"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Ne eblas malfermi je \"%s\"\n"
+"%s"
 
 msgid "Load file"
 msgstr "Ŝargi dosieron"
@@ -1006,12 +1011,10 @@ msgstr "Ŝargi dosieron"
 msgid "Error reading %s"
 msgstr "Eraro legi je %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Ne eblas akiri grandon/permesojn por %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" estas ne normala dosiero"
 
 #, c-format
@@ -1029,8 +1032,10 @@ msgstr "Averto"
 msgid "Error reading from pipe: %s"
 msgstr "Eraro dum legi de dukto: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Ne eblas malfermi dukton por legi: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1043,12 +1048,11 @@ msgstr "La dosiero estis ekstere modifita. Ĉu senkonsidere konservi?"
 msgid "Error writing to pipe: %s"
 msgstr "Eraro dum skribi al dukto: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Ne eblas malfermi dukton por skribi: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Ne eblas malfermi dosieron por skribi: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1093,8 +1097,12 @@ msgstr "Kontroli la novan linion laŭ &POSIX"
 msgid "Edit Save Mode"
 msgstr "Reĝimo de redakta konservado"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Ne eblas konservi: celo ne estas normala dosiero"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Ne eblas vidi: ne normala dosiero"
 
 msgid "A file already exists with this name"
 msgstr "Dosiero kun tiu nomo jam ekzistas"
@@ -1153,9 +1161,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Fermi dosieron"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander estas haltigita.\n"
@@ -1598,15 +1606,13 @@ msgstr "Konfirmi anstataŭigon"
 msgid "%ld replacements made"
 msgstr "%ld anstataŭigoj faritaj"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Afabla tekstoredaktilo\n"
 "verkita por Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Pri"
@@ -1734,16 +1740,14 @@ msgstr "< Aŭtomata >"
 msgid "< Reload Current Syntax >"
 msgstr "< Reŝargi nunan sintakson >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Ne eblas malfermi dosieron %s"
+
 msgid "Load syntax file"
 msgstr "Ŝargi sintakso-dosieron"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Ne eblas malfermi dosieron %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1774,7 +1778,8 @@ msgstr ""
 "Ne xterm-fenestron aŭ linuksan terminalon;\n"
 "la subŝelon oni ne ne povas baskuligi."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Tajpu \"exit\" por reiri al Midnight Commander"
 
 msgid "Set &all"
@@ -1805,26 +1810,33 @@ msgstr "Permesoj (Okuma): %o"
 msgid "Chown advanced command"
 msgstr "[chown] altnivelaj komandoj"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Ne eblas ŝanĝi permesojn de \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Ne eblas ŝanĝi estrecon de \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Ne eblas ŝanĝi permesojn de \"%s\"\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignori"
-
-msgid "Ignore &all"
-msgstr "Ignori ĉio&n"
-
-msgid "&Retry"
-msgstr "&Reprovi"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Ne eblas ŝanĝi estrecon de \"%s\"\n"
@@ -1841,6 +1853,20 @@ msgstr "Plenumanta"
 
 msgid "Stopped"
 msgstr "Ĉesigita"
+
+#, fuzzy
+msgid "No translation"
+msgstr "- < Neniu traduko >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Enmeta / elmontra kodpaĝo:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Neniam"
@@ -1919,17 +1945,6 @@ msgstr "Aŭtomate konservi agor&don"
 
 msgid "Configure options"
 msgstr "Agordaĵoj"
-
-#, fuzzy
-msgid "No translation"
-msgstr "- < Neniu traduko >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Enmeta / elmontra kodpaĝo:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Etoso:"
@@ -2126,10 +2141,9 @@ msgstr "&Mortigi"
 msgid "Background jobs"
 msgstr "Fonaj taskoj"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "Ne eblas ŝanĝi dosierujon al\n"
@@ -2223,19 +2237,29 @@ msgstr "&Forviŝi markitajn"
 msgid "Chattr command"
 msgstr "Chattr-komando"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Ne eblas plenumi la komandon chattr por \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Ne eblas malfermi tar-dosieron\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Ne eblas plenumi la komandon chattr por \"%s\"\n"
+"%s"
 
 msgid "set &user ID on execution"
 msgstr "agordi &uzantan identigilon dum plenumigo"
@@ -2337,13 +2361,21 @@ msgstr "Ligi je %s al:"
 msgid "Link"
 msgstr "Ligi"
 
-#, c-format
-msgid "link: %s"
-msgstr "ligilo: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Ne eblas krei celan simbolan ligilon \"%s\"\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "simbola ligilo: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Ne eblas kopii ciklan simbolan ligilon\n"
+"\"%s\""
 
 msgid "View file"
 msgstr "Vidi dosieron"
@@ -2365,6 +2397,12 @@ msgstr "Krei novan dosierujon"
 
 msgid "Enter directory name:"
 msgstr "Enmetu dosierujan nomon:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Ne eblas krei dosierujon %s"
 
 msgid "Extension file edit"
 msgstr "sufikso-dosiera redaktilo"
@@ -2414,12 +2452,16 @@ msgstr "Mola ligilo '%s' alidirektas al:"
 msgid "Edit symlink"
 msgstr "Redakti simbolan ligilon"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "redakti simbolan ligilon, ne eblas forigi %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "redakti simbolan ligilon: %s"
 
 msgid "FTP to machine"
@@ -2461,10 +2503,8 @@ msgstr "Ne eblas plenumi komandojn en foraj dosiersistemoj"
 msgid "Parameter"
 msgstr "Parametro"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Ne eblas krei provizoran komandodosieron\n"
 "%s"
@@ -2472,23 +2512,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Dukto malsukcesis"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "Vi havas malaktualan dosieron %s.\n"
 "Midnight Cammander now uzas la dosieron %s.\n"
 "Bonvolu kopii viajn modifojn de la malnova dosiero al la nova."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "La aranĝo de la dosiero\n"
 "%s%s\n"
@@ -2552,29 +2592,23 @@ msgstr "dosier(uj)ojn"
 msgid " with source mask:"
 msgstr " kun fonta masko:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Ne eblas trovi rektligilan fontan dosieron \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Ne eblas krei celan rektan ligilon \"%s\"\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Ne eblas krei celan rektan ligilon \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Ne eblas legi fontan ligilon \"%s\"\n"
@@ -2589,9 +2623,9 @@ msgstr ""
 "\n"
 "La agordaĵo \"Stabilaj simbolaj ligiloj\" estos malaktivigita"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Ne eblas krei celan simbolan ligilon \"%s\"\n"
@@ -2621,21 +2655,31 @@ msgstr ""
 "\"%s\"\n"
 "estas la sama dosiero"
 
+msgid "&Ignore"
+msgstr "&Ignori"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "&Reprovi"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Dosierujo \"%s\" ne vaka.\n"
 "Ĉu forigi ĝin funde?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Fona procezo:\n"
@@ -2645,17 +2689,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Neni&o"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Ne eblas forigi dosieron \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Ne eblas trovi dosieron \"%s\n"
@@ -2665,102 +2709,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Ne eblas anstataŭigi dosierujon \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Ne eblas movi dosieron \"%s\" al \"%s\"\n"
+"Ne eblas forigi dosieron \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Ne eblas forigi dosierujon \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Ne eblas anstataŭigi dosierujon \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Ne eblas anstataŭigi dosierujon \"%s\"\n"
-"%s"
+msgstr "Ne eblas anstataŭigi dosierujon \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Ne eblas anstataŭigi dosieron \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Ne eblas movi dosierujon \"%s\" al \"%s\"\n"
+"Ne eblas forigi dosierujon \"%s\"\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Ne eblas operacii je \"..\"!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Ne eblas trovi fontan dosieron \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Ne eblas trovi rektligilan fontan dosieron \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Ne eblas trovi celan dosieron \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Ne eblas trovi specialan dosieron \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Ne eblas ŝanĝi estrecon de cela dosiero \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Ne eblas ŝanĝi permesojn de cela dosiero \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Ne eblas malfermi fontan dosieron \"%s\"\n"
@@ -2769,49 +2819,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Denova akirado malsukcesis, anstataŭigos dosieron"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Ne eblas trovi fontan dosieron \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Ne eblas krei celan dosieron \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Ne eblas trovi celan dosieron \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Ne eblas generi spacon por cela dosiero \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Ne eblas legi fontan dosieron \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Ne eblas skribi celan dosieron \"%s\"\n"
@@ -2829,41 +2879,45 @@ msgstr "&Teni"
 msgid "&Continue copy"
 msgstr "D&aŭrigi kopii"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Ne eblas fermi fontan dosieron \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Ne eblas fermi celan dosieron \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Ne eblas generi spacon por cela dosiero \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Ne eblas trovi fontan dosierujon \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Ne eblas trovi fontan dosierujon \"%s\"\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2881,25 +2935,27 @@ msgstr ""
 "Ne eblas kopii ciklan simbolan ligilon\n"
 "\"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Celo \"%s\" devas esti dosierujo\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Ne eblas krei celan dosierujon \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Ne eblas ŝanĝi estrecon de cela dosierujo \"%s\"\n"
@@ -3227,11 +3283,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "%zu paĝo estas malfermita. Ĉu senkonsidere eliri?"
 msgstr[1] "%zu paĝoj estas malfermitaj. Ĉu senkonsidere eliri?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Ĉu vi efektive volas eliri el Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Ĉu vi efekti volas plenumigi?"
 
 msgid "&Above"
 msgstr "&Supra"
@@ -3730,11 +3784,10 @@ msgstr ""
 "Eksterigi flankojn:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Eksteraj paneloj:\n"
 "malsukcesis legi datumojn el ida ĉefeligujo\n"
@@ -3777,6 +3830,15 @@ msgid ""
 "%s"
 msgstr ""
 "Ne eblas trovi la celon\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Celo \"%s\" devas esti dosierujo\n"
 "%s"
 
 #, c-format
@@ -3898,8 +3960,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Hejma-dosieruja vojo ne estas absoluta"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4615,8 +4678,9 @@ msgstr "Dosiero estis modifita. Ĉu konservi dum eliro?"
 msgid "&Cancel quit"
 msgstr "Ne &eliri"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander estas elirinta.\n"
@@ -4667,10 +4731,8 @@ msgstr "Buttonbar|Malform"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Format"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Malsukcesis legi datumojn el ida ĉefeligujo:\n"
 "%s"
@@ -4696,20 +4758,18 @@ msgstr ""
 msgid "View: "
 msgstr "Vidi: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Ne eblas malfermi je \"%s\"\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Ne eblas vidi: ne normala dosiero"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Ne eblas malfermi je \"%s\" laŭ analiza reĝimo\n"
@@ -4723,6 +4783,78 @@ msgstr "Ĉu deiri de la komenco?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Ne eblas atingi lokan kopion de /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Ĉu vi efektive volas eliri el Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Ne eblas malfermi je %s por legi"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Ne eblas akiri grandon/permesojn por %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Ne eblas malfermi dukton por skribi: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Ne eblas konservi: celo ne estas normala dosiero"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Ne eblas malfermi dosieron %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignori ĉio&n"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "ligilo: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "simbola ligilo: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Ne eblas krei celan rektan ligilon \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Ne eblas movi dosieron \"%s\" al \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Ne eblas anstataŭigi dosierujon \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Ne eblas movi dosierujon \"%s\" al \"%s\"\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Alia 8-bita"

--- a/po/es.po
+++ b/po/es.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Spanish (http://app.transifex.com/mc/mc/language/es/)\n"
@@ -55,6 +55,9 @@ msgstr "¡Imposible crear el grupo de eventos «%s»!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "¡Imposible crear el evento «%s»!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr "Copyright (C) 1996-2025 the Free Software Foundation"
 
 #, c-format
 msgid ""
@@ -794,10 +797,10 @@ msgstr "archivo1 archivo2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[DIRECTORIO] [SEGUNDO_DIRECTORIO]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -868,28 +871,23 @@ msgstr "Buscar"
 msgid "Search is disabled"
 msgstr "Busquedas deshabilitadas"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Imposible crear archivo temporal de diferencias\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Imposible crear archivo de copia\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Imposible crear archivo temporal de mezcla\n"
 "%s"
@@ -960,18 +958,19 @@ msgstr "Opciones"
 msgid "ButtonBar|Quit"
 msgstr "Salir"
 
-msgid "Quit"
-msgstr "Salir"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Algún archivo fue modificado. ¿Desea guardar al salir?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Saliendo de Midnight Commander.\n"
 "¿Desea guardar los archivos modificados?"
+
+msgid "Quit"
+msgstr "Salir"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -979,13 +978,15 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr "¡Nombre de archivo vacío!"
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "«%s» no es un directorio"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Imposible identificar «%s»\n"
@@ -1006,9 +1007,13 @@ msgstr "Cargando: %3d%%"
 msgid "Loading..."
 msgstr "Cargando..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Imposible abrir %s para lectura"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Imposible abrir «%s»\n"
+"%s"
 
 msgid "Load file"
 msgstr "Cargar archivo"
@@ -1017,12 +1022,10 @@ msgstr "Cargar archivo"
 msgid "Error reading %s"
 msgstr "Error al leer %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Imposible obtener tamaño/permisos para %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "«%s» no es un archivo ordinario"
 
 #, c-format
@@ -1040,8 +1043,10 @@ msgstr "¡ Atención !"
 msgid "Error reading from pipe: %s"
 msgstr "Error al leer en tubería: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Imposible abrir tubería para lectura: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1054,12 +1059,11 @@ msgstr "El archivo ha estado siendo modificado por otros. ¿Desea guardar?"
 msgid "Error writing to pipe: %s"
 msgstr "Error al escribir en tubería: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Imposible abrir tubería para escritura: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Imposible abrir archivo para escritura: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1104,8 +1108,12 @@ msgstr "verificar salto de línea &POSIX"
 msgid "Edit Save Mode"
 msgstr "Modo de guardar"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Imposible guardar: el destino no es un archivo ordinario"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Imposible ver: no es un archivo ordinario"
 
 msgid "A file already exists with this name"
 msgstr "Ya existe un archivo con ese nombre."
@@ -1164,9 +1172,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Cerrar archivo"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Saliendo de Midnight Commander.\n"
@@ -1607,15 +1615,13 @@ msgstr "Confirmar cambios"
 msgid "%ld replacements made"
 msgstr "%ld reemplazos hechos."
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Un editor de texto amigable\n"
 "para Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr "Copyright (C) 1996-2025 the Free Software Foundation"
 
 msgid "About"
 msgstr "Acerca de..."
@@ -1743,16 +1749,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Releer sintaxis >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Imposible abrir el archivo %s"
+
 msgid "Load syntax file"
 msgstr "Cargar archivo de sintaxis"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Imposible abrir el archivo %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1783,7 +1787,8 @@ msgstr ""
 "No se está usando ni xterm ni la consola Linux;\n"
 "no se pueda cambiar el uso de subshell."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Teclee «exit» para regresar a Midnight Commander"
 
 msgid "Set &all"
@@ -1814,26 +1819,33 @@ msgstr "Permisos (octal): %o"
 msgid "Chown advanced command"
 msgstr "Cambiar dueño y permisos"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Imposible cambiar los permisos de «%s»\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Imposible cambiar el dueño de «%s»\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Imposible cambiar los permisos de «%s»\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignorar"
-
-msgid "Ignore &all"
-msgstr "ignorar &Todos"
-
-msgid "&Retry"
-msgstr "&Reintentar"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Imposible cambiar el dueño de «%s»\n"
@@ -1850,6 +1862,20 @@ msgstr "Corriendo"
 
 msgid "Stopped"
 msgstr "Detenido"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Sin traducción >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Juego de caracteres entrada/pantalla:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Nunca"
@@ -1928,17 +1954,6 @@ msgstr "auto-guarda con&Figuración"
 
 msgid "Configure options"
 msgstr "Configuración"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Sin traducción >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Juego de caracteres entrada/pantalla:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Skin:"
@@ -2135,10 +2150,9 @@ msgstr "&Matar"
 msgid "Background jobs"
 msgstr "Procesos en 2º plano"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "Imposible cambiar al directorio\n"
@@ -2232,20 +2246,28 @@ msgstr "* a &Quitar"
 msgid "Chattr command"
 msgstr "Chattr"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Imposible chattr a «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 "Imposible obtener atributos ext2 de «%s»\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Imposible chattr a «%s»\n"
 "%s"
 
 msgid "set &user ID on execution"
@@ -2348,13 +2370,21 @@ msgstr "Crear enlace a %s como:"
 msgid "Link"
 msgstr "Crear enlace"
 
-#, c-format
-msgid "link: %s"
-msgstr "enlace: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Imposible crear el enlace simbólico destino «%s»\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "enlace simbólico: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Imposible copiar un enlace simbólico cíclico\n"
+"«%s»"
 
 msgid "View file"
 msgstr "Ver archivo"
@@ -2376,6 +2406,12 @@ msgstr "Crear directorio"
 
 msgid "Enter directory name:"
 msgstr "Teclee el nombre del directorio:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Imposible crear directorio %s"
 
 msgid "Extension file edit"
 msgstr "Editar extensiones"
@@ -2425,12 +2461,16 @@ msgstr "El enlace simbólico «%s» apunta a:"
 msgid "Edit symlink"
 msgstr "Editar enlace simbólico"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "edite enlace simbólico, imposible borrar %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "editar enlace simbólico: %s"
 
 msgid "FTP to machine"
@@ -2472,10 +2512,8 @@ msgstr "Imposible ejecutar comandos desde directorios no locales"
 msgid "Parameter"
 msgstr "Parámetro"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Imposible crear el archivo temporal para comandos\n"
 "%s"
@@ -2483,23 +2521,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Fallo en la tubería"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "Tiene un archivo %s obsoleto.\n"
 "Midnight Commander usa ahora el archivo %s. Por favor,\n"
 "copie las modificaciones realizadas al nuevo."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "El formato del archivo \n"
 "%s%s\n"
@@ -2565,29 +2603,23 @@ msgstr "archivos/directorios"
 msgid " with source mask:"
 msgstr " aplicando la máscara:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Imposible identificar enlace «%s» en el origen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Imposible crear enlace «%s» en el destino\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Imposible crear enlace «%s» en el destino"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Imposible leer el enlace original «%s»\n"
@@ -2603,9 +2635,9 @@ msgstr ""
 "\n"
 "La opción de enlaces simbólicos estables será desactivada"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Imposible crear el enlace simbólico destino «%s»\n"
@@ -2635,21 +2667,31 @@ msgstr ""
 "«%s»\n"
 "son el mismo archivo"
 
+msgid "&Ignore"
+msgstr "&Ignorar"
+
 msgid "Ignore a&ll"
 msgstr "ignorar &Todos"
 
-#, c-format
+msgid "&Retry"
+msgstr "&Reintentar"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "El directorio «%s» no está vacío.\n"
 "¿Desea borrarlo recursivamente?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Proceso en 2º plano: El directorio «%s» no está vacío.\n"
@@ -2658,17 +2700,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "nin&Guno"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Imposible borrar el archivo «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Imposible identificar el archivo «%s»\n"
@@ -2678,108 +2720,110 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Imposible sobrescribir el directorio «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Imposible mover el archivo «%s» a «%s»\n"
+"Imposible borrar el archivo «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Imposible eliminar el directorio «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 "Imposible acceder al directorio «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Imposible sobrescribir el directorio «%s»\n"
-"%s"
+msgstr "Imposible sobrescribir el directorio «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Imposible sobrescribir el archivo «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Imposible mover el directorio «%s» a «%s»\n"
+"Imposible eliminar el directorio «%s»\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "¡Imposible operar sobre «..»!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Imposible identificar el archivo origen «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 "Imposible obtener atributos ext2 del archivo origen «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 "Imposible establecer atributos ext2 del archivo destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Imposible crear el archivo especial «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Imposible cambiar el dueño del archivo destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Imposible cambiar los permisos del archivo destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Imposible abrir el archivo fuente «%s»\n"
@@ -2788,49 +2832,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Falló el reintento, se va a sobrescribir el archivo"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Imposible identificar el archivo origen «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Imposible crear el archivo destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Imposible identificar el archivo destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Imposible reservar espacio para el archivo destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Imposible leer el archivo origen «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Imposible escribir el archivo destino «%s»\n"
@@ -2848,41 +2892,41 @@ msgstr "&Mantener"
 msgid "&Continue copy"
 msgstr "&Continuar copia"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Imposible cerrar el archivo origen «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Imposible cerrar el archivo destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 "Imposible establecer atributos ext2 para el archivo destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Imposible identificar el directorio de origen «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 "Imposible obtener atributos ext2 del directorio de origen «%s»\n"
@@ -2904,25 +2948,27 @@ msgstr ""
 "Imposible copiar un enlace simbólico cíclico\n"
 "«%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "El destino «%s» debe ser un directorio\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Imposible crear el directorio destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Imposible cambiar el dueño del directorio destino «%s»\n"
@@ -3251,11 +3297,9 @@ msgstr[0] "Hay %zu pantalla abierta. ¿Desea realmente salir?"
 msgstr[1] "Hay %zu de pantallas abiertas. ¿Desea realmente salir?"
 msgstr[2] "Hay %zu pantallas abiertas. ¿Desea realmente salir?"
 
-msgid "The Midnight Commander"
-msgstr "The Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "¿Desea realmente salir del Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "¿Realmente quiere ejecutar?"
 
 msgid "&Above"
 msgstr "a&Rriba"
@@ -3757,11 +3801,10 @@ msgstr ""
 "Búsqueda externa:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Búsqueda externa:\n"
 "Fallo de lectura sobre la salida estándar del proceso hijo:\n"
@@ -3804,6 +3847,15 @@ msgid ""
 "%s"
 msgstr ""
 "Imposible identificar el destino\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"El destino «%s» debe ser un directorio\n"
 "%s"
 
 #, c-format
@@ -3927,8 +3979,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "La ruta del directorio de inicio no es ruta absoluta"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4644,8 +4697,9 @@ msgstr "El archivo fue modificado. ¿Desea guardarlo al salir?"
 msgid "&Cancel quit"
 msgstr "&Cancelar salida"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Saliendo de Midnight Commander.\n"
@@ -4696,10 +4750,8 @@ msgstr "SinFor"
 msgid "ButtonBar|Format"
 msgstr "Format"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Fallo de lectura sobre la salida estándar del proceso hijo:\n"
 "%s"
@@ -4725,20 +4777,18 @@ msgstr ""
 msgid "View: "
 msgstr "Ver:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Imposible abrir «%s»\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Imposible ver: no es un archivo ordinario"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Imposible abrir «%s» para analizar\n"
@@ -4752,6 +4802,78 @@ msgstr "¿Continuar desde el principio?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Imposible obtener una copia local de /ftp://ese.equipo/edítame.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "The Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "¿Desea realmente salir del Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Imposible abrir %s para lectura"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Imposible obtener tamaño/permisos para %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Imposible abrir tubería para escritura: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Imposible guardar: el destino no es un archivo ordinario"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Imposible abrir el archivo %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "ignorar &Todos"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "enlace: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "enlace simbólico: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Imposible crear enlace «%s» en el destino\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Imposible mover el archivo «%s» a «%s»\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Imposible sobrescribir el directorio «%s»\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Imposible mover el directorio «%s» a «%s»\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Otro (8 bit)"

--- a/po/et.po
+++ b/po/et.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Estonian (http://app.transifex.com/mc/mc/language/et/)\n"
@@ -53,6 +53,9 @@ msgstr "Nurjus grupi \"%s\" loomine sündmustele!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Sündmust \"%s\" ei õnnestunud luua!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr "Autoriõigused (C) 1996-2025 the Free Software Foundation"
 
 #, c-format
 msgid ""
@@ -792,10 +795,10 @@ msgstr "fail1 fail2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[this_dir] [other_panel_dir]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -866,28 +869,23 @@ msgstr "Otsing"
 msgid "Search is disabled"
 msgstr "Otsing on keelatud"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Ajutise erinevuste faili loomine ei õnnestunud\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Varukoopia faili loomine nurjus\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Ajutise ühendfaili loomine nurjus\n"
 "%s"
@@ -958,18 +956,19 @@ msgstr "ButtonBar|Suvandid"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Välju"
 
-msgid "Quit"
-msgstr "Välju"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Faili(e) on muudetud. Kas salvestame väljumisel?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander on lõpetamas.\n"
 "Kas salvestada muudetud fail(id)?"
+
+msgid "Quit"
+msgstr "Välju"
 
 msgid "Diff:"
 msgstr "Erinevused:"
@@ -977,13 +976,15 @@ msgstr "Erinevused:"
 msgid "File name is empty!"
 msgstr "Faili nimi on tühi!"
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" on kataloog"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "\"%s\" attribuutide päring nurjus\n"
@@ -1002,9 +1003,13 @@ msgstr "Laaditakse: %3d%%"
 msgid "Loading..."
 msgstr "Laaditakse..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Faili %s avamine lugemiseks nurjus"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"\"%s\" avamine nurjus\n"
+"%s"
 
 msgid "Load file"
 msgstr "Laadi fail"
@@ -1013,12 +1018,10 @@ msgstr "Laadi fail"
 msgid "Error reading %s"
 msgstr "Viga %s lugemisel"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Faili %s suuruse/õiguste küsimine nurjus"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" ei ole harilik fail"
 
 #, c-format
@@ -1036,8 +1039,10 @@ msgstr "Hoiatus"
 msgid "Error reading from pipe: %s"
 msgstr "Viga torust lugemisel: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Toru avamine lugemiseks nurjus: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1050,12 +1055,11 @@ msgstr "Faili on vahepeal muudetud. Kas ikkagi salvestame?"
 msgid "Error writing to pipe: %s"
 msgstr "Viga torusse kirjutamisel: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Toru avamine kirjutamiseks nurjus: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Faili avamine kirjutamiseks nurjus: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1100,8 +1104,12 @@ msgstr "Kontrolli &POSIXi uus rida"
 msgid "Edit Save Mode"
 msgstr "Muuda salvestusrežiim"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Salvestamine nurjus: sihtkoht ei ole harilik fail"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Vaatamine pole võimalik: see pole harilik fail"
 
 msgid "A file already exists with this name"
 msgstr "Sellise nimega fail on juba olemas"
@@ -1160,9 +1168,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Sulge fail"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander on lõpetamas.\n"
@@ -1605,15 +1613,13 @@ msgstr "Kinnita asendamine"
 msgid "%ld replacements made"
 msgstr "Teostati %ld asendust"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Kasutajasõbralik tekstitoimeti, mis\n"
 "on loodud Midnight Commanderile."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr "Autoriõigused (C) 1996-2025 the Free Software Foundation"
 
 msgid "About"
 msgstr "Programmist"
@@ -1741,16 +1747,14 @@ msgstr "<Auto>"
 msgid "< Reload Current Syntax >"
 msgstr "<Valitud süntaksi taaslaadimine>"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Faili %s avamine nurjus"
+
 msgid "Load syntax file"
 msgstr "Laadi süntaksi fail"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Faili %s avamine nurjus\n"
-" %s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1780,7 +1784,8 @@ msgstr ""
 "Sa ei kasuta xtermi või Linuxi konsooli;\n"
 "alamkesta ei saa sisse/välja lülitada."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Midnight Commanderisse tagasipöördumiseks sisesta 'exit'"
 
 msgid "Set &all"
@@ -1811,26 +1816,33 @@ msgstr "Õigused (8nd süsteemis): %o"
 msgid "Chown advanced command"
 msgstr "Keerukas omanikuvahetus"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"\"%s\" õiguste muutmine nurjus\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"\"%s\" omaniku vahetus nurjus:\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "\"%s\" õiguste muutmine nurjus\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "E&ira"
-
-msgid "Ignore &all"
-msgstr "Eira &kõiki"
-
-msgid "&Retry"
-msgstr "&Proovi uuesti"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "\"%s\" omaniku vahetus nurjus:\n"
@@ -1847,6 +1859,20 @@ msgstr "Töötab"
 
 msgid "Stopped"
 msgstr "Peatatud"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < tõlkimata >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Sisend/kuva kooditabel:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Mitte kunagi"
@@ -1925,17 +1951,6 @@ msgstr "Seadete a&utomaatsalvestus"
 
 msgid "Configure options"
 msgstr "Häälestuse suvandid"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < tõlkimata >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Sisend/kuva kooditabel:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Nahk:"
@@ -2131,10 +2146,9 @@ msgstr "&Tapa"
 msgid "Background jobs"
 msgstr "Tööd taustal"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "Nurjus vahetus kataloogiks \n"
@@ -2228,20 +2242,28 @@ msgstr "Tü&hista valik"
 msgid "Chattr command"
 msgstr "Chattr käsk"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "\"%s\" attribuutide muutmine nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 "Objekti ext2 atribuute ei õnnestu laadida „%s“\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"\"%s\" attribuutide muutmine nurjus\n"
 "%s"
 
 msgid "set &user ID on execution"
@@ -2344,13 +2366,21 @@ msgstr "Loo link %s:"
 msgid "Link"
 msgstr "Link"
 
-#, c-format
-msgid "link: %s"
-msgstr "link: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Nimeviida \"%s\" loomine nurjus sihtkohas\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "nimeviit: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Tsüklilise nimeviida kopeerimine nurjus\n"
+"\"%s\""
 
 msgid "View file"
 msgstr "Vaata faili"
@@ -2372,6 +2402,12 @@ msgstr "Loo uus kataloog"
 
 msgid "Enter directory name:"
 msgstr "Sisesta kataloogi nimi:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "%s kataloogi loomine ei õnnestunud"
 
 msgid "Extension file edit"
 msgstr "Laiendite faili muutmine"
@@ -2421,12 +2457,16 @@ msgstr "Nimeviit \"%s\" viitab:"
 msgid "Edit symlink"
 msgstr "Muuda nimeviita"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "nimeviida muutmine: %s eemaldamine nurjus: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "nimeviida muutmine: %s"
 
 msgid "FTP to machine"
@@ -2468,10 +2508,8 @@ msgstr "Käske ei saa käivitada kaugfailisüsteemidel"
 msgid "Parameter"
 msgstr "Parameeter"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Ajutise käsufaili loomine nurjus\n"
 "%s"
@@ -2479,23 +2517,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Funktsioon pipe nurjus"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "Sul on aegunud %s fail.\n"
 "Midnight Commander kasutab nüüd faili %s.\n"
 "Palun kopeeri oma vana faili muudatused uude."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "Formaat\n"
 "%s%s\n"
@@ -2561,29 +2599,23 @@ msgstr "failid/kataloogid"
 msgid " with source mask:"
 msgstr " lähtemaskiga:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Jäikviida lähtefaili \"%s\" info päring nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Jäikviida sihtfaili \"%s\" loomine nurjus\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Jäikviida sihtfaili \"%s\" loomine nurjus"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Lähteviida \"%s\" lugemine nurjus\n"
@@ -2598,9 +2630,9 @@ msgstr ""
 "\n"
 "Valik stabiilsed nimeviidad keelatakse"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Nimeviida \"%s\" loomine nurjus sihtkohas\n"
@@ -2630,21 +2662,31 @@ msgstr ""
 "\"%s\"\n"
 "on üks ja see sama fail"
 
+msgid "&Ignore"
+msgstr "E&ira"
+
 msgid "Ignore a&ll"
 msgstr "Eira &kõiki"
 
-#, c-format
+msgid "&Retry"
+msgstr "&Proovi uuesti"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Kataloog \"%s\" ei ole tühi.\n"
 "Kas kustutame selle rekursiivselt?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Taustaprotsess:\n"
@@ -2654,17 +2696,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "&Mitte ükski"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Faili \"%s\" eemaldamine nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Faili \"%s\" info päring nurjus\n"
@@ -2674,108 +2716,110 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Kataloogi \"%s\" ülekirjutamine nurjus"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Faili \"%s\" teisaldamine kataloogi \"%s\" nurjus\n"
+"Faili \"%s\" eemaldamine nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Kataloogi \"%s\" eemaldamine nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 "„%s“ kausta avamine ei õnnestu\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Kataloogi \"%s\" ülekirjutamine nurjus\n"
-"%s"
+msgstr "Kataloogi \"%s\" ülekirjutamine nurjus"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Faili \"%s\" ülekirjutamine nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Kataloogi \"%s\" teisaldamine kataloogi \"%s\" nurjus\n"
+"Kataloogi \"%s\" eemaldamine nurjus\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Kataloogi \"..\" kasutamine on keelatud!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Lähtefaili \"%s\" info päring nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 "Lähtefaili ext2 atribuute ei õnnestu laadida „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 "Sihtfaili ext2 atribuute ei õnnestu määrata „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Erifaili \"%s\" loomine nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Sihtfaili \"%s\" omaniku määramine nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Sihtfaili \"%s\" õiguste määramine nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Lähtefaili \"%s\" avamine nurjus\n"
@@ -2784,49 +2828,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Kordushankimine nurjus, fail kirjutatakse üle"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Lähtefaili \"%s\" info päring nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Sihtfaili \"%s\" loomine nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Sihtfaili \"%s\" info päring nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Ruumi eelhankimine sihtfailile \"%s\" nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Ei saa lugeda lähtefaili \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Sihtfaili \"%s\" kirjutamine nurjus\n"
@@ -2844,41 +2888,41 @@ msgstr "&Hoia"
 msgid "&Continue copy"
 msgstr "&Jätka kopeerimist"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Lähtefaili \"%s\" sulgemine nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Sihtfaili \"%s\" sulgemine nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 "Sihtfaili ext2 atribuute ei õnnestu määrata „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Lähtekataloogi \"%s\" info päring nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 "Lähtekausta ext2 atribuute ei õnnestu laadida „%s“\n"
@@ -2900,25 +2944,27 @@ msgstr ""
 "Tsüklilise nimeviida kopeerimine nurjus\n"
 "\"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Sihtkoht \"%s\" peab olema kataloog\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Sihtkataloogi \"%s\" loomine nurjus\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Kataloogi \"%s\" omaniku muutmine nurjus\n"
@@ -3246,11 +3292,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "Sul on %zu avatud ekraan. Kas ikkagi lõpetada?"
 msgstr[1] "Sul on %zu avatud ekraani. Kas ikkagi lõpetada?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Kas sa soovid tõesti Midnight Commanderist väljuda?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Kas sa soovid tõesti käivitada?"
 
 msgid "&Above"
 msgstr "Ü&lal"
@@ -3749,11 +3793,10 @@ msgstr ""
 "Väline paneel:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Väline paneel:\n"
 "alamstdouti andmete lugemine ebaõnnestus:\n"
@@ -3796,6 +3839,15 @@ msgid ""
 "%s"
 msgstr ""
 "Sihtkoha info päring nurjus\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Sihtkoht \"%s\" peab olema kataloog\n"
 "%s"
 
 #, c-format
@@ -3919,8 +3971,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Kodukataloog ei ole absoluutne"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4637,8 +4690,9 @@ msgstr "Faili on muudetud. Kas väljumisel salvestame?"
 msgid "&Cancel quit"
 msgstr "&Tühista väljumine"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander on sulgumas.\n"
@@ -4689,10 +4743,8 @@ msgstr "ButtonBar|Vormita"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Vormiga"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Nurjus tütre std. väljundist andmete lugemine:\n"
 "%s"
@@ -4718,20 +4770,18 @@ msgstr ""
 msgid "View: "
 msgstr "Vaade: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"\"%s\" avamine nurjus\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Vaatamine pole võimalik: see pole harilik fail"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Faili \"%s\" avamine parsimisrežiimis nurjus\n"
@@ -4745,6 +4795,78 @@ msgstr "Kas jätkata algusest?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Kohaliku koopia hankimine failist /ftp://some.host/editme.txt nurjus"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Kas sa soovid tõesti Midnight Commanderist väljuda?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Faili %s avamine lugemiseks nurjus"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Faili %s suuruse/õiguste küsimine nurjus"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Toru avamine kirjutamiseks nurjus: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Salvestamine nurjus: sihtkoht ei ole harilik fail"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Faili %s avamine nurjus\n"
+#~ " %s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Eira &kõiki"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "link: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "nimeviit: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Jäikviida sihtfaili \"%s\" loomine nurjus\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Faili \"%s\" teisaldamine kataloogi \"%s\" nurjus\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kataloogi \"%s\" ülekirjutamine nurjus\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kataloogi \"%s\" teisaldamine kataloogi \"%s\" nurjus\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Muu 8-bitine"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Basque (http://app.transifex.com/mc/mc/language/eu/)\n"
@@ -50,6 +50,9 @@ msgstr "Ezin '%s' taldea gertaeratarako sortu!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Ezin '%s' gertaera sortu!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -759,10 +762,10 @@ msgstr "file1 file2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[dir_hau] [beste_panel_dir]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -833,28 +836,23 @@ msgstr "Bilatu"
 msgid "Search is disabled"
 msgstr "Bilaketa ezgaituta dago"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Aldiuneko diff fitxategia ezin sortu\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Babeskopia fitxategia ezin sortu\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Aldiuneko fitxategi bateratua ezin sortu\n"
 "%s"
@@ -925,18 +923,19 @@ msgstr "Aukerak"
 msgid "ButtonBar|Quit"
 msgstr "Irten"
 
-msgid "Quit"
-msgstr "Irten"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Fitxategia(k) aldatu d(ir)a. Gorde irteterakoan?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander itzaltzen ari da.\n"
 "Gorde aldatutako fitxategia(k)?"
+
+msgid "Quit"
+msgstr "Irten"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -944,13 +943,15 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" direktorio bat da"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "\"%s\"-ren egoera (\"stat\") ezin lortu\n"
@@ -969,9 +970,13 @@ msgstr "Zamatzen: %3d%%"
 msgid "Loading..."
 msgstr "Zamatzen..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "%s irakurtzeko ezin ireki"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"\"%s\" ezin ireki\n"
+"%s"
 
 msgid "Load file"
 msgstr "Zamatu fitxategia"
@@ -980,12 +985,10 @@ msgstr "Zamatu fitxategia"
 msgid "Error reading %s"
 msgstr "Akatsa %s irakurtzerakoan"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "%s-ren neurria/baimenak ezin eskuratu"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" ez da fitxategi arrunta"
 
 #, c-format
@@ -1003,8 +1006,10 @@ msgstr "Abisua"
 msgid "Error reading from pipe: %s"
 msgstr "Akatsa hoditik irakurtzerakoan: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Hodia irakurtzeko ezin ireki: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1017,12 +1022,11 @@ msgstr "Fitxategia bitartean aldatu egin da. Gorde hala ere?"
 msgid "Error writing to pipe: %s"
 msgstr "Akatsa hodira idazterakoan: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Hodia idazteko ezin ireki: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Fitxategia idazteko ezin ireki: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1067,8 +1071,12 @@ msgstr "Egiaztatu &POSIX lerro berria"
 msgid "Edit Save Mode"
 msgstr "Editatu gordetzeko modua"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Ezin da gorde: helburua ez da ohiko fitxategi bat"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Ezin ikusi: ez da fitxategi arrunta"
 
 msgid "A file already exists with this name"
 msgstr "Fitxategi bat dago izen hori duena"
@@ -1127,9 +1135,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Itxi fitxategia"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander itzaltzen ari da.\n"
@@ -1570,15 +1578,13 @@ msgstr "Berretsi ordezkapena"
 msgid "%ld replacements made"
 msgstr "%ld ordezkapen egin dira"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Testu editore lagunkoi bat\n"
 "Midnight Commander-rarentzako idatzia."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Honi buruz"
@@ -1706,16 +1712,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Birzamatu uneko sintaxia >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "%s fitxategia ezin ireki"
+
 msgid "Load syntax file"
 msgstr "Zamatu sintaxi fitxategia"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"%s fitxategia ezin ireki\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1744,7 +1748,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Tekleatu «exit» Midnight Commanderrera itzultzeko"
 
 msgid "Set &all"
@@ -1775,26 +1780,33 @@ msgstr ""
 msgid "Chown advanced command"
 msgstr "Chown komando aurreratua"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"\"%s\"-ren baimenak ezin aldatu (\"chmod\")\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"\"%s\"-ren jabea ezin aldatu (\"chown\")\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "\"%s\"-ren baimenak ezin aldatu (\"chmod\")\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Jaromonik ez"
-
-msgid "Ignore &all"
-msgstr "Jaramonik ez &guztiari"
-
-msgid "&Retry"
-msgstr "&Saiatu berriz"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "\"%s\"-ren jabea ezin aldatu (\"chown\")\n"
@@ -1811,6 +1823,20 @@ msgstr "Martxan"
 
 msgid "Stopped"
 msgstr "Geldituta"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Ez dago itzulpenik >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Sartu / bistaratu kode-orrialdea:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Inoiz ere ez"
@@ -1889,17 +1915,6 @@ msgstr "A&uto gorde ezarpena"
 
 msgid "Configure options"
 msgstr "Konfiguratu aukerak"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Ez dago itzulpenik >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Sartu / bistaratu kode-orrialdea:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Azala:"
@@ -2098,12 +2113,13 @@ msgstr "&Hil"
 msgid "Background jobs"
 msgstr "Hondoko lanak"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"Ezin da aldatu \"%s\" helburu direktorioaren jabea (chown)\n"
+"%s"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2192,17 +2208,27 @@ msgstr "&Garbitu markatutakoa"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
+"\"%s\"-ren egoera (\"stat\") ezin lortu\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"tar artxiboa ezin ireki\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Azterketa sintaktikoa ezin da egin:"
 
 msgid "set &user ID on execution"
 msgstr "ezarri &erabiltzaile ID exekutatzean"
@@ -2304,13 +2330,21 @@ msgstr "Estekatu %s hona:"
 msgid "Link"
 msgstr "Esteka"
 
-#, c-format
-msgid "link: %s"
-msgstr "esteka: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Ezin da sortu \"%s\" helburu esteka sinbolikoa\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "esteka sinbolikoa: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"\"%s\"\n"
+"esteka sinboliko ziklikoa ezin kopiatu"
 
 msgid "View file"
 msgstr "Ikusi fitxategia"
@@ -2332,6 +2366,12 @@ msgstr "Sortu direktorio berria"
 
 msgid "Enter directory name:"
 msgstr "Sartu direktorio izena:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "%s direktorioa ezin sortu"
 
 msgid "Extension file edit"
 msgstr "Editatu luzapen fitxategia"
@@ -2381,12 +2421,16 @@ msgstr "'%s' esteka sinbolikoak erakusten du:"
 msgid "Edit symlink"
 msgstr "Editatu esteka sinbolikoa"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "editatu esteka sinbolikoa, ezin da %s kendu: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "editatu esteka sinbolikoa: %s"
 
 msgid "FTP to machine"
@@ -2428,10 +2472,8 @@ msgstr "Komandoak ezin exekutatu bertakoa ez den fitxategi-sistema batean"
 msgid "Parameter"
 msgstr "Parametroa"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "%s\n"
 "aldiuneko komando fitxategia ezin sortu"
@@ -2442,7 +2484,7 @@ msgstr "Hodiak huts egin du"
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2452,7 +2494,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2507,30 +2549,24 @@ msgstr "fitxategiak/direktorioak"
 msgid " with source mask:"
 msgstr " iturburu maskararekin:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Ezin da lortu esteka trinkoaren \"%s\" iturburu fitxategiaren egoera (stat)"
 "\\n\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Ezin da sortu iturburuaren \"%s\" esteka sinbolikoa\\n\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Ezin da sortu iturburuaren \"%s\" esteka sinbolikoa"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Ezin da irakurri \"%s\" iturburu esteka\\n\n"
@@ -2546,9 +2582,9 @@ msgstr ""
 "\n"
 "Esteka-sinboliko egonkorrak aukera desgaituko da"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Ezin da sortu \"%s\" helburu esteka sinbolikoa\n"
@@ -2578,21 +2614,31 @@ msgstr ""
 "\"%s\"\n"
 "fitxategi bera dira"
 
+msgid "&Ignore"
+msgstr "&Jaromonik ez"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "&Saiatu berriz"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "\"%s\" direktorioa ez dago hutsik.\n"
 "Errekurtsiboki ezabatu?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Hondoko prozesua:\n"
@@ -2602,17 +2648,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "&Bat ere ez"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "\"%s\" fitxategia ezin ezabatu\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Ezin da lortu \"%s\" fitxategiaren egoera (stat)\n"
@@ -2622,102 +2668,109 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Ezin da gainidatzi \"%s\" direktorioa"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Ezin da mugitu \"%s\" fitxategia \"%s\"-ra\n"
+"\"%s\" fitxategia ezin ezabatu\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Ezin da ezabatu \"%s\" direktorioa\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Ezin da gainidatzi \"%s\" direktorioa"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Ezin da gainidatzi \"%s\" direktorioa\n"
-"%s"
+msgstr "Ezin da gainidatzi \"%s\" direktorioa"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Ezin da gainidatzi \"%s\" fitxategia\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Ezin da mugitu \"%s\" direktorioa \"%s\"-ra\n"
+"Ezin da ezabatu \"%s\" direktorioa\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Ezin da \"..\" erabili!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Ezin da lortu \"%s\" iturburu fitxategiaren egoera\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Ezin da lortu esteka trinkoaren \"%s\" iturburu fitxategiaren egoera (stat)"
+"\\n\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Ezin da loortu \"%s\" helburu fitxategiaren egoera (fstat)\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Ezin da sortu \"%s\" fitxategi berezia\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Ezin da aldatu \"%s\" helburu fitxategiaren jabea (chown)\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Ezin dira aldatu \"%s\" helburu fitxategiaren baimenak\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Ezin da ireki \"%s\" iturburu fitxategia\n"
@@ -2726,49 +2779,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Berreskuratzeak huts egin du, fitxategia gainidazteko zorian"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Ezin da lortu \"%s\" iturburu fitxategiaren egoera (fstat)\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Ezin da sortu \"%s\" helburu fitxategia\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Ezin da loortu \"%s\" helburu fitxategiaren egoera (fstat)\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Lekua ezin aurrealokatu \"%s\" helburu fitxategiarentzako⏎\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Ezin da irakurri \"%s\" iturburu fitxategia\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Ezin da idatzi \"%s\" helburu fitxategia\n"
@@ -2786,41 +2839,45 @@ msgstr "&Gorde"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Ezin da itxi \"%s\" iturburu fitxategia\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Ezin da itxi \"%s\" helburu fitxategia\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Lekua ezin aurrealokatu \"%s\" helburu fitxategiarentzako⏎\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Ezin da lortu \"%s\" iturburu direktorioaren egoera (stat)\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Ezin da lortu \"%s\" iturburu direktorioaren egoera (stat)\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2838,25 +2895,27 @@ msgstr ""
 "\"%s\"\n"
 "esteka sinboliko ziklikoa ezin kopiatu"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "\"%s\" helburua direktorio bat izan behar da\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "\"%s\" helburu direktorioa ezin sortu\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Ezin da aldatu \"%s\" helburu direktorioaren jabea (chown)\n"
@@ -3184,11 +3243,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "Pantaila %zu irekita duzu. Irten hala ere?"
 msgstr[1] "%zu pantaila irekita dituzu. Irten hala ere?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander-ra"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Benetan utzi nahi duzu Midnight Commander-ra?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Beneta exekutatu nahi duzu?"
 
 msgid "&Above"
 msgstr "&Gainean"
@@ -3685,12 +3742,13 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
+"Ume stdout-etik datuak irakurtzeak huts egin du:\n"
+"%s"
 
 msgid "Cannot run external panelize in a non-local directory"
 msgstr ""
@@ -3730,6 +3788,15 @@ msgid ""
 "%s"
 msgstr ""
 "Helburuaren egoera (\"stat\") ezin lortu\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"\"%s\" helburua direktorio bat izan behar da\n"
 "%s"
 
 #, c-format
@@ -3851,8 +3918,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Etxeko direktorioaren bide-izena ez da absolutua"
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4537,8 +4605,9 @@ msgstr "Fitxategia aldatu da. Gorde irtetzerakoan?"
 msgid "&Cancel quit"
 msgstr "Irteera bertan behera &utzi"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander itzaltzen ari da.\n"
@@ -4589,10 +4658,8 @@ msgstr "FormGabe"
 msgid "ButtonBar|Format"
 msgstr "Format"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Ume stdout-etik datuak irakurtzeak huts egin du:\n"
 "%s"
@@ -4618,20 +4685,18 @@ msgstr ""
 msgid "View: "
 msgstr "Ikusi:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"\"%s\" ezin ireki\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Ezin ikusi: ez da fitxategi arrunta"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Ezin da ireki \"%s\" sintaxi-azterketa moduan\n"
@@ -4646,6 +4711,78 @@ msgstr "Hasieratik jarraitu?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
 "Ezin eskuratu ondokoaren bertako kopia bat: /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander-ra"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Benetan utzi nahi duzu Midnight Commander-ra?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "%s irakurtzeko ezin ireki"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "%s-ren neurria/baimenak ezin eskuratu"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Hodia idazteko ezin ireki: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Ezin da gorde: helburua ez da ohiko fitxategi bat"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "%s fitxategia ezin ireki\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Jaramonik ez &guztiari"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "esteka: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "esteka sinbolikoa: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Ezin da sortu iturburuaren \"%s\" esteka sinbolikoa\\n\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Ezin da mugitu \"%s\" fitxategia \"%s\"-ra\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Ezin da gainidatzi \"%s\" direktorioa\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Ezin da mugitu \"%s\" direktorioa \"%s\"-ra\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Beste 8 bit"

--- a/po/fa.po
+++ b/po/fa.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Arya Hadi <arya.hadi97@gmail.com>, 2017\n"
 "Language-Team: Persian (http://app.transifex.com/mc/mc/language/fa/)\n"
@@ -52,6 +52,9 @@ msgstr "ایجاد گروه '%s' برای رویدادها ممکن نیست!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "ایجاد رویداد '%s' ممکن نیست!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -730,7 +733,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -796,23 +799,16 @@ msgstr "جستجو"
 msgid "Search is disabled"
 msgstr "جستجو غیرفعال است"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -881,16 +877,17 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr "خروج"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
+
+msgid "Quit"
+msgstr "خروج"
 
 msgid "Diff:"
 msgstr ""
@@ -898,15 +895,17 @@ msgstr ""
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"%s\n"
+"is a directory"
+msgstr "پوشه"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat\n"
 "%s"
-msgstr ""
+msgstr "نمی‌توان فایل را ذخیره کرد"
 
 msgid "Diff viewer: invalid mode"
 msgstr ""
@@ -922,7 +921,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -933,11 +934,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -953,9 +952,11 @@ msgstr "اخطار"
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
+msgstr "امکان باز کردن فایل برای نوشتن وجود ندارد: %s"
 
 msgid "File has hard-links. Detach before saving?"
 msgstr ""
@@ -967,12 +968,11 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "امکان باز کردن فایل برای نوشتن وجود ندارد: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1017,8 +1017,12 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr "ویرایش روش ذخیره"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "نمی‌توان فایل را ذخیره کرد"
 
 msgid "A file already exists with this name"
 msgstr "فایلی با این نام وجود دارد"
@@ -1077,7 +1081,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1513,12 +1517,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1647,13 +1649,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr "نمی‌توان فایل را ذخیره کرد"
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1679,7 +1681,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1712,22 +1715,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1741,6 +1747,18 @@ msgid "Running"
 msgstr "در حال اجرا"
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1820,15 +1838,6 @@ msgstr ""
 
 msgid "Configure options"
 msgstr "تنظیمات پیکربندی"
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr ""
@@ -2021,12 +2030,11 @@ msgstr "کشتن"
 msgid "Background jobs"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
-msgstr ""
+msgstr "ساخت پوشه‌ی جدید"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2117,13 +2125,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2228,11 +2242,15 @@ msgid "Link"
 msgstr "پیوند"
 
 #, c-format
-msgid "link: %s"
-msgstr "پیوند: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2255,6 +2273,12 @@ msgstr "ساخت پوشه‌ی جدید"
 
 msgid "Enter directory name:"
 msgstr "نام پوشه را وارد کنید:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "اخطار: پوشه‌ی %s را نمی‌توان باز کرد\n"
 
 msgid "Extension file edit"
 msgstr ""
@@ -2303,11 +2327,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2347,11 +2375,9 @@ msgstr "در فایل سیستم غیرمحلی نمی‌توان فرمانی �
 msgid "Parameter"
 msgstr "پارامتر"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
-msgstr ""
+#, fuzzy
+msgid "Cannot create temporary command file"
+msgstr "فرمان مرتب‌سازی قابل اجرا نیست"
 
 msgid "Pipe failed"
 msgstr ""
@@ -2359,7 +2385,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2369,7 +2395,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2426,23 +2452,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2454,7 +2476,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2474,160 +2496,174 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 msgid "Non&e"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
-msgstr ""
+msgstr "نمی‌توان فایل را ذخیره کرد"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
-msgstr ""
+msgstr "نمی‌توان فایل را ذخیره کرد"
 
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
-msgstr ""
+msgstr "نمی‌توان فایل را ذخیره کرد"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot remove directory\n"
+"%s"
+msgstr "اخطار: پوشه‌ی %s را نمی‌توان باز کرد\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot enter into directory\n"
+"%s"
+msgstr "اخطار: پوشه‌ی %s را نمی‌توان باز کرد\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot overwrite directory\n"
+"%s"
+msgstr "اخطار: پوشه‌ی %s را نمی‌توان باز کرد\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot overwrite file\n"
+"%s"
+msgstr "نمی‌توان فایل را ذخیره کرد"
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot enter into directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot overwrite directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot overwrite file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
+#, fuzzy, c-format
+msgid ""
+"Cannot stat source file\n"
+"%s"
+msgstr "نمی‌توان فایل را ذخیره کرد"
+
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
-msgstr ""
+msgstr "نمی‌توان فایل را ذخیره کرد"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
-msgstr ""
+msgstr "نمی‌توان فایل را ذخیره کرد"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
-msgstr ""
+msgstr "نمی‌توان فایل را ذخیره کرد"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot open source file \"%s\"\n"
-"%s"
-msgstr ""
+msgstr "نمی‌توان فایل را ذخیره کرد"
 
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
-msgstr ""
+msgstr "نمی‌توان فایل را ذخیره کرد"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create target file\n"
+"%s"
+msgstr "نمی‌توان فایل را ذخیره کرد"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot fstat target file\n"
+"%s"
+msgstr "نمی‌توان فایل را ذخیره کرد"
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
-msgstr ""
+msgstr "نمی‌توان فایل را ذخیره کرد"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot read source file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot write target file \"%s\"\n"
-"%s"
-msgstr ""
+msgstr "نمی‌توان فایل را ذخیره کرد"
 
 msgid "(stalled)"
 msgstr ""
@@ -2641,33 +2677,33 @@ msgstr ""
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
-msgstr ""
+msgstr "نمی‌توان فایل را ذخیره کرد"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot close target file\n"
+"%s"
+msgstr "نمی‌توان فایل را ذخیره کرد"
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
-msgstr ""
+msgstr "اخطار: پوشه‌ی %s را نمی‌توان باز کرد\n"
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2685,21 +2721,23 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
-msgstr ""
+msgstr "ساخت پوشه‌ی جدید"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
-msgstr ""
+msgstr "اخطار: پوشه‌ی %s را نمی‌توان باز کرد\n"
 
 #, c-format
 msgid "Directories: %zu, total size: %s"
@@ -3022,10 +3060,8 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr "فرماندار نیمه‌شب"
-
-msgid "Do you really want to quit the Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
 msgstr "واقعا می‌خواهید از فرماندار نیمه‌شب خارج شوید؟"
 
 msgid "&Above"
@@ -3519,11 +3555,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3559,6 +3593,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3661,8 +3702,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4312,8 +4354,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4362,10 +4405,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4384,18 +4424,18 @@ msgstr ""
 msgid "View: "
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
-msgstr ""
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
+msgstr "نمی‌توان فایل را ذخیره کرد"
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 
@@ -4407,6 +4447,13 @@ msgstr ""
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "فرماندار نیمه‌شب"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "پیوند: %s"
 
 #~ msgid "Display bits"
 #~ msgstr "بیت‌های نمایش"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>, 2021\n"
 "Language-Team: Finnish (http://app.transifex.com/mc/mc/language/fi/)\n"
@@ -51,6 +51,9 @@ msgstr "Ryhmää '%s' ei voi luoda tapahtumille!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Tapahtuman '%s' luonti epäonnistui!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -759,7 +762,7 @@ msgstr "[this_dir] [other_panel_dir]"
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -827,28 +830,23 @@ msgstr "Etsi"
 msgid "Search is disabled"
 msgstr "Haku on pois käytöstä"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Väliaikaista diff-tiedostoa ei voi luoda\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Ei voi luoda varmuuskopion tiedostoa\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Väliaikaista merge-tiedostoa ei voi luoda\n"
 "%s"
@@ -919,18 +917,19 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr "Poistu"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Tiedostot ovat muuttuneet. Tallenna ja poistu?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander suljetaan.\n"
 "Tallenna muuttuneet tiedostot?"
+
+msgid "Quit"
+msgstr "Poistu"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -938,15 +937,19 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" on hakemisto"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
+"Tiedostoa \"%s\" ei voi lisätä\n"
+"%s"
 
 msgid "Diff viewer: invalid mode"
 msgstr "Diff viewer: virheellinen tila"
@@ -961,9 +964,13 @@ msgstr "Avataan: %3d%%"
 msgid "Loading..."
 msgstr "Avataan..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Ei voida avata %s lukemista varten"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Ei voi avata tiedostoa %s\n"
+"%s"
 
 msgid "Load file"
 msgstr "Avaa tiedosto"
@@ -972,12 +979,10 @@ msgstr "Avaa tiedosto"
 msgid "Error reading %s"
 msgstr "Virhe lukiessa %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Ei saada kohteen %s kokoa/käyttöoikeuksia"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" ei ole tavallinen tiedosto"
 
 #, c-format
@@ -995,8 +1000,10 @@ msgstr "Varoitus"
 msgid "Error reading from pipe: %s"
 msgstr "Virhe luettaessa putkesta: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Putki ei avaudu lukemista varten: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1009,12 +1016,11 @@ msgstr "Tiedosto on muuttunut tällä välin. Tallenna kuitenkin?"
 msgid "Error writing to pipe: %s"
 msgstr "Virhe kirjoitettaessa putkeen: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Putki ei avaudu kirjoitusta varten: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Ei voida avata %s kirjoitusta varten"
 
 msgid "The file you are saving does not end with a newline."
@@ -1059,7 +1065,11 @@ msgstr "Tarkista &POSIX uusi rivi"
 msgid "Edit Save Mode"
 msgstr "Muokkaa tallennustilaa"
 
-msgid "Cannot save: destination is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr "Ei voi tallentaa: kohde ei ole tavallinen tiedosto"
 
 msgid "A file already exists with this name"
@@ -1119,9 +1129,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Sulje tiedosto"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander suljetaan.\n"
@@ -1561,15 +1571,13 @@ msgstr "Vahvista vaihto"
 msgid "%ld replacements made"
 msgstr "%ld korvaaminen tehty"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Midnight Commanderille kirjoitettu\n"
 "käyttäjäystävällinen tekstieditori."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Tietoja"
@@ -1697,16 +1705,16 @@ msgstr "< Automaatti >"
 msgid "< Reload Current Syntax >"
 msgstr "< Lataa syntaksi uudelleen >"
 
-msgid "Load syntax file"
-msgstr "Lataa syntaksi tiedosto"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
 msgstr ""
 "Ei voi avata tiedostoa %s\n"
 "%s"
+
+msgid "Load syntax file"
+msgstr "Lataa syntaksi tiedosto"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1731,7 +1739,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1762,26 +1771,37 @@ msgstr ""
 msgid "Chown advanced command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Ei onnistu chmod kohdetiedostoon \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Ei voi avata tiedostoa %s\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
+"Ei onnistu chmod kohdetiedostoon \"%s\"\n"
+"%s"
 
-msgid "&Ignore"
-msgstr "&Ohita"
-
-msgid "Ignore &all"
-msgstr "Ohita &kaikki"
-
-msgid "&Retry"
-msgstr "&Uudelleen"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
+"Ei voi avata tiedostoa %s\n"
+"%s"
 
 msgid "< Default >"
 msgstr "<Oletus>"
@@ -1794,6 +1814,18 @@ msgstr "Käynnissä"
 
 msgid "Stopped"
 msgstr "Pysäytetty"
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Koskaan"
@@ -1871,15 +1903,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2073,12 +2096,13 @@ msgstr "&Tapa"
 msgid "Background jobs"
 msgstr "Taustatyöt"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"Ei onnistu chown kohdekansioon \"%s\"\n"
+"%s"
 
 msgid "Secure deletion"
 msgstr "Turvallinen poistaminen"
@@ -2167,17 +2191,23 @@ msgstr "&Tyhjennä merkityt"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
-msgstr ""
+"Cannot chattr\n"
+"%sn%s"
+msgstr "Ei voi jäsentää:"
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Ei voi jäsentää:"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2279,13 +2309,21 @@ msgstr ""
 msgid "Link"
 msgstr ""
 
-#, c-format
-msgid "link: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
+"Erikoistiedostoa ei voi luoda \"%s\"\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
+"Väliaikaista diff-tiedostoa ei voi luoda\n"
+"%s"
 
 msgid "View file"
 msgstr ""
@@ -2307,6 +2345,12 @@ msgstr "Luo uusi hakemisto"
 
 msgid "Enter directory name:"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Hakemiston %s luonti epäonnistui"
 
 msgid "Extension file edit"
 msgstr "Laajennustiedoston muokkaus"
@@ -2355,12 +2399,18 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
+"Ei voi avata tiedostoa %s\n"
+"%s"
 
 msgid "FTP to machine"
 msgstr ""
@@ -2399,11 +2449,11 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
+"Väliaikaista diff-tiedostoa ei voi luoda\n"
+"%s"
 
 msgid "Pipe failed"
 msgstr "Virheellinen putki"
@@ -2411,7 +2461,7 @@ msgstr "Virheellinen putki"
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2421,7 +2471,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2476,27 +2526,29 @@ msgstr ""
 msgid " with source mask:"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"Lähdetiedostoa ei voi lisätä \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
+"Kohdetiedostoa ei voi luoda \"%s\"\n"
+"%s"
 
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
+"Lähdetiedostoa ei voi lukea \"%s\"\n"
+"%s"
 
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
@@ -2504,11 +2556,13 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
+"Kohdetiedostoa ei voi luoda \"%s\"\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2526,36 +2580,46 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr "&Ohita"
+
 msgid "Ignore a&ll"
 msgstr ""
 
+msgid "&Retry"
+msgstr "&Uudelleen"
+
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 msgid "Non&e"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Tiedostoa \"%s\" ei voi poistaa\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Tiedostoa \"%s\" ei voi lisätä\n"
@@ -2565,102 +2629,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Kansiota \"%s\" ei voi ylikirjoittaa"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Tiedostoa ei voi siirtää \"%s\" - \"%s\"\n"
+"Tiedostoa \"%s\" ei voi poistaa\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Kansiota \"%s\" ei voi poistaa\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Kansiota \"%s\" ei voi ylikirjoittaa"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Kansiota \"%s\" ei voi ylikirjoittaa\n"
-"%s"
+msgstr "Kansiota \"%s\" ei voi ylikirjoittaa"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Tiedostoa \"%s\" ei voi ylikirjoittaa\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Kansiota ei voi siirtää \"%s\" - \"%s\"\n"
+"Kansiota \"%s\" ei voi poistaa\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Ei voi käyttää \"..\"!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Lähdetiedostoa ei voi lisätä \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Lähdetiedostoa ei voi lisätä \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Ei onnistu fstat kohdetiedostoon \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Erikoistiedostoa ei voi luoda \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Ei onnistu chown kohdetiedostoon \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Ei onnistu chmod kohdetiedostoon \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Lähdetiedostoa ei voi avata \"%s\"\n"
@@ -2669,49 +2739,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Ei onnistu fstat lähdetiedostoon \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Kohdetiedostoa ei voi luoda \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Ei onnistu fstat kohdetiedostoon \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Ei voitu varata tilaa kohdetiedostolle \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Lähdetiedostoa ei voi lukea \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Kohdetiedostoa ei voi kirjoittaa \"%s\"\n"
@@ -2729,41 +2799,45 @@ msgstr "&Pidä"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Lähdetiedostoa ei voi sulkea \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Kohdetiedostoa ei voi sulkea \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Ei voitu varata tilaa kohdetiedostolle \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Kohdekansiota ei voi lisätä \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Kohdekansiota ei voi lisätä \"%s\"\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2779,25 +2853,27 @@ msgid ""
 "\"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Kohteen \"%s\" on oltava kansio\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Kohdekansiota ei voi luoda \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Ei onnistu chown kohdekansioon \"%s\"\n"
@@ -3124,10 +3200,8 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
 msgstr "Haluatko sulkea Midnight Commanderin?"
 
 msgid "&Above"
@@ -3621,11 +3695,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3662,6 +3734,15 @@ msgid ""
 "Cannot stat the destination\n"
 "%s"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Kohteen \"%s\" on oltava kansio\n"
+"%s"
 
 #, c-format
 msgid "Delete %s?"
@@ -3763,8 +3844,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4421,10 +4503,13 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
+"Midnight Commander suljetaan.\n"
+"Tallenna muuttuneet tiedostot?"
 
 msgid "&Line number"
 msgstr ""
@@ -4471,10 +4556,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4493,20 +4575,22 @@ msgstr ""
 msgid "View: "
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
+msgstr "Ei voi tallentaa: kohde ei ole tavallinen tiedosto"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
-
-msgid "Cannot view: not a regular file"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Ei voi avata tiedostoa %s\n"
 "%s"
-msgstr ""
 
 msgid "Search done"
 msgstr ""
@@ -4516,6 +4600,48 @@ msgstr ""
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Ei voida avata %s lukemista varten"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Ei saada kohteen %s kokoa/käyttöoikeuksia"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Putki ei avaudu kirjoitusta varten: %s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ohita &kaikki"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Tiedostoa ei voi siirtää \"%s\" - \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kansiota \"%s\" ei voi ylikirjoittaa\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kansiota ei voi siirtää \"%s\" - \"%s\"\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Muut 8-bittiset"

--- a/po/fr.po
+++ b/po/fr.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2016,2025\n"
 "Language-Team: French (http://app.transifex.com/mc/mc/language/fr/)\n"
@@ -59,6 +59,9 @@ msgstr "Impossible de créer le groupe « %s » pour les événements !"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Impossible de créer l’événement « %s » !"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr "Copyright (C) 1996-2025 the Free Software Foundation"
 
 #, c-format
 msgid ""
@@ -801,10 +804,10 @@ msgstr "fichier1 fichier2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[ce_rép] [autre_rép_panneau]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -875,28 +878,23 @@ msgstr "Rechercher"
 msgid "Search is disabled"
 msgstr "Recherche désactivée"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Impossible de créer le fichier de comparaison temporaire\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Impossible de créer le fichier de sauvegarde\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Impossible de créer le fichier fusionné temporaire\n"
 "%s"
@@ -967,18 +965,19 @@ msgstr "ButtonBar|Options"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Quitter"
 
-msgid "Quit"
-msgstr "Quitter"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Un ou plusieurs fichiers ont été modifiés. Sauvegarder puis quitter ?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander va s’éteindre.\n"
 "Enregistrer le(s) fichier(s) modifié(s) ?"
+
+msgid "Quit"
+msgstr "Quitter"
 
 msgid "Diff:"
 msgstr "Comparaison :"
@@ -986,13 +985,15 @@ msgstr "Comparaison :"
 msgid "File name is empty!"
 msgstr "Le nom du fichier est vide !"
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "« %s » est un répertoire"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Impossible d’obtenir les caractéristiques de « %s »\n"
@@ -1011,9 +1012,13 @@ msgstr "Chargement : %3d%%"
 msgid "Loading..."
 msgstr "Chargement..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Impossible d’ouvrir %s en lecture"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Impossible d’ouvrir « %s »\n"
+"%s"
 
 msgid "Load file"
 msgstr "Chargement du fichier"
@@ -1022,12 +1027,10 @@ msgstr "Chargement du fichier"
 msgid "Error reading %s"
 msgstr "Erreur de lecture de %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Impossible d’obtenir la taille ou les permissions de %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "« %s » n’est pas un fichier régulier"
 
 #, c-format
@@ -1045,8 +1048,10 @@ msgstr "Attention"
 msgid "Error reading from pipe: %s"
 msgstr "Erreur de lecture dans le tube : %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Impossible d’ouvrir le tube pour lire : %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1059,12 +1064,11 @@ msgstr "Le fichier a été modifié entre-temps. Enregistrer quand même ?"
 msgid "Error writing to pipe: %s"
 msgstr "Erreur d’écriture dans le tube : %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Impossible d’ouvrir le tube en écriture : %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Impossible d’ouvrir le fichier en écriture : %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1111,9 +1115,12 @@ msgstr "Vérifier les nouvelles lignes &POSIX"
 msgid "Edit Save Mode"
 msgstr "Mode Sauver Éditer"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr ""
-"Impossible de sauvegarder : la destination n’est pas un fichier régulier"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Visualisation impossible : ce n’est pas un fichier régulier"
 
 msgid "A file already exists with this name"
 msgstr "Un fichier de même nom existe déjà"
@@ -1172,9 +1179,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Fermer le fichier"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander va s’éteindre.\n"
@@ -1616,15 +1623,13 @@ msgstr "Confirmer le remplacement"
 msgid "%ld replacements made"
 msgstr "%ld remplacements effectués"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Un éditeur de texte facile d’utilisation\n"
 "écrit pour Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr "Copyright (C) 1996-2025 the Free Software Foundation"
 
 msgid "About"
 msgstr "À propos"
@@ -1752,16 +1757,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Recharger la syntaxe courante >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Impossible d’ouvrir le fichier %s"
+
 msgid "Load syntax file"
 msgstr "Charger le fichier de syntaxe"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Impossible d’ouvrir le fichier %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1792,7 +1795,8 @@ msgstr ""
 "Pas un xterm ou une console Linux ;\n"
 "le sous-shell ne peut pas être commuté."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Tapez « exit » pour retourner à Midnight Commander"
 
 msgid "Set &all"
@@ -1823,26 +1827,33 @@ msgstr "Permissions (octal) : %o"
 msgid "Chown advanced command"
 msgstr " Commande chown avancée"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Ne peut changer les permissions de « %s »\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Ne peut changer l’appartenance de « %s »\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Ne peut changer les permissions de « %s »\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignorer"
-
-msgid "Ignore &all"
-msgstr "Ignorer &tout"
-
-msgid "&Retry"
-msgstr "&Réessayer"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Ne peut changer l’appartenance de « %s »\n"
@@ -1859,6 +1870,20 @@ msgstr "En cours"
 
 msgid "Stopped"
 msgstr "Stoppé"
+
+#, fuzzy
+msgid "No translation"
+msgstr "- < Pas de conversion >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Entrée / affichage de la page de code :"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Jamais"
@@ -1937,17 +1962,6 @@ msgstr "Enregistrement a&utomatique de la configuration"
 
 msgid "Configure options"
 msgstr "Configurer les options"
-
-#, fuzzy
-msgid "No translation"
-msgstr "- < Pas de conversion >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Entrée / affichage de la page de code :"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Thème :"
@@ -2144,10 +2158,9 @@ msgstr "&Tuer"
 msgid "Background jobs"
 msgstr "Processus en arrière-plan"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "Impossible de changer de répertoire en\n"
@@ -2241,20 +2254,28 @@ msgstr "&Supprimer les marqués"
 msgid "Chattr command"
 msgstr "Commande chattr"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Chattr impossible « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 "Impossible d’obtenir les attributs ext2 de « %s »\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Chattr impossible « %s »\n"
 "%s"
 
 msgid "set &user ID on execution"
@@ -2357,13 +2378,21 @@ msgstr "Lien %s vers :"
 msgid "Link"
 msgstr "Lien"
 
-#, c-format
-msgid "link: %s"
-msgstr "lien : %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Impossible de créer le lien symbolique cible « %s »\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "lien symbolique : %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Impossible de copier le lien symbolique cyclique\n"
+"« %s »"
 
 msgid "View file"
 msgstr "Voir le fichier"
@@ -2385,6 +2414,12 @@ msgstr "Créer un nouveau répertoire"
 
 msgid "Enter directory name:"
 msgstr " Saisissez le nom du répertoire :"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Ne peut créer le répertoire %s"
 
 msgid "Extension file edit"
 msgstr "Éditer les extensions de fichiers"
@@ -2434,12 +2469,16 @@ msgstr "Lien symbolique « %s » pointe vers :"
 msgid "Edit symlink"
 msgstr "Éditer le lien symbolique"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "édition de lien symbolique, incapable d’enlever %s : %s "
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "Éditer le lien symbolique : %s"
 
 msgid "FTP to machine"
@@ -2483,10 +2522,8 @@ msgstr ""
 msgid "Parameter"
 msgstr "Paramètre"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Impossible de créer le fichier de commande temporaire\n"
 "%s"
@@ -2494,23 +2531,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr " Échec du tube "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "Vous avez un fichier %s obsolète.\n"
 "Midnight Commander utilise maintenant le fichier %s.\n"
 "Veuillez copier vos modifications de l’ancien fichier vers le nouveau."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "Le format du fichier\n"
 "%s%s\n"
@@ -2576,30 +2613,24 @@ msgstr "fichiers/répertoires"
 msgid " with source mask:"
 msgstr " avec masque source :"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Impossible de statuer sur le fichier source de la liaison physique "
 "« hardlink » « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Impossible de créer un lien physique « hardlink » cible « %s »\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Impossible de créer un lien physique « hardlink » cible « %s »"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Impossible de lire le lien source « %s »\n"
@@ -2614,9 +2645,9 @@ msgstr ""
 "fichiers non-locaux : désactivation de l’option « Liens symboliques "
 "stables »."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Impossible de créer le lien symbolique cible « %s »\n"
@@ -2646,21 +2677,31 @@ msgstr ""
 "« %s »\n"
 "sont identiques"
 
+msgid "&Ignore"
+msgstr "&Ignorer"
+
 msgid "Ignore a&ll"
 msgstr "Ignorer &tout"
 
-#, c-format
+msgid "&Retry"
+msgstr "&Réessayer"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Répertoire « %s » non vide.\n"
 "Effacer tous les sous-répertoires ?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Processus en arrière-plan :\n"
@@ -2670,17 +2711,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "&Aucun"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Impossible d’effacer le fichier « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Impossible d’obtenir les caractéristiques du fichier « %s »\n"
@@ -2690,108 +2731,110 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Impossible d’écraser le répertoire « %s »"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Impossible de déplacer le fichier « %s » vers « %s »\n"
+"Impossible d’effacer le fichier « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Impossible d’effacer le répertoire « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 "Impossible d’accéder au répertoire « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Impossible d’écraser le répertoire « %s »\n"
-"%s"
+msgstr "Impossible d’écraser le répertoire « %s »"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Impossible d’écraser le fichier « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Impossible de déplacer le répertoire de « %s » vers « %s »\n"
+"Impossible d’effacer le répertoire « %s »\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Impossible de travailler avec « .. » !"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Impossible d’obtenir les caractéristiques du fichier source « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 "Impossible d’obtenir les attributs ext2 du fichier source « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 "Impossible de définir les attributs ext2 du fichier cible « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Impossible de créer le fichier spécial « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Impossible de changer le propriétaire du fichier « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Impossible de changer les permissions du fichier « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Impossible d’ouvrir le fichier source « %s »\n"
@@ -2800,49 +2843,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Reget a échoué, sur le point d’écraser le fichier"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Impossible d’obtenir les caractéristiques du fichier source « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Impossible de créer le fichier cible « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Impossible d’obtenir les caractéristiques du fichier cible « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Impossible de préallouer l’espace pour le fichier cible « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Impossible de lire le fichier source « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Impossible d’écrire dans le fichier cible « %s »\n"
@@ -2860,41 +2903,41 @@ msgstr "C&onserver"
 msgid "&Continue copy"
 msgstr "&Continuer à copier"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Impossible de fermer le fichier source « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Impossible de fermer le fichier cible « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 "Impossible de définir les attributs ext2 pour le fichier cible « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Impossible d’obtenir les caractéristiques du fichier source « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 "Impossible d’obtenir les attributs ext2 du répertoire source « %s »\n"
@@ -2916,25 +2959,27 @@ msgstr ""
 "Impossible de copier le lien symbolique cyclique\n"
 "« %s »"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "La cible « %s » doit être un répertoire\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Impossible de créer le fichier de destination « %s »\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Impossible de modifier le propriétaire du répertoire « %s »\n"
@@ -3263,11 +3308,9 @@ msgstr[0] "Il y a %zu fenêtre d’ouverte. Quitter ?"
 msgstr[1] "Il y a %zu fenêtres ouvertes. Quitter ?"
 msgstr[2] "Il y a %zu fenêtres ouvertes. Quitter ?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Souhaitez-vous vraiment quitter Midnight Commander ?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Voulez-vous vraiment l’exécuter ?"
 
 msgid "&Above"
 msgstr "&Au-dessus"
@@ -3771,11 +3814,10 @@ msgstr ""
 "Panneau externe :\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Panneau externe :\n"
 "échec de la lecture des données du « stdout » enfant :\n"
@@ -3819,6 +3861,15 @@ msgid ""
 "%s"
 msgstr ""
 "Impossible d’obtenir les caractéristiques de la cible\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"La cible « %s » doit être un répertoire\n"
 "%s"
 
 #, c-format
@@ -3942,8 +3993,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Le chemin vers le répertoire utilisateur n’est pas absolu"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4673,8 +4725,9 @@ msgstr "Le fichier a été modifié. Sauvegarder puis quitter ?"
 msgid "&Cancel quit"
 msgstr "&Annuler quitter"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander va s’éteindre.\n"
@@ -4725,10 +4778,8 @@ msgstr "ButtonBar|Déformater"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Formater"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Impossible de lire des données sur le flux de sortie fils\n"
 "%s"
@@ -4754,20 +4805,18 @@ msgstr ""
 msgid "View: "
 msgstr "Vue :"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Impossible d’ouvrir « %s »\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Visualisation impossible : ce n’est pas un fichier régulier"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Impossible d’ouvrir « %s » en mode analyse\n"
@@ -4782,6 +4831,79 @@ msgstr "Continuer à partir du début ?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
 "Impossible de récupérer localement le fichier /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Souhaitez-vous vraiment quitter Midnight Commander ?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Impossible d’ouvrir %s en lecture"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Impossible d’obtenir la taille ou les permissions de %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Impossible d’ouvrir le tube en écriture : %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr ""
+#~ "Impossible de sauvegarder : la destination n’est pas un fichier régulier"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Impossible d’ouvrir le fichier %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignorer &tout"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "lien : %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "lien symbolique : %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Impossible de créer un lien physique « hardlink » cible « %s »\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Impossible de déplacer le fichier « %s » vers « %s »\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Impossible d’écraser le répertoire « %s »\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Impossible de déplacer le répertoire de « %s » vers « %s »\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Autre 8 bits"

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2015-02-26 09:48+0000\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: French (Canada) (http://www.transifex.com/projects/p/mc/"
@@ -47,6 +47,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -726,7 +729,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -792,23 +795,16 @@ msgstr ""
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -877,15 +873,16 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr ""
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Diff:"
@@ -895,12 +892,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -918,7 +917,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -929,11 +930,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -950,7 +949,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -964,11 +965,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1013,7 +1013,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1073,7 +1077,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1509,12 +1513,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1643,13 +1645,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1675,7 +1677,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1708,22 +1711,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1737,6 +1743,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1815,15 +1833,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2020,7 +2029,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2113,13 +2121,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2224,11 +2238,15 @@ msgid "Link"
 msgstr ""
 
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2250,6 +2268,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2299,11 +2323,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2343,10 +2371,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2355,7 +2380,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2365,7 +2390,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2422,23 +2447,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2450,7 +2471,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2470,19 +2491,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2491,13 +2522,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2507,37 +2538,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2546,43 +2581,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2591,37 +2626,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2639,31 +2674,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2681,19 +2716,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3018,10 +3055,7 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3515,11 +3549,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3555,6 +3587,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3657,8 +3696,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4308,8 +4348,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4358,10 +4399,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4382,16 +4420,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/ga.po
+++ b/po/ga.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Irish (http://app.transifex.com/mc/mc/language/ga/)\n"
@@ -47,6 +47,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -726,7 +729,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -792,23 +795,16 @@ msgstr ""
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -877,15 +873,16 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr ""
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Diff:"
@@ -895,12 +892,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -918,7 +917,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -929,11 +930,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -950,7 +949,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -964,11 +965,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1013,7 +1013,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1073,7 +1077,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1509,12 +1513,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1643,13 +1645,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1675,7 +1677,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1708,22 +1711,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1737,6 +1743,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1815,15 +1833,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2020,7 +2029,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2113,13 +2121,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2224,11 +2238,15 @@ msgid "Link"
 msgstr ""
 
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2250,6 +2268,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2299,11 +2323,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2343,10 +2371,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2355,7 +2380,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2365,7 +2390,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2422,23 +2447,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2450,7 +2471,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2470,19 +2491,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2491,13 +2522,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2507,37 +2538,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2546,43 +2581,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2591,37 +2626,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2639,31 +2674,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2681,19 +2716,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3021,10 +3058,7 @@ msgstr[2] ""
 msgstr[3] ""
 msgstr[4] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3527,11 +3561,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3567,6 +3599,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3669,8 +3708,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4320,8 +4360,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4370,10 +4411,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4394,16 +4432,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Galician (http://app.transifex.com/mc/mc/language/gl/)\n"
@@ -53,6 +53,9 @@ msgstr "Non foi posíbel crear o grupo «%s» para accións!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Non foi posíbel crear a acción «%s»!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -766,10 +769,10 @@ msgstr "ficheiro1 ficheiro2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[Este_directorio] [outro_directorio _de_panel]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -840,28 +843,23 @@ msgstr "Buscar"
 msgid "Search is disabled"
 msgstr "A busca está desactivada"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Non é posíbel crear o ficheiro temporal «diff»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Non é posíbel crear o ficheiro de copia de seguranza\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Non é posíbel crear o ficheiro temporal para mesturas\n"
 "%s"
@@ -932,18 +930,19 @@ msgstr "ButtonBar|Opcións"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Saír"
 
-msgid "Quit"
-msgstr "Saír"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "O(s) ficheiro(s) foi/foron modificado(s). Quere gardalo(s) ao saír?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Saíndo de Midnight Commander.\n"
 "Gardar o(s) ficheiro(s) modificado(s)?"
+
+msgid "Quit"
+msgstr "Saír"
 
 msgid "Diff:"
 msgstr "Diferenza:"
@@ -951,13 +950,15 @@ msgstr "Diferenza:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "«%s» é un directorio"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Non é posíbel identificar «%s»\n"
@@ -976,9 +977,13 @@ msgstr "Cargando: %3d%%"
 msgid "Loading..."
 msgstr "Cargando..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Non é posíbel abrir %s para lectura"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Non é posíbel abrir «%s»\n"
+"%s"
 
 msgid "Load file"
 msgstr "Cargar ficheiro"
@@ -987,12 +992,10 @@ msgstr "Cargar ficheiro"
 msgid "Error reading %s"
 msgstr "Produciuse un erro ao ler %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Non é posíbel obter tamaño/permisos do ficheiro: %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "«%s» non é un ficheiro regular"
 
 #, c-format
@@ -1010,8 +1013,10 @@ msgstr "Atención"
 msgid "Error reading from pipe: %s"
 msgstr "Produciuse un erro ao ler da canalización: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Non é posíbel abrir canalización para lectura: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1024,12 +1029,11 @@ msgstr "O ficheiro esta a ser modificado por outros. Desexa gardar aínda así?"
 msgid "Error writing to pipe: %s"
 msgstr "Produciuse un erro ao escribir na canalización: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Non é posíbel abrir canalización para escritura: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Non é posíbel abrir o ficheiro para escritura: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1074,8 +1078,12 @@ msgstr "Verificar salto de líña &POSIX"
 msgid "Edit Save Mode"
 msgstr "Editar modo de gardar"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Non se pode gardar: o destino non é un ficheiro normal"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Non é posíbel ver: non é un ficheiro regular"
 
 msgid "A file already exists with this name"
 msgstr "Xa existe un ficheiro con ese nome"
@@ -1134,9 +1142,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Pechar o ficheiro"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Saíndo de Midnight Commander.\n"
@@ -1577,15 +1585,13 @@ msgstr "Confirmar cambios"
 msgid "%ld replacements made"
 msgstr " %ld substitucións feitas"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Un editor de texto de uso amigábel\n"
 "escrito para o Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Sobre"
@@ -1713,16 +1719,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Recargar a sintaxe actual >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Non é posíbel abrir o ficheiro %s"
+
 msgid "Load syntax file"
 msgstr "Cargar ficheiro de sintaxe"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Non se pode abrir o ficheiro %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1751,7 +1755,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Escriba «exit» para volver ao Midnight Commander"
 
 msgid "Set &all"
@@ -1782,26 +1787,33 @@ msgstr ""
 msgid "Chown advanced command"
 msgstr "Cambiar propietario e permisos"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Non é posíbel cambiar permisos de «%s»\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Non é posíbel cambiar o propietario de «%s»\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Non é posíbel cambiar permisos de «%s»\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignorar"
-
-msgid "Ignore &all"
-msgstr "Ignorar &Todo"
-
-msgid "&Retry"
-msgstr "&Reintentar"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Non é posíbel cambiar o propietario de «%s»\n"
@@ -1818,6 +1830,20 @@ msgstr "Executándose"
 
 msgid "Stopped"
 msgstr "Detido"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Sen tradución >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Entrada / mostrar xogo de caracteres:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Nunca"
@@ -1896,17 +1922,6 @@ msgstr "Configuración do &Auto-gardado"
 
 msgid "Configure options"
 msgstr "Configuración"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Sen tradución >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Entrada / mostrar xogo de caracteres:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Tema:"
@@ -2104,12 +2119,13 @@ msgstr "&Eliminar"
 msgid "Background jobs"
 msgstr "Traballos en segundo plano"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"Non é posíbel cambiar os permisos do directorio destino «%s»\n"
+"%s"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2198,17 +2214,27 @@ msgstr "&Limpar marcados"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
+"Non é posíbel identificar «%s»\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Non é posíbel abrir arquivos de tipo tar\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Non é posíbel analizar:"
 
 msgid "set &user ID on execution"
 msgstr "Estabelecer o ID do &Ususrio na execución"
@@ -2310,13 +2336,21 @@ msgstr "Crear ligazón a %s como:"
 msgid "Link"
 msgstr "Ligar"
 
-#, c-format
-msgid "link: %s"
-msgstr "ligar: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Non é posíbel crear a ligazón simbólica «%s»\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "ligazón simbólica: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Non é posíbel copiar unha ligazón simbólica cíclica\n"
+"«%s»"
 
 msgid "View file"
 msgstr "Ver ficheiro"
@@ -2338,6 +2372,12 @@ msgstr "Crear un novo directorio"
 
 msgid "Enter directory name:"
 msgstr "Introduza nome do directorio:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Non é posíbel crear o directorio %s"
 
 msgid "Extension file edit"
 msgstr "Editar o ficheiro de extensións"
@@ -2387,12 +2427,16 @@ msgstr "A ligazón simbólica «%s» apunta a:"
 msgid "Edit symlink"
 msgstr "Editar ligazón simbólica"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "edite a ligazón simbólica, non é posíbel eliminar %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "editar ligazón simbólica: %s"
 
 msgid "FTP to machine"
@@ -2434,10 +2478,8 @@ msgstr "Non é posíbel executar ordes desde sistemas de ficheiros non locais"
 msgid "Parameter"
 msgstr "Parámetro"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Non é posíbel crear o ficheiro temporal para ordes\n"
 "%s"
@@ -2448,7 +2490,7 @@ msgstr "Fallo na canalización"
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2458,7 +2500,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2513,29 +2555,23 @@ msgstr "ficheiros/directorios"
 msgid " with source mask:"
 msgstr " con máscara de orixe:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Non é posíbel estabelecer o ficheiro orixe da ligazón dura «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Non é posíbel crear o destino da ligazón dura «%s»\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Non é posíbel crear o destino da ligazón dura «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Non é posíbel ler a ligazón orixe «%s»\n"
@@ -2551,9 +2587,9 @@ msgstr ""
 "\n"
 "A opción de ligazóns simbólicas estábeis será desactivada"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Non é posíbel crear a ligazón simbólica «%s»\n"
@@ -2583,21 +2619,31 @@ msgstr ""
 "«%s»\n"
 "son o mesmo ficheiro"
 
+msgid "&Ignore"
+msgstr "&Ignorar"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "&Reintentar"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "O directorio «%s» non está baleiro.\n"
 "Eliminalo recursivamente?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Proceso en segundo plano:\n"
@@ -2607,17 +2653,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Nin&Gún"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Non é posíbel eliminar o ficheiro «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Non é posíbel identificar o ficheiro «%s»\n"
@@ -2627,102 +2673,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Non é posíbel sobrescribir o directorio «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Non é posíbel mover o ficheiro «%s» a «%s»\n"
+"Non é posíbel eliminar o ficheiro «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Non é posíbel eliminar o directorio «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Non é posíbel sobrescribir o directorio «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Non é posíbel sobrescribir o directorio «%s»\n"
-"%s"
+msgstr "Non é posíbel sobrescribir o directorio «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Non é posíbel sobrescribir o ficheiro «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Non é posíbel mover o directorio «%s» a «%s»\n"
+"Non é posíbel eliminar o directorio «%s»\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Non é posíbel operar sobre «..»!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Non é posíbel identificar o ficheiro orixe «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Non é posíbel estabelecer o ficheiro orixe da ligazón dura «%s»\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Non é posíbel identificar o ficheiro destino «%s»\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Non é posíbel crear o ficheiro especial «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Non é posíbel cambiar o propietario do ficheiro destino: «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Non é posíbel cambiar os permisos do ficheiro destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Non é posíbel abrir o ficheiro orixe «%s»\n"
@@ -2731,49 +2783,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Fallou o reintento, vaise a sobrescribir o ficheiro"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Non é posíbel identificar o ficheiro orixe «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Non é posíbel crear o ficheiro destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Non é posíbel identificar o ficheiro destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Non é posíbel reservar espazo para o ficheiro destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Non é posíbel ler o ficheiro orixe «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Non é posíbel escribir o ficheiro destino «%s»\n"
@@ -2791,41 +2843,45 @@ msgstr "&Manter"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Non é posíbel pechar o ficheiro orixe «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Non é posíbel pechar o ficheiro destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Non é posíbel reservar espazo para o ficheiro destino «%s»\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Non é posíbel identificar o directorio de orixe «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Non é posíbel identificar o directorio de orixe «%s»\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2843,25 +2899,27 @@ msgstr ""
 "Non é posíbel copiar unha ligazón simbólica cíclica\n"
 "«%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "O destino «%s» debe ser un directorio\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Non é posíbel crear o directorio destino «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Non é posíbel cambiar os permisos do directorio destino «%s»\n"
@@ -3189,11 +3247,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "Ten %zu pantalla aberta. Saír aínda así?"
 msgstr[1] "Ten %zu pantallas abertas. Saír aínda así?"
 
-msgid "The Midnight Commander"
-msgstr "O Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Confirma que quere saír do Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Confirma que quere executalo?"
 
 msgid "&Above"
 msgstr "&Arriba"
@@ -3690,12 +3746,13 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
+"Produciuse un erro ao ler os datos da saída estándar filla:\n"
+"%s"
 
 msgid "Cannot run external panelize in a non-local directory"
 msgstr "Non é posíbel executar a panelización externa nun directorio non local"
@@ -3734,6 +3791,15 @@ msgid ""
 "%s"
 msgstr ""
 "Non é posíbel determinar o destino\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"O destino «%s» debe ser un directorio\n"
 "%s"
 
 #, c-format
@@ -3855,8 +3921,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "A ruta do directorio de inicio non é absoluta"
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4539,8 +4606,9 @@ msgstr "O ficheiro foi modificado. Desexa gardalo ao saír?"
 msgid "&Cancel quit"
 msgstr "&Cancelar saída"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Saíndo de Midnight Commander.\n"
@@ -4591,10 +4659,8 @@ msgstr "ButtonBar|SenFormato"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Formato"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Produciuse un erro ao ler os datos da saída estándar filla:\n"
 "%s"
@@ -4620,20 +4686,18 @@ msgstr ""
 msgid "View: "
 msgstr "Vista: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Non é posíbel abrir «%s»\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Non é posíbel ver: non é un ficheiro regular"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Non é posíbel abrir «%s» en modo de análise\n"
@@ -4647,6 +4711,78 @@ msgstr "Continuar desde o principio?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Non é posíbel obter unha copia local de /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "O Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Confirma que quere saír do Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Non é posíbel abrir %s para lectura"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Non é posíbel obter tamaño/permisos do ficheiro: %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Non é posíbel abrir canalización para escritura: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Non se pode gardar: o destino non é un ficheiro normal"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Non se pode abrir o ficheiro %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignorar &Todo"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "ligar: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "ligazón simbólica: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Non é posíbel crear o destino da ligazón dura «%s»\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Non é posíbel mover o ficheiro «%s» a «%s»\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Non é posíbel sobrescribir o directorio «%s»\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Non é posíbel mover o directorio «%s» a «%s»\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Outro (8 bit)"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hebrew (http://app.transifex.com/mc/mc/language/he/)\n"
@@ -47,6 +47,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -726,7 +729,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -792,23 +795,16 @@ msgstr ""
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -877,15 +873,16 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr ""
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Diff:"
@@ -895,12 +892,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -918,7 +917,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -929,11 +930,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -950,7 +949,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -964,11 +965,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1013,7 +1013,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1073,7 +1077,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1509,12 +1513,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1643,13 +1645,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1675,7 +1677,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1708,22 +1711,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1737,6 +1743,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1815,15 +1833,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2020,7 +2029,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2113,13 +2121,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2224,11 +2238,15 @@ msgid "Link"
 msgstr ""
 
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2250,6 +2268,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2299,11 +2323,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2343,10 +2371,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2355,7 +2380,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2365,7 +2390,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2422,23 +2447,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2450,7 +2471,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2470,19 +2491,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2491,13 +2522,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2507,37 +2538,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2546,43 +2581,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2591,37 +2626,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2639,31 +2674,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2681,19 +2716,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3019,10 +3056,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3519,11 +3553,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3559,6 +3591,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3661,8 +3700,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4312,8 +4352,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4362,10 +4403,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4386,16 +4424,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Croatian (http://app.transifex.com/mc/mc/language/hr/)\n"
@@ -47,6 +47,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -726,7 +729,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -792,23 +795,16 @@ msgstr ""
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -877,15 +873,16 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr ""
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Diff:"
@@ -895,12 +892,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -918,7 +917,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -929,11 +930,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -950,7 +949,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -964,11 +965,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1013,7 +1013,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1073,7 +1077,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1509,12 +1513,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1643,13 +1645,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1675,7 +1677,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1708,22 +1711,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1737,6 +1743,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1815,15 +1833,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2020,7 +2029,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2113,13 +2121,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2224,11 +2238,15 @@ msgid "Link"
 msgstr ""
 
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2250,6 +2268,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2299,11 +2323,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2343,10 +2371,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2355,7 +2380,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2365,7 +2390,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2422,23 +2447,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2450,7 +2471,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2470,19 +2491,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2491,13 +2522,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2507,37 +2538,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2546,43 +2581,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2591,37 +2626,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2639,31 +2674,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2681,19 +2716,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3019,10 +3056,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3519,11 +3553,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3559,6 +3591,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3661,8 +3700,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4312,8 +4352,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4362,10 +4403,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4386,16 +4424,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Hungarian (http://app.transifex.com/mc/mc/language/hu/)\n"
@@ -53,6 +53,9 @@ msgstr "Nem hozható létre a(z) '%s' csoport az eseményekhez"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "%s esemény nem hozható létre"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -752,10 +755,10 @@ msgstr ""
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[aktuális_könyvtár] [másik_könyvtár]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -826,28 +829,23 @@ msgstr "Keresés"
 msgid "Search is disabled"
 msgstr "Keresés letiltva"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Ideiglenes diff fájl létrehozáasa sikertelen\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Biztonsági másolat létrehozása sikertelen\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Ideiglenes egyesített fájl létrehozása sikertelen\n"
 "%s"
@@ -918,18 +916,19 @@ msgstr "Opciók"
 msgid "ButtonBar|Quit"
 msgstr "Kilép"
 
-msgid "Quit"
-msgstr "Kilép"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Egy vagy több fájl megváltozott. Menti kilépéskor?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "A Midnight Commander kilép.\n"
 "Menti a módosított fájl(oka)t?"
+
+msgid "Quit"
+msgstr "Kilép"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -937,13 +936,15 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" egy könyvtár"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "A(z) \"%s\" adatai nem lekérdezhetők \n"
@@ -962,9 +963,13 @@ msgstr "Betöltés: %3d%%"
 msgid "Loading..."
 msgstr "Betöltés..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "A(z) \"%s\" fájl nem megnyitható olvasásra"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"A(z) \"%s\" fájl nem megnyitható \n"
+"%s"
 
 msgid "Load file"
 msgstr "Fájl betöltése"
@@ -973,12 +978,10 @@ msgstr "Fájl betöltése"
 msgid "Error reading %s"
 msgstr "%s nem olvasható:"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Méret/hozzáférés lekérdezése nem sikerült: %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\": speciális fájl"
 
 #, c-format
@@ -996,8 +999,10 @@ msgstr "Figyelem"
 msgid "Error reading from pipe: %s"
 msgstr "Hiba a cső olvasásakor: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "A cső nem megnyitható olvasásra: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1010,12 +1015,11 @@ msgstr "A fájl időközben módosult. Mentés mindenképpen?"
 msgid "Error writing to pipe: %s"
 msgstr "Hiba a cső írásakor: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "A cső nem megnyitható írásra: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "A(z) \"%s\" fájl nem megnyitható írásra."
 
 msgid "The file you are saving does not end with a newline."
@@ -1060,8 +1064,12 @@ msgstr "&POSIX soremelés vizsgálata"
 msgid "Edit Save Mode"
 msgstr "Mentési mód"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Nem lehet elmenteni - a cél egy speciális fájl"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Nem lehet megjeleníteni - speciális fájl."
 
 msgid "A file already exists with this name"
 msgstr "Már létezik ilyen nevű fájl."
@@ -1120,9 +1128,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Fájl bezárása"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "A Midnight Commander kilép.\n"
@@ -1563,15 +1571,13 @@ msgstr "Csere megerősítése"
 msgid "%ld replacements made"
 msgstr "%ld csere történt."
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Felhasználóbarát szövegszerkesztő\n"
 "a Midnight Commander-hez készítve"
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Névjegy"
@@ -1699,16 +1705,14 @@ msgstr "< Automatikus >"
 msgid "< Reload Current Syntax >"
 msgstr "< Aktuális szintaktika újratöltése >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "A(z) %s fájl nem megnyitható"
+
 msgid "Load syntax file"
 msgstr "Szintaxisfájl betöltése"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"A(z) %s fájl nem megnyitható\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1737,7 +1741,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Írjon \"exit\"-et a Midnight Commanderbe való visszatéréshez."
 
 msgid "Set &all"
@@ -1768,26 +1773,33 @@ msgstr ""
 msgid "Chown advanced command"
 msgstr "Chmod-Chown parancs"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"\"%s\" jogai nem állíthatók\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"\"%s\" tulaja nem állítható\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "\"%s\" jogai nem állíthatók\n"
 "%s"
 
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
-msgstr "Új&ra"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "\"%s\" tulaja nem állítható\n"
@@ -1804,6 +1816,20 @@ msgstr "Futtatás:"
 
 msgid "Stopped"
 msgstr "Megállítva"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Nincs konverzió >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Beviteli/kijelzési kódlap:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "So&ha"
@@ -1882,17 +1908,6 @@ msgstr "Auto &Beállításmentés"
 
 msgid "Configure options"
 msgstr "Alapbeállítások"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Nincs konverzió >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Beviteli/kijelzési kódlap:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr ""
@@ -2088,12 +2103,13 @@ msgstr "&Töröl"
 msgid "Background jobs"
 msgstr "Háttérfolyamatok"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"Célkönyvtár \"%s\" tulajdonosa nem beállítható \n"
+"%s"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2182,17 +2198,27 @@ msgstr "Jel. &ki"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
+"A(z) \"%s\" adatai nem lekérdezhetők \n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"A tar-archívum nem nyitható meg\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Nem sikerült értelmezni:"
 
 msgid "set &user ID on execution"
 msgstr "&felhasználó-azonosító beállítása végrehajtáskor"
@@ -2294,13 +2320,21 @@ msgstr "\"%s\" linkelése ide:"
 msgid "Link"
 msgstr "Link"
 
-#, c-format
-msgid "link: %s"
-msgstr "link: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Nem sikerült létrehozni a cél szim-linket \"%s\"\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "szimbolikus link: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Ciklikus szimbolikus linket nem lehet átmásolni: \n"
+"\"%s\""
 
 msgid "View file"
 msgstr "Fájl megjelenítése"
@@ -2322,6 +2356,12 @@ msgstr "Új könyvtár létrehozása"
 
 msgid "Enter directory name:"
 msgstr "Könyvtár neve:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "A(z) %s könyvtár nem létrehozható"
 
 msgid "Extension file edit"
 msgstr "Kiterjesztésfájl szerkesztése"
@@ -2371,12 +2411,16 @@ msgstr "A \"%s\" szimbolikus link ide mutasson:"
 msgid "Edit symlink"
 msgstr "Szimb. link módosítása"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "\"%s\" törlése nem sikerült: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "szimbolikus link módosítása: %s"
 
 msgid "FTP to machine"
@@ -2418,10 +2462,8 @@ msgstr "Távoli fájlrendszeren nem lehet végrehajtani a parancsokat"
 msgid "Parameter"
 msgstr "Paraméter"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Nem sikerült ideiglenes parancsfájlt létrehozni\n"
 "%s"
@@ -2432,7 +2474,7 @@ msgstr "Cső-hiba"
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2442,7 +2484,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2497,25 +2539,25 @@ msgstr "fájl/könyvtár"
 msgid " with source mask:"
 msgstr " az alábbi maszkkal:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"A(z) \"%s\" forrásfájl adatai nem elérhetők \n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
+"Nem sikerült létrehozni a cél szim-linket \"%s\"\n"
+"%s"
 
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Nem sikerült olvasni a forráslinket (\"%s\")\n"
@@ -2527,9 +2569,9 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Nem sikerült létrehozni a cél szim-linket \"%s\"\n"
@@ -2558,21 +2600,31 @@ msgstr ""
 "\"%s\" \n"
 "ugyanaz a fájl"
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "Új&ra"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "\"%s\" könyvtár nem üres.   \n"
 "Törölni kívánja az alkönyvtáraival együtt?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "\"%s\" könyvtár nem üres.   \n"
@@ -2581,17 +2633,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "&Egyiket sem"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "A(z) \"%s\" fájl nem törölhető \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "A(z) \"%s\" fájl adatai nem lekérdezhetők \n"
@@ -2601,103 +2653,110 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "A(z) \"%s\" könyvtár nem felülírható"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"A(z) \"%s\" fájl nem átnevezhető/mozgatható erre: \"%s\"\n"
+"A(z) \"%s\" fájl nem törölhető \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "A(z) \"%s\" könyvtár nem törölhető \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "A(z) \"%s\" könyvtár nem felülírható"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"A(z) \"%s\" könyvtár nem felülírható \n"
-"%s"
+msgstr "A(z) \"%s\" könyvtár nem felülírható"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "A(z) \"%s\" fájl nem felülírható\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"A(z) \"%s\" könyvtár nem átnevezhető/mozgatható erre: \"%s\" \n"
+"A(z) \"%s\" könyvtár nem törölhető \n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "A \"..\" könyvtárral ez nem lehetséges!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "A(z) \"%s\" forrásfájl adatai nem elérhetők \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"A(z) \"%s\" forrásfájl adatai nem elérhetők \n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Nem sikerült lekérdezni a(z) \"%s\" \n"
+"célfájl adatait. \n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Nem sikerült létrehozni a(z) \"%s\"\n"
 "speciális fájlt. \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "A(z) \"%s\" célfájl tulajdonosa nem állítható \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "A(z) \"%s\" célfájl jogai nem állíthatók \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "A(z) \"%s\" forrásfájl nem megnyitható \n"
@@ -2706,51 +2765,51 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "A pozicionálás nem sikerült, a célfájl felülíódik."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Nem sikerült lekérdezni a(z) \"%s\" \n"
 "forrásfájl adatait. \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Nem sikerült létrehozni a(z) \"%s\" célfájlt. \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Nem sikerült lekérdezni a(z) \"%s\" \n"
 "célfájl adatait. \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "%s célfájl számára nem foglalható le hely:\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "\"%s\" forrásfájl olvasása sikertelen \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Nem sikerült írni a(z) \"%s\" célfájlt. \n"
@@ -2768,42 +2827,47 @@ msgstr "&Megtartás"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Nem sikerült lezárni a(z) \"%s\" forrásfájlt. \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Nem sikerült lezárni a(z) \"%s\" célfájlt. \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"%s célfájl számára nem foglalható le hely:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Nem sikerült lekérdezni a(z) \"%s\" \n"
 "forráskönyvtár adatait. \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Nem sikerült lekérdezni a(z) \"%s\" \n"
+"forráskönyvtár adatait. \n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2821,25 +2885,27 @@ msgstr ""
 "Ciklikus szimbolikus linket nem lehet átmásolni: \n"
 "\"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "A cél (\"%s\") csak könyvtár lehet. \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Célkönyvtár \"%s\" nem létrehozható \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Célkönyvtár \"%s\" tulajdonosa nem beállítható \n"
@@ -3167,11 +3233,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Valóban ki szeretne lépni a Midnight Commanderből?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Biztosan futtatni kívánja a programot?"
 
 msgid "&Above"
 msgstr "Fe&nt"
@@ -3668,11 +3732,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3712,6 +3774,15 @@ msgid ""
 "%s"
 msgstr ""
 "Nem sikerült lekérdezni a célobjektum adatait. \n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"A cél (\"%s\") csak könyvtár lehet. \n"
 "%s"
 
 #, c-format
@@ -3836,8 +3907,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "A Home könyvtár elérési útja nem abszolút"
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4520,8 +4592,9 @@ msgstr "A fájl módosult. Menti kilépéskor?"
 msgid "&Cancel quit"
 msgstr "&Mégsem lép ki"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "A Midnight Commander kilép.\n"
@@ -4572,10 +4645,7 @@ msgstr "NemForm"
 msgid "ButtonBar|Format"
 msgstr "Formáz"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4599,22 +4669,22 @@ msgstr ""
 msgid "View: "
 msgstr "Megnéz: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"A(z) \"%s\" fájl nem megnyitható \n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Nem lehet megjeleníteni - speciális fájl."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
+"A tar-archívum nem nyitható meg\n"
+"%s"
 
 msgid "Search done"
 msgstr "Keresés kész"
@@ -4624,6 +4694,67 @@ msgstr "Folytatás az elejéről?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Nem sikerült behozni /ftp://some.host/editme.txt helyi másolatát"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Valóban ki szeretne lépni a Midnight Commanderből?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "A(z) \"%s\" fájl nem megnyitható olvasásra"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Méret/hozzáférés lekérdezése nem sikerült: %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "A cső nem megnyitható írásra: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Nem lehet elmenteni - a cél egy speciális fájl"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "A(z) %s fájl nem megnyitható\n"
+#~ "%s"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "link: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "szimbolikus link: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "A(z) \"%s\" fájl nem átnevezhető/mozgatható erre: \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "A(z) \"%s\" könyvtár nem felülírható \n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "A(z) \"%s\" könyvtár nem átnevezhető/mozgatható erre: \"%s\" \n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Egyéb 8 bites"

--- a/po/ia.po
+++ b/po/ia.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Interlingua (http://app.transifex.com/mc/mc/language/ia/)\n"
@@ -50,6 +50,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -735,10 +738,10 @@ msgstr ""
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[iste_dir] [altere_dir_de_pannello]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -809,28 +812,23 @@ msgstr "Cercar"
 msgid "Search is disabled"
 msgstr "Le recerca es disactivate"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Impossibile crear file diff temporari\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Impossibile crear copia de reserva\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Impossibile crear file de fusionamento temporari\n"
 "%s"
@@ -901,16 +899,19 @@ msgstr "ButtonBar|Optiones"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Quitar"
 
-msgid "Quit"
-msgstr "Quitar"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
+"Midnight Commander essera ora claudite.\n"
+"Salveguardar le file modificate?"
+
+msgid "Quit"
+msgstr "Quitar"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -918,15 +919,17 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"%s\n"
+"is a directory"
+msgstr "Monstrar directorio de datos"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat\n"
 "%s"
-msgstr ""
+msgstr "Non pote processar:"
 
 msgid "Diff viewer: invalid mode"
 msgstr ""
@@ -941,9 +944,11 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Impossibile aperir %s pro lectura"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr "Le file %s non pote esser aperite"
 
 msgid "Load file"
 msgstr ""
@@ -952,12 +957,10 @@ msgstr ""
 msgid "Error reading %s"
 msgstr "Error legente %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Impossibile obtener dimension/permissiones pro %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" non es un file regular"
 
 #, c-format
@@ -973,8 +976,10 @@ msgstr "Advertimento"
 msgid "Error reading from pipe: %s"
 msgstr "Error de lectura ab tubo: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Impossibile aperir tubo pro lectura: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -987,13 +992,12 @@ msgstr "Le file ha essite modificate intertanto. Salveguardar nonobstante?"
 msgid "Error writing to pipe: %s"
 msgstr "Error de scriptura al tubo: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Impossibile aperir tubo pro scriptura: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
-msgstr ""
 
 msgid "The file you are saving does not end with a newline."
 msgstr ""
@@ -1037,8 +1041,12 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "\"%s\" non es un file regular"
 
 msgid "A file already exists with this name"
 msgstr "Il ja existe un file con iste nomine"
@@ -1095,11 +1103,13 @@ msgstr ""
 msgid "Close file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
+"Midnight Commander essera ora claudite.\n"
+"Salveguardar le file modificate?"
 
 msgid "This function is not implemented"
 msgstr "Iste function non es implementate"
@@ -1533,12 +1543,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1667,13 +1675,13 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Recargar syntaxe actual >"
 
-msgid "Load syntax file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr "Le file %s non pote esser aperite"
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1699,7 +1707,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1732,24 +1741,27 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%s"
+msgstr "Le file %s non pote esser aperite"
 
 msgid "< Default >"
 msgstr ""
@@ -1762,6 +1774,18 @@ msgstr ""
 
 msgid "Stopped"
 msgstr "Stoppate"
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Nunquam"
@@ -1840,15 +1864,6 @@ msgstr ""
 
 msgid "Configure options"
 msgstr "Configurar optiones"
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr ""
@@ -2041,12 +2056,11 @@ msgstr ""
 msgid "Background jobs"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
-msgstr ""
+msgstr "Crear un nove directorio"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2135,17 +2149,25 @@ msgstr ""
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
-msgstr ""
+"Cannot chattr\n"
+"%sn%s"
+msgstr "Non pote processar:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Impossibile aperir archivo tar\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Non pote processar:"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2247,13 +2269,22 @@ msgstr ""
 msgid "Link"
 msgstr ""
 
-#, c-format
-msgid "link: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
+"Impossibile crear copia de reserva\n"
+"%s%s\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
+"Impossibile crear file diff temporari\n"
+"%s"
 
 msgid "View file"
 msgstr ""
@@ -2275,6 +2306,14 @@ msgstr "Crear un nove directorio"
 
 msgid "Enter directory name:"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr ""
+"Impossibile crear file diff temporari\n"
+"%s"
 
 msgid "Extension file edit"
 msgstr ""
@@ -2323,11 +2362,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2367,11 +2410,11 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
+"Impossibile crear file diff temporari\n"
+"%s"
 
 msgid "Pipe failed"
 msgstr "Tubo fallite"
@@ -2379,7 +2422,7 @@ msgstr "Tubo fallite"
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2389,7 +2432,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2444,27 +2487,29 @@ msgstr "files/directorios"
 msgid " with source mask:"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"Impossibile crear file de fusionamento temporari\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
+"Impossibile crear file de fusionamento temporari\n"
+"%s"
 
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
+"Impossibile aperir archivo tar\n"
+"%s"
 
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
@@ -2472,11 +2517,13 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
+"Impossibile crear file de fusionamento temporari\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2494,160 +2541,193 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 msgid "Non&e"
 msgstr "Nul&le"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
-msgstr ""
+msgstr "Le file %s non pote esser aperite"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
-msgstr ""
+msgstr "Le file non pote esser salveguardate"
 
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
+"%s"
+msgstr "Le file %s non pote esser aperite"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot remove directory\n"
+"%s"
+msgstr "Attention: impossibile aperir directorio %s\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
+"Impossibile aperir le archivo cpio\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot overwrite directory\n"
+"%s"
+msgstr "Attention: impossibile aperir directorio %s\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot overwrite file\n"
+"%s"
+msgstr "Le file %s non pote esser aperite"
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot enter into directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot overwrite directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot overwrite file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
-msgstr ""
+msgstr "Le file non pote esser salveguardate"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Impossibile crear file de fusionamento temporari\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Impossibile crear file de fusionamento temporari\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
+"Impossibile crear copia de reserva\n"
+"%s%s\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
+"Impossibile aperir archivo tar\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
-msgstr ""
+msgstr "Le file %s non pote esser aperite"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
-msgstr ""
+msgstr "Le file %s non pote esser aperite"
 
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
-msgstr ""
+msgstr "Le file non pote esser salveguardate"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
+"Impossibile crear file de fusionamento temporari\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
+"Impossibile crear file de fusionamento temporari\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
+"Impossibile crear file de fusionamento temporari\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
-msgstr ""
+msgstr "Le file %s non pote esser aperite"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
+"Impossibile crear file de fusionamento temporari\n"
+"%s"
 
 msgid "(stalled)"
 msgstr ""
@@ -2661,33 +2741,37 @@ msgstr ""
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
+"%s"
+msgstr "Le file %s non pote esser aperite"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot close target file\n"
 "%s"
 msgstr ""
+"Impossibile crear file de fusionamento temporari\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot set ext2 attributes for target file\n"
+"%s"
+msgstr ""
+"Impossibile crear file de fusionamento temporari\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat source directory\n"
+"%s"
+msgstr "Attention: impossibile aperir directorio %s\n"
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot stat source directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2705,21 +2789,27 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
+"Impossibile crear file de fusionamento temporari\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
+"Impossibile aperir archivo tar\n"
+"%s"
 
 #, c-format
 msgid "Directories: %zu, total size: %s"
@@ -3042,10 +3132,7 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3539,11 +3626,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3579,6 +3664,13 @@ msgstr "Displaciar le directorio \"%s\" a:"
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3681,8 +3773,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4358,8 +4451,9 @@ msgstr "Le file ha essite modificate. Salveguardar ante exir?"
 msgid "&Cancel quit"
 msgstr ""
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander essera ora claudite.\n"
@@ -4410,10 +4504,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4432,20 +4523,22 @@ msgstr ""
 msgid "View: "
 msgstr "Vide:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
+msgstr "\"%s\" non es un file regular"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
-
-msgid "Cannot view: not a regular file"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Impossibile aperir archivo tar\n"
 "%s"
-msgstr ""
 
 msgid "Search done"
 msgstr ""
@@ -4455,3 +4548,11 @@ msgstr "Continuar ab initio?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Impossibile aperir %s pro lectura"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Impossibile obtener dimension/permissiones pro %s"

--- a/po/id.po
+++ b/po/id.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Indonesian (http://app.transifex.com/mc/mc/language/id/)\n"
@@ -51,6 +51,9 @@ msgstr "Gagal membuat group '%s' untuk events!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Gagal membuat event '%s'!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -743,10 +746,10 @@ msgstr ""
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[this_dir] [other_panel_dir]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -817,28 +820,23 @@ msgstr "Pencarian"
 msgid "Search is disabled"
 msgstr "Pencarian dinon aktifkan"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Gagal membuat temporary diff file\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Gagal membuat backup file\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Gagal membuat temporary merge file\n"
 "%s"
@@ -909,18 +907,19 @@ msgstr "ButtonBar|Opsi"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Keluar"
 
-msgid "Quit"
-msgstr "Keluar"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "File(s) telah dirubah. Simpan saat keluar?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander sedang dimatikan.\n"
 "Simpan file yang sudah dirubah?"
+
+msgid "Quit"
+msgstr "Keluar"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -928,13 +927,15 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" adalah directory"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Gagal stat \"%s\"\n"
@@ -953,9 +954,13 @@ msgstr "Memuat: %3d%%"
 msgid "Loading..."
 msgstr "Memuat..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Gagal membuka %s untuk dibaca"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Tak bisa membuka arsip cpio\n"
+"%s"
 
 msgid "Load file"
 msgstr "Memuat file"
@@ -964,12 +969,10 @@ msgstr "Memuat file"
 msgid "Error reading %s"
 msgstr "Kesalahan membaca %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Gagal mendapatkan ukuran/ijin untuk %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" bukan regular file"
 
 #, c-format
@@ -987,9 +990,11 @@ msgstr "Peringatan"
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
+msgstr "Gagal membuka %s untuk dibaca"
 
 msgid "File has hard-links. Detach before saving?"
 msgstr ""
@@ -1001,13 +1006,12 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
+msgstr "Gagal membuka %s untuk dibaca"
 
 msgid "The file you are saving does not end with a newline."
 msgstr ""
@@ -1051,8 +1055,12 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "\"%s\" bukan regular file"
 
 msgid "A file already exists with this name"
 msgstr ""
@@ -1109,11 +1117,13 @@ msgstr ""
 msgid "Close file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
+"Midnight Commander sedang dimatikan.\n"
+"Simpan file yang sudah dirubah?"
 
 msgid "This function is not implemented"
 msgstr ""
@@ -1547,12 +1557,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1681,13 +1689,15 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Reload Current Syntax >"
 
-msgid "Load syntax file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+"Tak bisa membuka arsip cpio\n"
+"%s"
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1713,7 +1723,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1746,22 +1757,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1775,6 +1789,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1853,15 +1879,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2055,12 +2072,11 @@ msgstr ""
 msgid "Background jobs"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
-msgstr ""
+msgstr "Tidak bisa membuat direktori %s"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2149,17 +2165,25 @@ msgstr ""
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
+"Gagal stat \"%s\"\n"
+"%s"
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Gagal mengurai:"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2261,13 +2285,19 @@ msgstr ""
 msgid "Link"
 msgstr ""
 
-#, c-format
-msgid "link: %s"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr "Tidak bisa membuat direktori %s"
 
-#, c-format
-msgid "symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
+"Gagal membuat temporary diff file\n"
+"%s"
 
 msgid "View file"
 msgstr ""
@@ -2289,6 +2319,12 @@ msgstr ""
 
 msgid "Enter directory name:"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Tidak bisa membuat direktori %s"
 
 msgid "Extension file edit"
 msgstr ""
@@ -2337,12 +2373,18 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
+"Gagal stat \"%s\"\n"
+"%s"
 
 msgid "FTP to machine"
 msgstr ""
@@ -2381,11 +2423,11 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
+"Gagal membuat temporary diff file\n"
+"%s"
 
 msgid "Pipe failed"
 msgstr "Pipa gagal"
@@ -2393,7 +2435,7 @@ msgstr "Pipa gagal"
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2403,7 +2445,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2458,27 +2500,29 @@ msgstr ""
 msgid " with source mask:"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
+"Tak bisa membuka arsip cpio\n"
+"%s"
 
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
@@ -2486,11 +2530,13 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2508,160 +2554,210 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 msgid "Non&e"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
+"Gagal stat \"%s\"\n"
+"%s"
 
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
+"Gagal membuat backup file\n"
+"%s%s\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
-msgstr ""
+msgstr "Tidak bisa membuat direktori %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Tidak bisa membuat direktori %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
+msgstr "Tidak bisa membuat direktori %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary diff file\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
-msgstr ""
+msgstr "Tidak bisa membuat direktori %s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
+"Gagal stat \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
+"Gagal membuat backup file\n"
+"%s%s\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
+"Tak bisa membuka arsip cpio\n"
+"%s"
 
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
+"Gagal stat \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
 msgid "(stalled)"
 msgstr ""
@@ -2675,35 +2771,41 @@ msgstr ""
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
+"Tak bisa membuka arsip cpio\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Gagal membuat temporary merge file\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
-msgstr ""
+msgstr "Tidak bisa membuat direktori %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
-msgstr ""
+msgstr "Tidak bisa membuat direktori %s"
 
 #, c-format
 msgid ""
@@ -2719,21 +2821,23 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
-msgstr ""
+msgstr "Tidak bisa membuat direktori %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
-msgstr ""
+msgstr "Tidak bisa membuat direktori %s"
 
 #, c-format
 msgid "Directories: %zu, total size: %s"
@@ -3055,10 +3159,7 @@ msgid "You have %zu opened screen. Quit anyway?"
 msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3549,11 +3650,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3589,6 +3688,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3691,8 +3797,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4346,10 +4453,13 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
+"Midnight Commander sedang dimatikan.\n"
+"Simpan file yang sudah dirubah?"
 
 msgid "&Line number"
 msgstr ""
@@ -4396,10 +4506,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4418,20 +4525,22 @@ msgstr ""
 msgid "View: "
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
+msgstr "\"%s\" bukan regular file"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
-
-msgid "Cannot view: not a regular file"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Tak bisa membuka arsip cpio\n"
 "%s"
-msgstr ""
 
 msgid "Search done"
 msgstr ""
@@ -4441,3 +4550,7 @@ msgstr ""
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Gagal mendapatkan ukuran/ijin untuk %s"

--- a/po/ie.po
+++ b/po/ie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Interlingue (http://app.transifex.com/mc/mc/language/ie/)\n"
@@ -46,6 +46,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -725,7 +728,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -791,23 +794,16 @@ msgstr "Serchar"
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -876,16 +872,17 @@ msgstr "Optnes"
 msgid "ButtonBar|Quit"
 msgstr "Surtir"
 
-msgid "Quit"
-msgstr "Surtir"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
+
+msgid "Quit"
+msgstr "Surtir"
 
 msgid "Diff:"
 msgstr ""
@@ -893,15 +890,17 @@ msgstr ""
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" es un directoria"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
-msgstr ""
+msgstr "Ne successat analisar:"
 
 msgid "Diff viewer: invalid mode"
 msgstr ""
@@ -916,9 +915,13 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#, c-format
-msgid "Cannot open %s for reading"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
+"chown \"%s\" ne successat\n"
+"%s"
 
 msgid "Load file"
 msgstr ""
@@ -927,12 +930,10 @@ msgstr ""
 msgid "Error reading %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" ne es un regulari file"
 
 #, c-format
@@ -948,9 +949,13 @@ msgstr "Avise"
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
+"Ne successat aperter li archive cpio\n"
+"%s"
 
 msgid "File has hard-links. Detach before saving?"
 msgstr ""
@@ -963,11 +968,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1012,8 +1016,12 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "\"%s\" ne es un regulari file"
 
 msgid "A file already exists with this name"
 msgstr ""
@@ -1072,7 +1080,7 @@ msgstr "Cluder li file"
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1508,12 +1516,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1642,13 +1648,15 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+"Ne successat aperter li archive cpio\n"
+"%s"
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1674,7 +1682,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1705,26 +1714,33 @@ msgstr ""
 msgid "Chown advanced command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"chmod \"%s\" ne successat\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"chown \"%s\" ne successat\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "chmod \"%s\" ne successat\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignorar"
-
-msgid "Ignore &all"
-msgstr "Ignorar &omni"
-
-msgid "&Retry"
-msgstr "&Repenar"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "chown \"%s\" ne successat\n"
@@ -1740,6 +1756,19 @@ msgid "Running"
 msgstr "Executente"
 
 msgid "Stopped"
+msgstr ""
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Null translation >"
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1818,16 +1847,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Null translation >"
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2024,7 +2043,6 @@ msgstr "Taches in funde"
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2115,17 +2133,25 @@ msgstr ""
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
+"chmod \"%s\" ne successat\n"
+"%s"
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Ne successat analisar:"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2228,12 +2254,16 @@ msgid "Link"
 msgstr "Ligament"
 
 #, c-format
-msgid "link: %s"
-msgstr "ligament: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
 
 #, c-format
-msgid "symlink: %s"
-msgstr "sim. lig.: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
 
 msgid "View file"
 msgstr ""
@@ -2255,6 +2285,12 @@ msgstr ""
 
 msgid "Enter directory name:"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Comparar directorias"
 
 msgid "Extension file edit"
 msgstr ""
@@ -2303,12 +2339,18 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
+"chmod \"%s\" ne successat\n"
+"%s"
 
 msgid "FTP to machine"
 msgstr ""
@@ -2347,10 +2389,7 @@ msgstr ""
 msgid "Parameter"
 msgstr "Parametre"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2359,7 +2398,7 @@ msgstr "pipe ne successat"
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2369,7 +2408,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2426,25 +2465,23 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
+"Ne successat aperter li archive cpio\n"
+"%s"
 
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
@@ -2454,7 +2491,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2474,34 +2511,46 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr "&Ignorar"
+
 msgid "Ignore a&ll"
 msgstr ""
 
+msgid "&Retry"
+msgstr "&Repenar"
+
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 msgid "Non&e"
 msgstr "N&ull"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
+"chmod \"%s\" ne successat\n"
+"%s"
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2509,123 +2558,145 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
+"chmod \"%s\" ne successat\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot remove directory\n"
+"%s"
+msgstr "Hem-directoria:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot enter into directory\n"
+"%s"
+msgstr ""
+"Ne successat aperter li archive cpio\n"
+"%s"
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
-msgstr ""
+msgstr "Superscrir omni files?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-
-#, c-format
-msgid ""
-"Cannot overwrite file \"%s\"\n"
+"chmod \"%s\" ne successat\n"
 "%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
-"%s"
-msgstr ""
 
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
+#, fuzzy, c-format
+msgid ""
+"Cannot stat source file\n"
+"%s"
+msgstr ""
+"Ne successat aperter li archive cpio\n"
+"%s"
+
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
+"Ne successat aperter li archive cpio\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
+"chown \"%s\" ne successat\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
+"chmod \"%s\" ne successat\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
-
-#, c-format
-msgid ""
-"Cannot open source file \"%s\"\n"
+"Ne successat aperter li archive cpio\n"
 "%s"
-msgstr ""
 
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
+"Ne successat aperter li archive cpio\n"
+"%s"
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2641,33 +2712,37 @@ msgstr "&Retener"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
+"Ne successat aperter li archive cpio\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot close target file\n"
+"%s"
+msgstr ""
+"Ne successat aperter li archive cpio\n"
+"%s"
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
-msgstr ""
+msgstr "Comparar directorias"
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2685,21 +2760,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
+"chown \"%s\" ne successat\n"
+"%s"
 
 #, c-format
 msgid "Directories: %zu, total size: %s"
@@ -3022,10 +3101,7 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3519,11 +3595,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3559,6 +3633,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3661,8 +3742,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4316,8 +4398,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4366,10 +4449,7 @@ msgstr "SinFmt"
 msgid "ButtonBar|Format"
 msgstr "Format"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4388,20 +4468,22 @@ msgstr ""
 msgid "View: "
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
+msgstr "\"%s\" ne es un regulari file"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
-
-msgid "Cannot view: not a regular file"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Ne successat aperter li archive cpio\n"
 "%s"
-msgstr ""
 
 msgid "Search done"
 msgstr ""
@@ -4411,6 +4493,20 @@ msgstr ""
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignorar &omni"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "ligament: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "sim. lig.: %s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Altri 8-bit"

--- a/po/it.po
+++ b/po/it.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Italian (http://app.transifex.com/mc/mc/language/it/)\n"
@@ -56,6 +56,9 @@ msgstr "Non posso creare il gruppo \"%s\" per gli eventi!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Non posso creare l'evento \"%s\"!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr "Copyright (C) 1996-2025 the Free Software Foundation"
 
 #, c-format
 msgid ""
@@ -794,10 +797,10 @@ msgstr "file1 file2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[questa_dir] [dir_altro_pannello]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -868,28 +871,23 @@ msgstr "Cerca"
 msgid "Search is disabled"
 msgstr "Ricerca disabilitata"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Non posso creare file diff temporaneo\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Non posso creare il file di backup\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Non posso creare il file fusione temporaneo\n"
 "%s"
@@ -960,18 +958,19 @@ msgstr "Opzioni"
 msgid "ButtonBar|Quit"
 msgstr "Esci"
 
-msgid "Quit"
-msgstr "Esci"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "File modificati. Salvarli all'uscita?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander sta per essere chiuso.\n"
 "Salvare i file modificati?"
+
+msgid "Quit"
+msgstr "Esci"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -979,13 +978,15 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr "Il nome file è vuoto!"
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "%s  è una directory"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Non posso ottenere info dal file \"%s\"\n"
@@ -1004,9 +1005,13 @@ msgstr "Caricamento: %3d%%"
 msgid "Loading..."
 msgstr "Caricamento..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Non posso aprire %s in lettura"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Non posso aprire il file \"%s\"\n"
+"%s"
 
 msgid "Load file"
 msgstr "Carica file"
@@ -1015,12 +1020,10 @@ msgstr "Carica file"
 msgid "Error reading %s"
 msgstr "Errore leggendo %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Non posso ottenere dimensioni/permessi per %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" non è un file normale"
 
 #, c-format
@@ -1038,8 +1041,10 @@ msgstr "Attenzione"
 msgid "Error reading from pipe: %s"
 msgstr "Errore leggendo dalla pipe: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Non posso aprire la pipe in lettura: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1052,12 +1057,11 @@ msgstr "Il file è stato modificato nel frattempo. Salvare comunque?"
 msgid "Error writing to pipe: %s"
 msgstr "Errore scrivendo sulla pipe: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Non posso aprire la pipe in scrittura: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Non posso aprire il file in scrittura: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1102,8 +1106,12 @@ msgstr "Controllo nuova linea &POSIX"
 msgid "Edit Save Mode"
 msgstr "Modifica modalità salvataggio"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Non posso salvare: la destinazione non è un file normale"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Visualizzazione impossibile: non è un semplice file"
 
 msgid "A file already exists with this name"
 msgstr "Un file con lo stesso nome esiste già"
@@ -1162,9 +1170,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Chiudi il file"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander si sta chiudendo.\n"
@@ -1605,15 +1613,13 @@ msgstr "Conferma sostituzione"
 msgid "%ld replacements made"
 msgstr "Eseguite %ld sostituzioni"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Un semplice editor di testi\n"
 "scritto per il Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr "Copyright (C) 1996-2025 the Free Software Foundation"
 
 msgid "About"
 msgstr "Informazioni"
@@ -1741,16 +1747,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Ricarica la sintassi corrente >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Non posso aprire il file %s"
+
 msgid "Load syntax file"
 msgstr "Carica file sintassi"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Non posso aprire il file %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1781,7 +1785,8 @@ msgstr ""
 "Non è un xterm né una console Linux; \n"
 "la subshell non può essere commutata."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Battere 'exit' per tornare al Midnight Commander"
 
 msgid "Set &all"
@@ -1812,26 +1817,33 @@ msgstr "Permessi (ottale): %o"
 msgid "Chown advanced command"
 msgstr "Comando chown avanzato"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Non posso eseguire chmod su \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Non posso eseguire chown su \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Non posso eseguire chmod su \"%s\"\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignora"
-
-msgid "Ignore &all"
-msgstr "Ignor&a tutto"
-
-msgid "&Retry"
-msgstr "&Riprova"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Non posso eseguire chown su \"%s\"\n"
@@ -1848,6 +1860,20 @@ msgstr "Attivo "
 
 msgid "Stopped"
 msgstr "Sospeso "
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Non tradotto >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Ingresso / mostra codepage:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "Mai (&J)"
@@ -1926,17 +1952,6 @@ msgstr "Autosalva &configurazione"
 
 msgid "Configure options"
 msgstr "Configura opzioni"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Non tradotto >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Ingresso / mostra codepage:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Tema:"
@@ -2134,10 +2149,9 @@ msgstr "&Ferma"
 msgid "Background jobs"
 msgstr "Processi in background"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "Non posso cambiare cartella a\n"
@@ -2231,21 +2245,29 @@ msgstr "&Canc. marc."
 msgid "Chattr command"
 msgstr "Comando chattr"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Non posso chattr \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 "Impossibile ottenere gli attributi ext2 di \" 1%s \"\n"
 "1%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Non posso chattr \"%s\"\n"
+"%s"
 
 msgid "set &user ID on execution"
 msgstr "imposta &UID all'esecuzione"
@@ -2347,13 +2369,21 @@ msgstr "Collega %s a:"
 msgid "Link"
 msgstr "Collegamento"
 
-#, c-format
-msgid "link: %s"
-msgstr "collegamento: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Non posso creare il coll. simb. di dest. \"%s\"\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "colleg. simb.: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Non posso copiare un collegamento simbolico ciclico\n"
+"\"%s\""
 
 msgid "View file"
 msgstr "Mostra file"
@@ -2375,6 +2405,12 @@ msgstr "Crea una nuova directory"
 
 msgid "Enter directory name:"
 msgstr "Inserire nome directory:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Non posso creare la directory %s"
 
 msgid "Extension file edit"
 msgstr "Modifica file delle estensioni"
@@ -2424,12 +2460,16 @@ msgstr "Il coll. simb. \"%s\" punta a:"
 msgid "Edit symlink"
 msgstr "Modifica coll. simb."
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "modifica collegamento simb., impossibile rimuovere %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "modifica del collegamento simb.: %s"
 
 msgid "FTP to machine"
@@ -2471,10 +2511,8 @@ msgstr "Non posso eseguire comandi su filesystem non locali"
 msgid "Parameter"
 msgstr "Parametro"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Non posso creare file comandi temporaneo \n"
 "%s"
@@ -2482,23 +2520,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Pipe fallita"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "C'è il file %s che è obsoleto.\n"
 "Midnight Commander ora usa il file %s.\n"
 "Copiare le proprie impostazioni dal vecchio file al nuovo."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "Il formato del file\n"
 "%s%s\n"
@@ -2564,29 +2602,23 @@ msgstr "file/directory"
 msgid " with source mask:"
 msgstr " con maschera sorgente:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Non posso fare stat su coll. fisico file sorg. \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Non posso creare il coll. fisico di dest. \"%s\"\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Non posso creare il coll. fisico di dest. \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Non posso leggere il coll. sorg. \"%s\"\n"
@@ -2601,9 +2633,9 @@ msgstr ""
 "\n"
 "L'opzione coll. simbolici stabili sarà disabilitata"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Non posso creare il coll. simb. di dest. \"%s\"\n"
@@ -2633,21 +2665,31 @@ msgstr ""
 "\"%s\"\n"
 "sono lo stesso file"
 
+msgid "&Ignore"
+msgstr "&Ignora"
+
 msgid "Ignore a&ll"
 msgstr "Ignora t&utto"
 
-#, c-format
+msgid "&Retry"
+msgstr "&Riprova"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "La directory \"%s\" non è vuota.\n"
 "Eliminarla ricorsivamente?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Processo in background:\n"
@@ -2657,17 +2699,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Nessun&o"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Non posso rimuovere il file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Non posso fare stat del file \"%s\"\n"
@@ -2677,108 +2719,110 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Non posso sovrascrivere la cartella \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Non posso spostare il file \"%s\" in \"%s\" \n"
+"Non posso rimuovere il file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Non posso cancellare la directory \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 "Impossibile entrare nella cartella \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Non posso sovrascrivere la cartella \"%s\"\n"
-"%s"
+msgstr "Non posso sovrascrivere la cartella \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Non posso sovrascrivere il file \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Non posso spostare la cartella \"%s\" in \"%s\"\n"
+"Non posso cancellare la directory \"%s\"\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Non posso operare su \"..\"!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Non posso fare fstat sul file sorgente \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 "Impossibile ottenere gli attributi ext2 del file sorgente \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 "Impossibile impostare gli attributi ext2 del file obiettivo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Non posso creare il file speciale \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Non posso cambiare il proprietario del file destinazione: \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Non posso cambiare i permessi del file destinazione \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Non posso aprire il file sorgente \"%s\"\n"
@@ -2787,49 +2831,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Reget fallito, riscrittura file"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Non posso fare fstat sul file sorgente: \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Non posso creare il file destinazione \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Non posso fstat sul file destinazione \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Non posso preallocare lo spazio del file obiettivo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Non posso leggere il file sorgente \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Non posso scrivere il file destinazione \"%s\"\n"
@@ -2847,41 +2891,41 @@ msgstr "&Mantieni"
 msgid "&Continue copy"
 msgstr "&Continuare la copia"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Non posso chiudere il file sorgente \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Non posso chiudere il file destinazione \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 "Impossibile impostare gli attributi ext2 per il file obiettivo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Non posso ottenere info sulla cartella sorgente \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 "Impossibile ottenere gli attributi ext2 della cartella sorgente \"%s\"\n"
@@ -2903,25 +2947,27 @@ msgstr ""
 "Non posso copiare un collegamento simbolico ciclico\n"
 "\"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "La destinazione \"%s\" deve essere una directory\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Non posso creare la cartella destinazione \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Non posso cambiare proprietario della directory destinazione \"%s\"\n"
@@ -3250,11 +3296,9 @@ msgstr[0] "Hai %zu schermo aperto. Uscire comunque?"
 msgstr[1] "Hai %zu schermi aperti. Uscire comunque?"
 msgstr[2] "Hai %zu schermi aperti. Uscire comunque?"
 
-msgid "The Midnight Commander"
-msgstr "Il Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Vuoi veramente uscire dal Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Vuoi veramente eseguirlo?"
 
 msgid "&Above"
 msgstr "Sopr&a"
@@ -3756,11 +3800,10 @@ msgstr ""
 "Pannellizza esternamente:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Pannellizza esternamente:\n"
 "Fallita la lettura dati stdout processo figlio:\n"
@@ -3803,6 +3846,15 @@ msgid ""
 "%s"
 msgstr ""
 "Non posso ottenere info sulla destinazione\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"La destinazione \"%s\" deve essere una directory\n"
 "%s"
 
 #, c-format
@@ -3926,8 +3978,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Il percorso della directory home non è assoluto"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4644,8 +4697,9 @@ msgstr "Il file è stato modificato. Lo salvo uscendo?"
 msgid "&Cancel quit"
 msgstr "Annulla l'us&cita"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander si sta chiudendo.\n"
@@ -4696,10 +4750,8 @@ msgstr "NonForm"
 msgid "ButtonBar|Format"
 msgstr "Formatt"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Fallita la lettura dati stdout processo figlio:\n"
 "%s"
@@ -4725,20 +4777,18 @@ msgstr ""
 msgid "View: "
 msgstr "Mostra: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Non posso aprire il file \"%s\"\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Visualizzazione impossibile: non è un semplice file"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Non posso aprire \"%s\" in modalità analisi\n"
@@ -4752,6 +4802,78 @@ msgstr "Continuare dall'inizio?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Non posso ricevere copia locale di /ftp://un.host/modificami.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Il Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Vuoi veramente uscire dal Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Non posso aprire %s in lettura"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Non posso ottenere dimensioni/permessi per %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Non posso aprire la pipe in scrittura: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Non posso salvare: la destinazione non è un file normale"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Non posso aprire il file %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignor&a tutto"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "collegamento: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "colleg. simb.: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Non posso creare il coll. fisico di dest. \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Non posso spostare il file \"%s\" in \"%s\" \n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Non posso sovrascrivere la cartella \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Non posso spostare la cartella \"%s\" in \"%s\"\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Altre a 8 bit"

--- a/po/ja.po
+++ b/po/ja.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Takuro Onoue <kusanaginoturugi@gmail.com>, 2021\n"
 "Language-Team: Japanese (http://app.transifex.com/mc/mc/language/ja/)\n"
@@ -52,6 +52,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -740,7 +743,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -806,24 +809,23 @@ msgstr "検索"
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
-msgstr ""
+#, fuzzy
+msgid "Cannot create temporary diff file"
+msgstr "ディレクトリー %s が作成できません"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
+"ファイル %s に書き込めません:\n"
+"%s\n"
 
 msgid "&Fastest (Assume large files)"
 msgstr ""
@@ -891,16 +893,17 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr "終了"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
+
+msgid "Quit"
+msgstr "終了"
 
 msgid "Diff:"
 msgstr ""
@@ -908,15 +911,19 @@ msgstr ""
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"%s\n"
+"is a directory"
+msgstr "directory"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
 msgid "Diff viewer: invalid mode"
 msgstr ""
@@ -931,9 +938,13 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#, c-format
-msgid "Cannot open %s for reading"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
+"「%s」を開けません\n"
+"%s"
 
 msgid "Load file"
 msgstr ""
@@ -943,11 +954,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -963,9 +972,13 @@ msgstr "警告"
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
+"書き出しのために %s をオープンすることができません:\n"
+"%s\n"
 
 msgid "File has hard-links. Detach before saving?"
 msgstr ""
@@ -977,13 +990,14 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
-msgstr ""
+"書き出しのために %s をオープンすることができません:\n"
+"%s\n"
 
 msgid "The file you are saving does not end with a newline."
 msgstr ""
@@ -1027,8 +1041,12 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr "保存モードの編集"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "ファイルを保存できません"
 
 msgid "A file already exists with this name"
 msgstr ""
@@ -1087,7 +1105,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1524,12 +1542,10 @@ msgstr "置換の確認"
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1658,16 +1674,16 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr "文法ファイルの読み込み"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
 msgstr ""
 "ファイル %s が開けません\n"
 "%s"
+
+msgid "Load syntax file"
+msgstr "文法ファイルの読み込み"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1692,7 +1708,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1723,28 +1740,37 @@ msgstr ""
 msgid "Chown advanced command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"chmod \"%s\" ができません\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"chmod \"%s\" ができません\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "chmod \"%s\" ができません\n"
 "%s"
 
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
-msgstr "再試行(&R)"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
+"chmod \"%s\" ができません\n"
+"%s"
 
 msgid "< Default >"
 msgstr ""
@@ -1757,6 +1783,20 @@ msgstr "実行しています"
 
 msgid "Stopped"
 msgstr "停止中"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < 翻訳がありません >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "入力 / コードページを表示:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "一時停止しない(&N)"
@@ -1835,17 +1875,6 @@ msgstr "自動保存の設定(&U)"
 
 msgid "Configure options"
 msgstr "設定オプション"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < 翻訳がありません >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "入力 / コードページを表示:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr ""
@@ -2038,12 +2067,11 @@ msgstr "強制終了(&K)"
 msgid "Background jobs"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
-msgstr ""
+msgstr "ディレクトリー %s が作成できません"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2132,17 +2160,27 @@ msgstr "マークをクリア(&l)"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
+"chmod \"%s\" ができません\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"tarアーカイブ%sを\n"
+"開けません"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "構文解析が出来ません:"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2244,13 +2282,19 @@ msgstr ""
 msgid "Link"
 msgstr "リンク"
 
-#, c-format
-msgid "link: %s"
-msgstr "リンク: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
 #, c-format
-msgid "symlink: %s"
-msgstr "シンボリックリンク: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
 
 msgid "View file"
 msgstr ""
@@ -2272,6 +2316,12 @@ msgstr "新規ディレクトリの作成"
 
 msgid "Enter directory name:"
 msgstr "ディレクトリー名の入力:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "ディレクトリー %s が作成できません"
 
 msgid "Extension file edit"
 msgstr "拡張ファイルの編集"
@@ -2320,11 +2370,15 @@ msgid "Edit symlink"
 msgstr "シンボリックリンクの編集"
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "シンボリックリンクの編集: %s"
 
 msgid "FTP to machine"
@@ -2364,11 +2418,9 @@ msgstr ""
 msgid "Parameter"
 msgstr "パラメーター"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
-msgstr ""
+#, fuzzy
+msgid "Cannot create temporary command file"
+msgstr "sort コマンドを実行できません"
 
 msgid "Pipe failed"
 msgstr "パイプの受け渡しに失敗しました"
@@ -2376,7 +2428,7 @@ msgstr "パイプの受け渡しに失敗しました"
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2386,7 +2438,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2441,27 +2493,29 @@ msgstr "files/directories"
 msgid " with source mask:"
 msgstr " with source mask:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
+"tarアーカイブ%sを\n"
+"開けません"
 
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
+"tarアーカイブ%sを\n"
+"開けません"
 
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
@@ -2469,11 +2523,11 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
-msgstr ""
+msgstr "ディレクトリー %s が作成できません"
 
 #, c-format
 msgid ""
@@ -2491,160 +2545,210 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
 msgstr ""
 
+msgid "&Retry"
+msgstr "再試行(&R)"
+
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 msgid "Non&e"
 msgstr "なし(&E)"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
+"ファイル %s が開けません\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
-msgstr ""
+msgstr "ディレクトリー %s が作成できません"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "ディレクトリー %s が作成できません"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
+msgstr "ディレクトリー %s が作成できません"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
+"ファイル %s が開けません\n"
+"%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"ファイル %s に書き込めません:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"ファイル %s に書き込めません:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
+"ファイル %s が開けません\n"
+"%s"
 
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
+"ファイル %s に書き込めません:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
+"ファイル %s に書き込めません:\n"
+"%s\n"
 
 msgid "(stalled)"
 msgstr "(stalled)"
@@ -2658,35 +2762,41 @@ msgstr "保存(&K)"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
+"ファイルの保存ができません:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"ファイル %s に書き込めません:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
-msgstr ""
+msgstr "ディレクトリー %s が作成できません"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
-msgstr ""
+msgstr "ディレクトリー %s が作成できません"
 
 #, c-format
 msgid ""
@@ -2702,21 +2812,23 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
-msgstr ""
+msgstr "ディレクトリー %s が作成できません"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
-msgstr ""
+msgstr "ディレクトリー %s が作成できません"
 
 #, c-format
 msgid "Directories: %zu, total size: %s"
@@ -3038,11 +3150,9 @@ msgid "You have %zu opened screen. Quit anyway?"
 msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 
-msgid "The Midnight Commander"
-msgstr "The Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "本当に Midnight Commander を終了しますか?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "本当に実行しますか?"
 
 msgid "&Above"
 msgstr "上(&A)"
@@ -3532,11 +3642,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3574,6 +3682,13 @@ msgstr "ディレクトリ \"%s\" を移動:"
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3690,8 +3805,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4360,8 +4476,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4410,10 +4527,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4434,22 +4548,22 @@ msgstr ""
 msgid "View: "
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"「%s」を開けません\n"
-"%s"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
+msgstr "ファイルの挿入ができません"
 
-msgid "Cannot view: not a regular file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
+"tarアーカイブ%sを\n"
+"開けません"
 
 msgid "Search done"
 msgstr "検索終了"
@@ -4459,6 +4573,20 @@ msgstr "初めから続けますか?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "The Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "本当に Midnight Commander を終了しますか?"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "リンク: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "シンボリックリンク: %s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "別の 8bit"

--- a/po/ka.po
+++ b/po/ka.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>, 2022\n"
 "Language-Team: Georgian (http://app.transifex.com/mc/mc/language/ka/)\n"
@@ -50,6 +50,9 @@ msgstr "მოვლენებისთვის ჯგუფის შექ�
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -733,7 +736,7 @@ msgstr "[this_dir] [other_panel_dir]"
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -799,24 +802,19 @@ msgstr "ძებნა"
 msgid "Search is disabled"
 msgstr "ძებნა გათიშულია"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
-msgstr ""
+#, fuzzy
+msgid "Cannot create temporary diff file"
+msgstr "საქაღალდე %s-ის შექმნა შეუძლებელია"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
-msgstr ""
+"%s~~~"
+msgstr "ფაილის ნაკადის შექმნა შეუძლებელია"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
-msgstr ""
+#, fuzzy
+msgid "Cannot create temporary merge file"
+msgstr "ფაიფის დესკრიპტორის შექმნა შეუძლებელია"
 
 msgid "&Fastest (Assume large files)"
 msgstr ""
@@ -884,16 +882,17 @@ msgstr "პარამ"
 msgid "ButtonBar|Quit"
 msgstr "გასვლა"
 
-msgid "Quit"
-msgstr "გამოსვლა"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
+
+msgid "Quit"
+msgstr "გამოსვლა"
 
 msgid "Diff:"
 msgstr "განსხვავება:"
@@ -901,15 +900,17 @@ msgstr "განსხვავება:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" საქაღალდეა"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
-msgstr ""
+msgstr "დამუშავება შეუძლებელია:"
 
 msgid "Diff viewer: invalid mode"
 msgstr ""
@@ -924,9 +925,11 @@ msgstr "ჩატვირთვა: %3d%%"
 msgid "Loading..."
 msgstr "ჩატვირთვა..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "%s-ის წაკითხვის შეცდომა"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr "%s ფაილის გახსნა ვერ მოხერხდა"
 
 msgid "Load file"
 msgstr "ფაილის ჩატვირთვა"
@@ -935,12 +938,10 @@ msgstr "ფაილის ჩატვირთვა"
 msgid "Error reading %s"
 msgstr "%s-ის კითხვის შეცდომა"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" ჩვეულებრივი ფაილი არაა"
 
 #, c-format
@@ -956,9 +957,11 @@ msgstr "გაფრთხილება"
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
+msgstr "%s-ის წაკითხვის შეცდომა"
 
 msgid "File has hard-links. Detach before saving?"
 msgstr ""
@@ -970,13 +973,12 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr "ფაიფში ჩაწერის შეცდომა: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
+msgstr "%s-ის წაკითხვის შეცდომა"
 
 msgid "The file you are saving does not end with a newline."
 msgstr ""
@@ -1020,8 +1022,12 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr "შენახვის რეჟიმის ჩასწორება"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "\"%s\" ჩვეულებრივი ფაილი არაა"
 
 msgid "A file already exists with this name"
 msgstr "ფაილი ამ სახელით უკვე არსებობს"
@@ -1080,7 +1086,7 @@ msgstr "ფაილის დაკეტვა"
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1517,12 +1523,10 @@ msgstr "ჩანაცვლების დადასტურება"
 msgid "%ld replacements made"
 msgstr "მოხდა %ld ჩანაცვლება"
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1651,16 +1655,14 @@ msgstr "< ავტომატური >"
 msgid "< Reload Current Syntax >"
 msgstr "< მიმდინარე სინტაქსის თავიდან ჩატვირთვა >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "%s ფაილის გახსნა ვერ მოხერხდა"
+
 msgid "Load syntax file"
 msgstr "სინტაქსის ფაილის ჩატვირთვა"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"ფაილის გახსნის შეცდომა %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1685,7 +1687,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1716,26 +1719,33 @@ msgstr "უფლებები (8-ბიტიანი): %o"
 msgid "Chown advanced command"
 msgstr "Chmod-ის დამატებითი პარამეტრები"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"\"%s\"-ის chmod_ის შეცდომა\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"\"%s\"-ის chown შეუძლებელია\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "\"%s\"-ის chmod_ის შეცდომა\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "იგნორი"
-
-msgid "Ignore &all"
-msgstr "ყველას იგნორირება"
-
-msgid "&Retry"
-msgstr "&თავიდან ცდა"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "\"%s\"-ის chown შეუძლებელია\n"
@@ -1752,6 +1762,18 @@ msgstr "გაშვებულია"
 
 msgid "Stopped"
 msgstr "შეჩერებულია"
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "არასოდეს"
@@ -1830,15 +1852,6 @@ msgstr "&პარამეტრების ავტომატური შ
 
 msgid "Configure options"
 msgstr "პარამეტრების მორგება"
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "გარეგნობა:"
@@ -2032,12 +2045,11 @@ msgstr "მოკვლა"
 msgid "Background jobs"
 msgstr "ფონური ამოცანები"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
-msgstr ""
+msgstr "საქაღალდე %s-ის შექმნა შეუძლებელია"
 
 msgid "Secure deletion"
 msgstr "უსაფრთხოდ წაშლა"
@@ -2126,17 +2138,25 @@ msgstr ""
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
+"\"%s\"-ის chmod_ის შეცდომა\n"
+"%s"
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "დამუშავება შეუძლებელია:"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2238,13 +2258,17 @@ msgstr "%s-ის მიბმა:"
 msgid "Link"
 msgstr "ბმული"
 
-#, c-format
-msgid "link: %s"
-msgstr "ბმული: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr "საქაღალდე %s-ის შექმნა შეუძლებელია"
 
 #, c-format
-msgid "symlink: %s"
-msgstr "სიმბმული: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
 
 msgid "View file"
 msgstr "ფაილის ჩვენება"
@@ -2266,6 +2290,12 @@ msgstr "ახალი საქაღალდის შექმნა"
 
 msgid "Enter directory name:"
 msgstr "შეიყვანეთ საქაღალდის სახელი:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "საქაღალდე %s-ის შექმნა შეუძლებელია"
 
 msgid "Extension file edit"
 msgstr ""
@@ -2314,11 +2344,15 @@ msgid "Edit symlink"
 msgstr "სიმბმულის ჩასწორება"
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "სიმბმულის ჩასწორება: %s"
 
 msgid "FTP to machine"
@@ -2358,10 +2392,7 @@ msgstr ""
 msgid "Parameter"
 msgstr "პარამეტრი"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2370,7 +2401,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2380,7 +2411,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2435,25 +2466,21 @@ msgstr "ფაილები/საქაღალდეები"
 msgid " with source mask:"
 msgstr " წყაროს ნიღბით:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
-msgstr ""
+msgstr "ფაილის ჩასმა ვერ მოხერხდა"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
+msgstr "ფაილის ნაკადის შექმნა შეუძლებელია"
 
 #, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2463,11 +2490,11 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
-msgstr ""
+msgstr "ფაილის ნაკადის შექმნა შეუძლებელია"
 
 #, c-format
 msgid ""
@@ -2485,162 +2512,182 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr "იგნორი"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "&თავიდან ცდა"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "საქაღალდე \"%s\"ცარიელი არაა.\n"
 "წავშალო რეკურსიულად?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
+"საქაღალდე \"%s\"ცარიელი არაა.\n"
+"წავშალო რეკურსიულად?"
 
 msgid "Non&e"
 msgstr "არცერთი"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
-msgstr ""
+msgstr "%s ფაილის გახსნა ვერ მოხერხდა"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
-msgstr ""
+msgstr "ფაილის შენახვა შეუძლებელია"
 
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
+"ფაილის გახსნის შეცდომა %s\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
-msgstr ""
+msgstr "საქაღალდე %s-ის შექმნა შეუძლებელია"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "საქაღალდე %s-ის შექმნა შეუძლებელია"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
+msgstr "საქაღალდე %s-ის შექმნა შეუძლებელია"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
-msgstr ""
+msgstr "%s ფაილის გახსნა ვერ მოხერხდა"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
+"ფაილის გახსნის შეცდომა %s\n"
+"%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
+#, fuzzy, c-format
+msgid ""
+"Cannot stat source file\n"
+"%s"
+msgstr "ფაილის შენახვა შეუძლებელია"
+
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
-msgstr ""
+msgstr "ფაილის ნაკადის შექმნა შეუძლებელია"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
-msgstr ""
+msgstr "%s ფაილის გახსნა ვერ მოხერხდა"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
-msgstr ""
+msgstr "%s ფაილის გახსნა ვერ მოხერხდა"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot open source file \"%s\"\n"
-"%s"
-msgstr ""
+msgstr "%s ფაილის გახსნა ვერ მოხერხდა"
 
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
-msgstr ""
+msgstr "ფაილის შენახვა შეუძლებელია"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create target file\n"
+"%s"
+msgstr "ფაილის ნაკადის შექმნა შეუძლებელია"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot fstat target file\n"
+"%s"
+msgstr "ფაილის შენახვა შეუძლებელია"
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
-msgstr ""
+msgstr "%s ფაილის გახსნა ვერ მოხერხდა"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot read source file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot write target file \"%s\"\n"
-"%s"
-msgstr ""
+msgstr "ფაილის ჩასმა ვერ მოხერხდა"
 
 msgid "(stalled)"
 msgstr "(დაეკიდა)"
@@ -2654,35 +2701,35 @@ msgstr "&შენარჩუნება"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
-msgstr ""
+msgstr "%s ფაილის გახსნა ვერ მოხერხდა"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot close target file\n"
+"%s"
+msgstr "ფაილის ჩასმა ვერ მოხერხდა"
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
-msgstr ""
+msgstr "საქაღალდე %s-ის შექმნა შეუძლებელია"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
-"%s"
-msgstr ""
+msgstr "საქაღალდე %s-ის შექმნა შეუძლებელია"
 
 #, c-format
 msgid ""
@@ -2698,21 +2745,23 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
-msgstr ""
+msgstr "საქაღალდე %s-ის შექმნა შეუძლებელია"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
-msgstr ""
+msgstr "საქაღალდე %s-ის შექმნა შეუძლებელია"
 
 #, c-format
 msgid "Directories: %zu, total size: %s"
@@ -3036,10 +3085,8 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "გაქვთ %zu ღია ეკრანი. მაინც გააგრძელებთ?"
 msgstr[1] "გაქვთ %zu ღია ეკრანი. მაინც გააგრძელებთ?"
 
-msgid "The Midnight Commander"
-msgstr "The Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
 msgstr "ნამდვილად გნებავთ Midnight Commander-დან გასვლა?"
 
 msgid "&Above"
@@ -3533,11 +3580,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3573,6 +3618,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3675,8 +3727,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4328,8 +4381,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr "&გასვლის გაუქმება"
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4378,10 +4432,7 @@ msgstr "დაუფორმ"
 msgid "ButtonBar|Format"
 msgstr "ფორმატი"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4400,20 +4451,22 @@ msgstr ""
 msgid "View: "
 msgstr "ნახვა: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
+msgstr "\"%s\" ჩვეულებრივი ფაილი არაა"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
-
-msgid "Cannot view: not a regular file"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"ფაილის გახსნის შეცდომა %s\n"
 "%s"
-msgstr ""
 
 msgid "Search done"
 msgstr "ძებნა დასრულდა"
@@ -4423,6 +4476,20 @@ msgstr "თავიდან დავიწყო?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "The Midnight Commander"
+
+#~ msgid "Ignore &all"
+#~ msgstr "ყველას იგნორირება"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "ბმული: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "სიმბმული: %s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "სხვა 8 ბიტიანი"

--- a/po/kk.po
+++ b/po/kk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Kazakh (http://app.transifex.com/mc/mc/language/kk/)\n"
@@ -48,6 +48,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -724,10 +727,10 @@ msgstr ""
 msgid "[this_dir] [other_panel_dir]"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -796,23 +799,16 @@ msgstr ""
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -881,15 +877,16 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr ""
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Diff:"
@@ -899,12 +896,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -922,7 +921,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -933,11 +934,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -954,7 +953,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -968,11 +969,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1017,7 +1017,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1077,7 +1081,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1513,12 +1517,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1647,13 +1649,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1679,7 +1681,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1712,22 +1715,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1741,6 +1747,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1819,15 +1837,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2024,7 +2033,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2117,13 +2125,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2228,11 +2242,15 @@ msgid "Link"
 msgstr ""
 
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2254,6 +2272,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2303,11 +2327,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2347,10 +2375,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2359,7 +2384,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2369,7 +2394,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2426,23 +2451,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2454,7 +2475,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2474,19 +2495,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2495,13 +2526,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2511,37 +2542,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2550,43 +2585,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2595,37 +2630,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2643,31 +2678,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2685,19 +2720,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3022,10 +3059,7 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3519,11 +3553,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3559,6 +3591,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3661,8 +3700,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4312,8 +4352,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4362,10 +4403,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4386,16 +4424,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Korean (http://app.transifex.com/mc/mc/language/ko/)\n"
@@ -56,6 +56,9 @@ msgstr "이벤트에 대한 '%s' 그룹을 생성할 수 없습니다!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "'%s' 이벤트를 생성할 수 없습니다!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -768,10 +771,10 @@ msgstr "파일1 파일2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[이_디렉터리] [다른_패널_디렉터리]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -842,28 +845,23 @@ msgstr "검색"
 msgid "Search is disabled"
 msgstr "검색이 비활성화되었습니다"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "%s\n"
 "임시 Diff 파일을 생성할 수 없음"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "%s%s\n"
 "%s\n"
 " 백업 파일을 생성할 수 없음"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "%s\n"
 "임시 병합 파일을 생성할 수 없음"
@@ -934,18 +932,19 @@ msgstr "옵션"
 msgid "ButtonBar|Quit"
 msgstr "종료"
 
-msgid "Quit"
-msgstr "종료"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "파일을 수정했습니다. 저장 후 나가시겠습니까?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "미드나잇 커맨더를 끝냅니다.\n"
 "수정한 파일을 저장하시겠습니까?"
+
+msgid "Quit"
+msgstr "종료"
 
 msgid "Diff:"
 msgstr "비교:"
@@ -953,13 +952,15 @@ msgstr "비교:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\"은(는) 디렉터리임"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "\"%s\"에 대한 상태\n"
@@ -978,9 +979,13 @@ msgstr "불러오는 중: %3d%%"
 msgid "Loading..."
 msgstr "불러오는 중..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "%s을(를) 열 수 없음"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"\"%s\"을(를) 열 수 없음\n"
+"%s"
 
 msgid "Load file"
 msgstr "파일 불러오기"
@@ -989,12 +994,10 @@ msgstr "파일 불러오기"
 msgid "Error reading %s"
 msgstr "%s을(를) 읽는 중 오류 발생"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "%s에 대한 크기/사용 권한을 가져올 수 없음"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\"가 일반 파일이 아님"
 
 #, c-format
@@ -1012,8 +1015,10 @@ msgstr "경고"
 msgid "Error reading from pipe: %s"
 msgstr "파이프에서 읽는 중 오류 발생: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "읽을 파이프를 열 수 없음: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1026,12 +1031,11 @@ msgstr "파일이 동시에 수정되었습니다. 그래도 저장하겠습니�
 msgid "Error writing to pipe: %s"
 msgstr "파이프에 쓰는 중 오류 발생: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "쓰기 위해 파이프를 열 수 없음: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "쓰기 위해 파일을 열 수 없음: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1076,8 +1080,12 @@ msgstr "POSIX 새 행 확인(&P)"
 msgid "Edit Save Mode"
 msgstr "저장 모드 편집"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "저장할 수 없음: 대상이 일반 파일이 아님"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "볼 수 없음: 일반 파일이 아님"
 
 msgid "A file already exists with this name"
 msgstr "이 이름의 파일이 이미 있음"
@@ -1136,9 +1144,9 @@ msgstr ""
 msgid "Close file"
 msgstr "파일 닫기"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "미드나잇 커맨더가 종료 중입니다.\n"
@@ -1579,15 +1587,13 @@ msgstr "바꾸기 확인"
 msgid "%ld replacements made"
 msgstr "%ld 교체"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "사용자 친화적인 텍스트 편집기\n"
 "미드나잇 커맨더를 위해 작성됨."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "소개"
@@ -1715,16 +1721,14 @@ msgstr "< 자동 >"
 msgid "< Reload Current Syntax >"
 msgstr "<현재 구문 새로 고침>"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "%s 파일을 열 수 없음"
+
 msgid "Load syntax file"
 msgstr "구문 파일 불러오기"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"%s 파일을 열 수 없음\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1754,7 +1758,8 @@ msgstr ""
 "xterm 또는 Linux 콘솔이 아닙니다.\n"
 "서브쉘은 토글할 수 없습니다."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "미드나잇 커맨더로 돌아가려면 'exit'를 입력하십시오."
 
 msgid "Set &all"
@@ -1785,26 +1790,33 @@ msgstr "사용권한 (octal): %o"
 msgid "Chown advanced command"
 msgstr "chown 고급 명령어"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"\"%s\"을(를) chmod할 수 없음\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"\"%s\"을(를) 선택할 수 없음\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "\"%s\"을(를) chmod할 수 없음\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "무시(&I)"
-
-msgid "Ignore &all"
-msgstr "모두 무시(&A)"
-
-msgid "&Retry"
-msgstr "재시도(&R)"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "\"%s\"을(를) 선택할 수 없음\n"
@@ -1821,6 +1833,20 @@ msgstr "실행중"
 
 msgid "Stopped"
 msgstr "중지됨"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < No translation >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "코드페이지 입력/표시:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "안 함(&N)"
@@ -1899,17 +1925,6 @@ msgstr "자동 저장 설정(&U)"
 
 msgid "Configure options"
 msgstr "설정 옵션"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < No translation >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "코드페이지 입력/표시:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "스킨:"
@@ -2106,10 +2121,9 @@ msgstr "강제종료(&K)"
 msgid "Background jobs"
 msgstr "백그라운드 작업"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "디렉터리를 다음으로 변경할 수 없음\n"
@@ -2203,19 +2217,29 @@ msgstr "표시됨 지우기(&L)"
 msgid "Chattr command"
 msgstr "Chattr 명령"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "\"%s\" 속성 변경을 할 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"tar 압축 파일을 열 수 없음\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"\"%s\" 속성 변경을 할 수 없음\n"
+"%s"
 
 msgid "set &user ID on execution"
 msgstr "실행 시 사용자 ID 설정(&U)"
@@ -2317,13 +2341,21 @@ msgstr "%s 링크 대상:"
 msgid "Link"
 msgstr "링크"
 
-#, c-format
-msgid "link: %s"
-msgstr "링크: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"\"%s\" 대상 심볼릭링크를 만들 수 없음\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "심볼릭링크: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"순환 심볼릭 링크를 복사할 수 없음\n"
+"\"%s\""
 
 msgid "View file"
 msgstr "파일 보기"
@@ -2345,6 +2377,12 @@ msgstr "새 디렉터리 만들기"
 
 msgid "Enter directory name:"
 msgstr "디렉터리 이름 입력:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "%s 디렉터리를 만들 수 없음"
 
 msgid "Extension file edit"
 msgstr "파일 확장 편집"
@@ -2394,12 +2432,16 @@ msgstr "'%s' 심볼릭링크가 가리키는 위치:"
 msgid "Edit symlink"
 msgstr "심볼릭링크 편집"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "심볼릭링크 편집, %s을(를) 제거할 수 없음: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "심볼릭링크 편집: %s"
 
 msgid "FTP to machine"
@@ -2441,10 +2483,8 @@ msgstr "로컬이 아닌 파일 시스템에서 명령을 실행할 수 없음"
 msgid "Parameter"
 msgstr "매개변수"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "임시 명령 파일을 생성할 수 없음\n"
 "%s"
@@ -2452,23 +2492,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "파이프 실패"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "오래된 %s 파일이 있습니다.\n"
 "Midnight Commander는 이제 %s 파일을 사용합니다.\n"
 "이전 파일의 수정 사항을 새 파일에 복사합니다."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "%s%s\n"
 "파일의 형식이 버전 4.0에서 변경되었습니다.\n"
@@ -2532,29 +2572,23 @@ msgstr "파일들/디렉터리들"
 msgid " with source mask:"
 msgstr " 소스 마스크 사용:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "\"%s\" 하드링크 소스 파일을 통계할 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"\"%s\" 대상 하드링크를 만들 수 없음\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "\"%s\" 대상 하드링크를 만들 수 없음"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "\"%s\" 소스 링크를 읽을 수 없음\n"
@@ -2569,9 +2603,9 @@ msgstr ""
 "\n"
 "옵션 안정 심볼릭링크가 비활성화 됩니다"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "\"%s\" 대상 심볼릭링크를 만들 수 없음\n"
@@ -2601,21 +2635,31 @@ msgstr ""
 "\"%s\"\n"
 "는 같은 파일임"
 
+msgid "&Ignore"
+msgstr "무시(&I)"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "재시도(&R)"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "\"%s\" 디렉터리가 비어 있지 않음.\n"
 "다시 삭제하시겠습니까?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "배경 프로세스:\n"
@@ -2625,17 +2669,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "없음(&E)"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "%s 파일을 제거할 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "%s 파일을 stat할 수 없음\n"
@@ -2645,103 +2689,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "%s 디렉터리를 덮어쓸 수 없음"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"%s 파일을 \"%s\"로 이동할 수 없음\n"
-"\n"
+"%s 파일을 제거할 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "%s 디렉터리를 제거할 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "%s 디렉터리를 덮어쓸 수 없음"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"%s 디렉터리를 덮어쓸 수 없음\n"
-"%s"
+msgstr "%s 디렉터리를 덮어쓸 수 없음"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "%s 파일을 덮어쓸 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"\"%s\" 디렉터리를 \"%s\"로 이동할 수 없음\n"
+"%s 디렉터리를 제거할 수 없음\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "\"..\"에서 작동할 수 없습니다!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "\"%s\" 원본 파일을 통계할 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"\"%s\" 하드링크 소스 파일을 통계할 수 없음\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"\"%s\" 대상 파일을 fstat할 수 없음\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "\"%s\" 특수 파일을 만들 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "\"%s\" 대상 파일을 chown 할 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "\"%s\" 대상 파일을 chmod할 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "\"%s\" 원본 파일을 열 수 없음\n"
@@ -2750,49 +2799,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "다시 받기 실패, 파일을 덮어쓰려고 합니다."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "\"%s\" 소스 파일을 fstat할 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "\"%s\" 대상 파일을 생성할 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "\"%s\" 대상 파일을 fstat할 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "\"%s\" 대상 파일에 대한 공간을 사전 할당할 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "\"%s\" 소스 파일를 읽을 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "\"%s\" 대상 파일을 쓸 수 없음\n"
@@ -2810,41 +2859,45 @@ msgstr "보존(&K)"
 msgid "&Continue copy"
 msgstr "복사 계속하기(&C)"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "\"%s\" 원본 파일을 닫을 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "\"%s\" 대상 파일을 닫을 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"\"%s\" 대상 파일에 대한 공간을 사전 할당할 수 없음\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "\"%s\" 소스 디렉터리를 stat할 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"\"%s\" 소스 디렉터리를 stat할 수 없음\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2862,25 +2915,27 @@ msgstr ""
 "순환 심볼릭 링크를 복사할 수 없음\n"
 "\"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "\"%s\" 대상은 디렉터리여야 함\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "\"%s\" 대상 디렉터리를 생성할 수 없음\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "\"%s\" 대상 디렉터리를 선택할 수 없음\n"
@@ -3207,11 +3262,9 @@ msgid "You have %zu opened screen. Quit anyway?"
 msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "%zu 화면이 열려 있습니다. 그래도 끝낼까요?"
 
-msgid "The Midnight Commander"
-msgstr "미드나잇 커맨더"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "미드나잇 커맨더를 절말로 끝내시겠습니까?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "정말로 실행하시겠습니까?"
 
 msgid "&Above"
 msgstr "이상(&A)"
@@ -3707,11 +3760,10 @@ msgstr ""
 "확장 패널크기:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "확장 패널크기:\n"
 "하위 프로세스의 stdout에서 ​​데이터를 읽을 수 없음:\n"
@@ -3754,6 +3806,15 @@ msgid ""
 "%s"
 msgstr ""
 "대상 정보를 볼 수 없음\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"\"%s\" 대상은 디렉터리여야 함\n"
 "%s"
 
 #, c-format
@@ -3875,8 +3936,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "홈 디렉터리 경로가 절대적이지 않음"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4589,8 +4651,9 @@ msgstr "파일이 수정되었습니다. 저장 후 나가시겠습니까?"
 msgid "&Cancel quit"
 msgstr "끝내기 취소(&C)"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "미드나잇 커맨더가 종료됩니다.\n"
@@ -4641,10 +4704,8 @@ msgstr " 형식화되지 않음"
 msgid "ButtonBar|Format"
 msgstr " 형식"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "하위 프로세스의 stdout에서 ​​데이터를 읽을 수 없음:\n"
 "%s"
@@ -4670,20 +4731,18 @@ msgstr ""
 msgid "View: "
 msgstr "보기: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"\"%s\"을(를) 열 수 없음\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "볼 수 없음: 일반 파일이 아님"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "\"%s\"을(를) 분석 모드에서 열 수 없음\n"
@@ -4697,6 +4756,79 @@ msgstr "처음부터 계속하시겠습니까?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "/ftp://some.host/editme.txt의 로컬 복사본을 가져올 수 없음"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "미드나잇 커맨더"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "미드나잇 커맨더를 절말로 끝내시겠습니까?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "%s을(를) 열 수 없음"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "%s에 대한 크기/사용 권한을 가져올 수 없음"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "쓰기 위해 파이프를 열 수 없음: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "저장할 수 없음: 대상이 일반 파일이 아님"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "%s 파일을 열 수 없음\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "모두 무시(&A)"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "링크: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "심볼릭링크: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "\"%s\" 대상 하드링크를 만들 수 없음\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "%s 파일을 \"%s\"로 이동할 수 없음\n"
+#~ "\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "%s 디렉터리를 덮어쓸 수 없음\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "\"%s\" 디렉터리를 \"%s\"로 이동할 수 없음\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "다른 8비트"

--- a/po/kw.po
+++ b/po/kw.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Cornish (http://app.transifex.com/mc/mc/language/kw/)\n"
@@ -52,6 +52,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -731,7 +734,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -797,23 +800,16 @@ msgstr ""
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -882,15 +878,16 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr ""
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Diff:"
@@ -900,12 +897,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -923,7 +922,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -934,11 +935,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -955,7 +954,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -969,11 +970,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1018,7 +1018,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1078,7 +1082,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1514,12 +1518,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1648,13 +1650,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1680,7 +1682,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1713,22 +1716,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1742,6 +1748,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1820,15 +1838,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2025,7 +2034,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2118,13 +2126,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2229,11 +2243,15 @@ msgid "Link"
 msgstr ""
 
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2255,6 +2273,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2304,11 +2328,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2348,10 +2376,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2360,7 +2385,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2370,7 +2395,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2427,23 +2452,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2455,7 +2476,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2475,19 +2496,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2496,13 +2527,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2512,37 +2543,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2551,43 +2586,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2596,37 +2631,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2644,31 +2679,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2686,19 +2721,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3027,10 +3064,7 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3536,11 +3570,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3576,6 +3608,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3678,8 +3717,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4329,8 +4369,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4379,10 +4420,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4403,16 +4441,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Mantas Kriaučiūnas Baltix <mantas@akl.lt>, 2020\n"
 "Language-Team: Lithuanian (http://app.transifex.com/mc/mc/language/lt/)\n"
@@ -56,6 +56,9 @@ msgstr "Nepavyko sukurti grupės '%s' įvykiams!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Nepavyko sukurti įvykio '%s'!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -756,7 +759,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -822,28 +825,23 @@ msgstr "Paieška"
 msgid "Search is disabled"
 msgstr "Paieška yra išjungta"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Nepavyko sukurti laikino diff failo\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Nepavyko sukurti atsarginės kopijos\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Napavyko sukurti sujungimo laikinojo failo\n"
 "%s"
@@ -914,18 +912,19 @@ msgstr "ButtonBar|Parinktys"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Išeit"
 
-msgid "Quit"
-msgstr "Išeiti"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Failas(-ai) buvo pakeisti. Ar išsaugoti pakeitimus?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander yra išjungiamas.\n"
 "Ar išsaugoti pakeitimus faile/failuose?"
+
+msgid "Quit"
+msgstr "Išeiti"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -933,15 +932,19 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" yra aplankas"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
+"Nepavyko išsaugoti failo:\n"
+"%s"
 
 msgid "Diff viewer: invalid mode"
 msgstr "Diff peržiūra: neteisingas režimas"
@@ -956,9 +959,13 @@ msgstr ""
 msgid "Loading..."
 msgstr "Įkeliama..."
 
-#, c-format
-msgid "Cannot open %s for reading"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
+"Nepavyksta atverti „%s“\n"
+"%s"
 
 msgid "Load file"
 msgstr "Įkelti failą"
@@ -967,12 +974,10 @@ msgstr "Įkelti failą"
 msgid "Error reading %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" yra neįprastas failas"
 
 #, c-format
@@ -990,9 +995,11 @@ msgstr "Įspėjimas"
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
+msgstr "Failas negali būti atvertas rašymui: %s"
 
 msgid "File has hard-links. Detach before saving?"
 msgstr ""
@@ -1004,12 +1011,11 @@ msgstr "Tuo tarpu failas buvo pakeistas. Vis tiek jį išsaugoti?"
 msgid "Error writing to pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Failas negali būti atvertas rašymui: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1054,8 +1060,12 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Neįmanoma išsaugoti: paskirtis nėra įprastas failas"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Peržiūra negalima: neįprastas failas"
 
 msgid "A file already exists with this name"
 msgstr "Failas su tokiu vardu jau egzistuoja"
@@ -1114,9 +1124,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Uždaryti failą"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander yra išjungiamas.\n"
@@ -1556,15 +1566,13 @@ msgstr "Patvirtinti pakeitimą"
 msgid "%ld replacements made"
 msgstr ""
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Lengvas vartoti teksto redaktorius\n"
 "sukurtas Midnight Commander aplinkai."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Apie"
@@ -1692,16 +1700,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Įkelti esamą sintaksę iš naujo >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Nepavyko atverti failo %s"
+
 msgid "Load syntax file"
 msgstr "Įkelti sintaksės failą"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Napavyko atverti failo %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1726,7 +1732,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1757,26 +1764,37 @@ msgstr ""
 msgid "Chown advanced command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Nepavyksta atverti „%s“\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Nepavyksta atverti „%s“\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
+"Nepavyksta atverti „%s“\n"
+"%s"
 
-msgid "&Ignore"
-msgstr "&Nepaisyti"
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
-msgstr "&Iš naujo"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
+"Nepavyksta atverti „%s“\n"
+"%s"
 
 msgid "< Default >"
 msgstr "< Numatytas >"
@@ -1789,6 +1807,20 @@ msgstr ""
 
 msgid "Stopped"
 msgstr "Sustojo"
+
+#, fuzzy
+msgid "No translation"
+msgstr "–  < Jokio vertimo >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Įvesties / išvesties kodų lentelė:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Niekada"
@@ -1867,17 +1899,6 @@ msgstr ""
 
 msgid "Configure options"
 msgstr "Keisti parinktis"
-
-#, fuzzy
-msgid "No translation"
-msgstr "–  < Jokio vertimo >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Įvesties / išvesties kodų lentelė:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Išvaizda"
@@ -2074,12 +2095,13 @@ msgstr "N&užudyti"
 msgid "Background jobs"
 msgstr "Foninio režimo užduotys"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"Nepavyko sukurti aplanko \"%s\"\n"
+"%s"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2168,17 +2190,25 @@ msgstr "Išva&lyti pažymėtus"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
-msgstr ""
+"Cannot chattr\n"
+"%sn%s"
+msgstr "Nepavyko apdoroti:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Nepavyko atverti tar archyvo\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Nepavyko apdoroti:"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2280,13 +2310,21 @@ msgstr "Sukurti nuorodą iš „%s“ į:"
 msgid "Link"
 msgstr "Nuoroda"
 
-#, c-format
-msgid "link: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
+"Nepavyko išsaugoti failo:\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "simbolinė nuoroda: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Nepavyko sukurti laikino diff failo\n"
+"%s"
 
 msgid "View file"
 msgstr "Žiūrėti failą"
@@ -2308,6 +2346,12 @@ msgstr "Sukurti naują aplanką"
 
 msgid "Enter directory name:"
 msgstr "Įvesti aplanko pavadinimą:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Nepavyko sukurti %s aplanko"
 
 msgid "Extension file edit"
 msgstr "Plėtinių failo keitimas"
@@ -2355,12 +2399,16 @@ msgstr "Simbolinė nuoroda '%s' nurodo į:"
 msgid "Edit symlink"
 msgstr "Keisti simbolinę nuorodą"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "keisti simbolinę nuorodą, neina pašalinti %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "keisti simbolinę nuorodą: %s"
 
 msgid "FTP to machine"
@@ -2400,11 +2448,11 @@ msgstr ""
 msgid "Parameter"
 msgstr "Parametras"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
+"Nepavyko sukurti laikino diff failo\n"
+"%s"
 
 msgid "Pipe failed"
 msgstr ""
@@ -2412,7 +2460,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2422,7 +2470,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2477,27 +2525,27 @@ msgstr "failus/aplankus"
 msgid " with source mask:"
 msgstr " naudojant šabloną:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"Nepavyko išsaugoti failo:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot read source link \"%s\"\n"
+"Nepavyko sukurti aplanko \"%s\"\n"
 "%s"
-msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot read source link\n"
+"%s"
+msgstr "Nepavyko perskaityti aplanko turinio"
 
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
@@ -2508,11 +2556,13 @@ msgstr ""
 "\n"
 "Parinktis 'Pastovios simbolinės nuorodos' bus išjungta"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
+"Nepavyko sukurti aplanko \"%s\"\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2534,21 +2584,31 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr "&Nepaisyti"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "&Iš naujo"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Aplankas \"%s\" ne tuščias.\n"
 "Trinti rekursyviai?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Foninis procesas:\n"
@@ -2558,153 +2618,182 @@ msgstr ""
 msgid "Non&e"
 msgstr "&Joks"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Nepavyko pašalinti failo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
+"Nepavyko išsaugoti failo:\n"
+"%s"
 
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Nepavyko perrašyti aplanko \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Nepavyko perkelti failo \"%s\" į \"%s\"\n"
+"Nepavyko pašalinti failo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Nepavyko pašalinti aplanko \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Nepavyko perrašyti aplanko \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Nepavyko perrašyti aplanko \"%s\"\n"
-"%s"
+msgstr "Nepavyko perrašyti aplanko \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Nepavyko perrašyti failo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Nepavyko perkelti aplanko \"%s\" į \"%s\"\n"
+"Nepavyko pašalinti aplanko \"%s\"\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
+"Nepavyko išsaugoti failo:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Napavyko sukurti sujungimo laikinojo failo\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Napavyko sukurti sujungimo laikinojo failo\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
+"Nepavyko sukurti atsarginės kopijos\n"
+"%s%s\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
+"Nepavyko išsaugoti failo:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
+"Nepavyko išsaugoti failo:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
-msgstr ""
+msgstr "Nepavyko atverti failo %s"
 
 msgid "Reget failed, about to overwrite file"
 msgstr "Pratęsti nepavyko, failas bus perrašytas"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
+"Nepavyko išsaugoti failo:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
+"Napavyko sukurti sujungimo laikinojo failo\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
+"Nepavyko išsaugoti failo:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
+"Napavyko sukurti sujungimo laikinojo failo\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
+"Nepavyko išsaugoti failo:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
+"Nepavyko įrašyti į failą %s:\n"
+"%s\n"
 
 msgid "(stalled)"
 msgstr "(sustojo)"
@@ -2718,35 +2807,43 @@ msgstr "Išlai&kyti"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
+"Nepavyko išsaugoti failo:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
+"Nepavyko išsaugoti failo:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Napavyko sukurti sujungimo laikinojo failo\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
-msgstr ""
+msgstr "Nepavyko sukurti %s aplanko"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Nepavyko sukurti aplanko \"%s\"\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2762,27 +2859,31 @@ msgid ""
 "\"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Paskirtis \"%s\" turi būti aplankas\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Nepavyko sukurti aplanko \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
+"Nepavyko sukurti aplanko \"%s\"\n"
+"%s"
 
 #, c-format
 msgid "Directories: %zu, total size: %s"
@@ -3107,10 +3208,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3612,11 +3710,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3656,6 +3752,15 @@ msgid ""
 "%s"
 msgstr ""
 "Nepavyko pasiekti paskirties\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Paskirtis \"%s\" turi būti aplankas\n"
 "%s"
 
 #, c-format
@@ -3772,8 +3877,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Namų aplanko kelias nėra absoliutus"
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4447,8 +4553,9 @@ msgstr "Failas buvo pakeistas. Ar išsaugoti?"
 msgid "&Cancel quit"
 msgstr "&Neišeiti"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander yra išjungiamas.\n"
@@ -4499,10 +4606,7 @@ msgstr "ButtonBar|Išform."
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Formuot."
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4526,22 +4630,22 @@ msgstr ""
 msgid "View: "
 msgstr "Rodymas:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Nepavyksta atverti „%s“\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Peržiūra negalima: neįprastas failas"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
+"Nepavyko atverti tar archyvo\n"
+"%s"
 
 msgid "Search done"
 msgstr "Paieška baigta"
@@ -4551,6 +4655,45 @@ msgstr "Tęsti nuo pradžios?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Neįmanoma išsaugoti: paskirtis nėra įprastas failas"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Napavyko atverti failo %s\n"
+#~ "%s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "simbolinė nuoroda: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nepavyko perkelti failo \"%s\" į \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nepavyko perrašyti aplanko \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nepavyko perkelti aplanko \"%s\" į \"%s\"\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Kita 8 bitų"

--- a/po/lv.po
+++ b/po/lv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Slava Zanko <slavazanko@gmail.com>, 2011\n"
 "Language-Team: Latvian (http://app.transifex.com/mc/mc/language/lv/)\n"
@@ -48,6 +48,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -729,7 +732,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -795,24 +798,22 @@ msgstr "Meklēt"
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
 msgid "&Fastest (Assume large files)"
 msgstr ""
@@ -880,16 +881,17 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr "Iziet"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
+
+msgid "Quit"
+msgstr "Iziet"
 
 msgid "Diff:"
 msgstr ""
@@ -897,15 +899,17 @@ msgstr ""
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"%s\n"
+"is a directory"
+msgstr "direktoriju"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat\n"
 "%s"
-msgstr ""
+msgstr "Nevar izanalizēt:"
 
 msgid "Diff viewer: invalid mode"
 msgstr ""
@@ -920,9 +924,13 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#, c-format
-msgid "Cannot open %s for reading"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
+"Nevar atvērt tar arhīvu\n"
+"%s"
 
 msgid "Load file"
 msgstr ""
@@ -932,11 +940,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -952,9 +958,13 @@ msgstr "Brīdinājums"
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
+"Nevarēja atvērt failu %s, lai ierakstītu:\n"
+"%s\n"
 
 msgid "File has hard-links. Detach before saving?"
 msgstr ""
@@ -966,13 +976,14 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
-msgstr ""
+"Nevarēja atvērt failu %s, lai ierakstītu:\n"
+"%s\n"
 
 msgid "The file you are saving does not end with a newline."
 msgstr ""
@@ -1016,7 +1027,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1076,7 +1091,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1512,12 +1527,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1646,13 +1659,15 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+"Nevar atvērt tar arhīvu\n"
+"%s"
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1678,7 +1693,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1711,22 +1727,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
-msgstr "&Vēlreiz"
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1741,6 +1760,20 @@ msgstr ""
 
 msgid "Stopped"
 msgstr "Apstādīnāts"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Nav tulkojuma >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Ievades / displeja kodu tabula:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Nekad"
@@ -1819,17 +1852,6 @@ msgstr ""
 
 msgid "Configure options"
 msgstr "Konfigurēt opcijas"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Nav tulkojuma >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Ievades / displeja kodu tabula:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr ""
@@ -2023,12 +2045,11 @@ msgstr "&Nokaut"
 msgid "Background jobs"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
-msgstr ""
+msgstr "Brīdinājums: Nevarēja pārmainīt uz %s.\n"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2117,17 +2138,25 @@ msgstr "A&ttīrīt izvēlēto"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
-msgstr ""
+"Cannot chattr\n"
+"%sn%s"
+msgstr "Nevar izanalizēt:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Nevar atvērt tar arhīvu\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Nevar izanalizēt:"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2229,12 +2258,18 @@ msgstr ""
 msgid "Link"
 msgstr ""
 
-#, c-format
-msgid "link: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2257,6 +2292,12 @@ msgstr "Izveidot Jaunu Direktoriju"
 
 msgid "Enter directory name:"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Izveidot Jaunu Direktoriju"
 
 msgid "Extension file edit"
 msgstr "Paplašinājuma faila rediģēšana"
@@ -2305,11 +2346,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2349,10 +2394,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2361,7 +2403,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2371,7 +2413,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2426,27 +2468,29 @@ msgstr "failus/direktorijas"
 msgid " with source mask:"
 msgstr " ar avota masku:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
+"Nevar atvērt tar arhīvu\n"
+"%s"
 
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
+"Nevar atvērt tar arhīvu\n"
+"%s"
 
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
@@ -2454,11 +2498,13 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
 #, c-format
 msgid ""
@@ -2476,160 +2522,212 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
 msgstr ""
 
+msgid "&Retry"
+msgstr "&Vēlreiz"
+
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 msgid "Non&e"
 msgstr "n&Evienu"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot remove directory\n"
+"%s"
+msgstr ""
+"Nevarēja atvērt cpio arhīvu\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot enter into directory\n"
+"%s"
+msgstr ""
+"Nevarēja atvērt cpio arhīvu\n"
+"%s"
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot overwrite file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
+"Nevar atvērt tar arhīvu\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
+"Nevar atvērt tar arhīvu\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
+"Nevarēja atvērt cpio arhīvu\n"
+"%s"
 
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
 
 msgid "(stalled)"
 msgstr "(staļļots)"
@@ -2643,33 +2741,39 @@ msgstr "&Paturēt"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
+"Nevarēja atvērt cpio arhīvu\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot close target file\n"
+"%s"
+msgstr ""
+"Nevar atvērt tar arhīvu\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot set ext2 attributes for target file\n"
+"%s"
+msgstr ""
+"Nevar ierakstīt failā %s:\n"
+"%s\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat source directory\n"
+"%s"
+msgstr "Izveidot Jaunu Direktoriju"
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot stat source directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2687,21 +2791,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
-msgstr ""
+msgstr "Izveidot Jaunu Direktoriju"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
+"Nevar atvērt tar arhīvu\n"
+"%s"
 
 #, c-format
 msgid "Directories: %zu, total size: %s"
@@ -3025,10 +3133,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3526,11 +3631,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3568,6 +3671,13 @@ msgstr "Pārvietot direktoriju \"%s\" uz:"
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3684,8 +3794,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4356,8 +4467,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4406,10 +4518,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4430,18 +4539,20 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
-msgid "Cannot view: not a regular file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
+"Nevar atvērt tar arhīvu\n"
+"%s"
 
 msgid "Search done"
 msgstr ""

--- a/po/mc.pot
+++ b/po/mc.pot
@@ -5,9 +5,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: mc 4.8.33-218-g1233c8780\n"
+"Project-Id-Version: mc 4.8.33-245-gfe9d4e95d\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -54,6 +54,10 @@ msgstr ""
 #: lib/event/manage.c:189
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+#: lib/global.c:117
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #: lib/lock.c:240
@@ -123,11 +127,11 @@ msgstr ""
 msgid "Invalid token number %d"
 msgstr ""
 
-#: lib/search/regex.c:340 lib/search/regex.c:817 src/filemanager/ext.c:758
+#: lib/search/regex.c:340 lib/search/regex.c:817 src/filemanager/ext.c:757
 msgid "Regular expression error"
 msgstr ""
 
-#: lib/search/search.c:53 src/diffviewer/ydiff.c:2333
+#: lib/search/search.c:53 src/diffviewer/ydiff.c:2331
 msgid "No&rmal"
 msgstr ""
 
@@ -602,31 +606,31 @@ msgstr ""
 msgid "Cannot check SIGWINCH pipe"
 msgstr ""
 
-#: lib/util.c:327
+#: lib/util.c:339
 msgid "B"
 msgstr ""
 
-#: lib/util.c:332
+#: lib/util.c:344
 msgid "kB"
 msgstr ""
 
-#: lib/util.c:332
+#: lib/util.c:344
 msgid "KiB"
 msgstr ""
 
-#: lib/util.c:337
+#: lib/util.c:349
 msgid "MB"
 msgstr ""
 
-#: lib/util.c:337
+#: lib/util.c:349
 msgid "MiB"
 msgstr ""
 
-#: lib/util.c:342
+#: lib/util.c:354
 msgid "GB"
 msgstr ""
 
-#: lib/util.c:342
+#: lib/util.c:354
 msgid "GiB"
 msgstr ""
 
@@ -727,38 +731,38 @@ msgstr ""
 msgid "Do you want clean this history?"
 msgstr ""
 
-#: lib/widget/listbox.c:325 src/diffviewer/ydiff.c:2979 src/editor/edit.c:358
+#: lib/widget/listbox.c:325 src/diffviewer/ydiff.c:2978 src/editor/edit.c:356
 #: src/editor/editcmd.c:175 src/editor/editcmd.c:198 src/editor/editcmd.c:1473
 #: src/editor/editcmd.c:1479 src/filemanager/cmd.c:138
-#: src/filemanager/file.c:999 src/filemanager/file.c:2025
-#: src/filemanager/filegui.c:477 src/filemanager/filemanager.c:1030
-#: src/filemanager/filemanager.c:1039 src/filemanager/hotlist.c:1153
+#: src/filemanager/file.c:997 src/filemanager/file.c:2028
+#: src/filemanager/filegui.c:477 src/filemanager/filemanager.c:1032
+#: src/filemanager/filemanager.c:1038 src/filemanager/hotlist.c:1153
 #: src/filemanager/hotlist.c:1171 src/filemanager/panel.c:2898
-#: src/filemanager/tree.c:817 src/subshell/common.c:1884
+#: src/filemanager/tree.c:820 src/subshell/common.c:1884
 #: src/vfs/sftpfs/connection.c:569 src/vfs/sftpfs/connection.c:582
-#: src/viewer/actions_cmd.c:597 src/viewer/actions_cmd.c:603
+#: src/viewer/actions_cmd.c:597 src/viewer/actions_cmd.c:604
 #: src/viewer/search.c:339
 msgid "&Yes"
 msgstr ""
 
-#: lib/widget/listbox.c:326 src/diffviewer/ydiff.c:2979 src/editor/edit.c:358
+#: lib/widget/listbox.c:326 src/diffviewer/ydiff.c:2978 src/editor/edit.c:356
 #: src/editor/editcmd.c:175 src/editor/editcmd.c:1473 src/editor/editcmd.c:1479
-#: src/filemanager/cmd.c:138 src/filemanager/file.c:1000
-#: src/filemanager/file.c:2025 src/filemanager/filegui.c:479
-#: src/filemanager/filemanager.c:1030 src/filemanager/filemanager.c:1039
+#: src/filemanager/cmd.c:138 src/filemanager/file.c:998
+#: src/filemanager/file.c:2028 src/filemanager/filegui.c:479
+#: src/filemanager/filemanager.c:1032 src/filemanager/filemanager.c:1039
 #: src/filemanager/hotlist.c:1154 src/filemanager/hotlist.c:1171
-#: src/filemanager/panel.c:2898 src/filemanager/tree.c:817
+#: src/filemanager/panel.c:2898 src/filemanager/tree.c:820
 #: src/subshell/common.c:1884 src/vfs/sftpfs/connection.c:569
 #: src/vfs/sftpfs/connection.c:582 src/viewer/actions_cmd.c:597
-#: src/viewer/actions_cmd.c:603 src/viewer/search.c:339
+#: src/viewer/actions_cmd.c:604 src/viewer/search.c:339
 msgid "&No"
 msgstr ""
 
 #: lib/widget/quick.h:216 lib/widget/wtools.c:131 lib/widget/wtools.c:406
 #: src/editor/editsearch.c:104 src/editor/editsearch.c:1015
-#: src/editor/editwidget.c:154 src/filemanager/boxes.c:1173
-#: src/filemanager/filegui.c:1430 src/filemanager/find.c:595
-#: src/filemanager/layout.c:504 src/main.c:388
+#: src/editor/editwidget.c:155 src/filemanager/boxes.c:520
+#: src/filemanager/boxes.c:1212 src/filemanager/filegui.c:1430
+#: src/filemanager/find.c:595 src/filemanager/layout.c:504 src/main.c:389
 msgid "&OK"
 msgstr ""
 
@@ -767,16 +771,13 @@ msgstr ""
 #: src/editor/editcmd.c:1023 src/editor/editcmd.c:1473
 #: src/editor/editcmd.c:1965 src/editor/editcmd.c:1994
 #: src/editor/editsearch.c:106 src/editor/editsearch.c:779
-#: src/editor/etags.c:370 src/editor/spell.c:354 src/filemanager/achown.c:87
-#: src/filemanager/achown.c:840 src/filemanager/achown.c:876
-#: src/filemanager/chattr.c:230 src/filemanager/chattr.c:1100
-#: src/filemanager/chmod.c:112 src/filemanager/chmod.c:427
-#: src/filemanager/chown.c:86 src/filemanager/chown.c:294
-#: src/filemanager/cmd.c:1008 src/filemanager/filegui.c:1434
-#: src/filemanager/find.c:596 src/filemanager/hotlist.c:184
-#: src/filemanager/hotlist.c:1005 src/filemanager/hotlist.c:1067
-#: src/filemanager/layout.c:505 src/filemanager/panelize.c:170 src/learn.c:261
-#: src/viewer/hex.c:419
+#: src/editor/etags.c:370 src/editor/spell.c:354 src/filemanager/achown.c:89
+#: src/filemanager/chattr.c:231 src/filemanager/chmod.c:114
+#: src/filemanager/chown.c:87 src/filemanager/cmd.c:1008
+#: src/filemanager/filegui.c:1434 src/filemanager/find.c:596
+#: src/filemanager/hotlist.c:184 src/filemanager/hotlist.c:1005
+#: src/filemanager/hotlist.c:1067 src/filemanager/layout.c:505
+#: src/filemanager/panelize.c:173 src/learn.c:261 src/viewer/hex.c:419
 msgid "&Cancel"
 msgstr ""
 
@@ -795,9 +796,9 @@ msgstr ""
 msgid "%s (%d)"
 msgstr ""
 
-#: lib/widget/wtools.c:664 src/filemanager/file.c:882
-#: src/filemanager/file.c:947 src/filemanager/file.c:950
-#: src/filemanager/file.c:1000 src/filemanager/file.c:3383
+#: lib/widget/wtools.c:664 src/filemanager/file.c:879
+#: src/filemanager/file.c:944 src/filemanager/file.c:947
+#: src/filemanager/file.c:998 src/filemanager/file.c:3374
 #: src/filemanager/filegui.c:244 src/filemanager/filegui.c:501
 msgid "&Abort"
 msgstr ""
@@ -957,7 +958,7 @@ msgstr ""
 msgid "[+lineno] file1[:lineno] [file2[:lineno]...]"
 msgstr ""
 
-#: src/args.c:438 src/filemanager/file.c:170
+#: src/args.c:438 src/filemanager/file.c:171
 msgid "file"
 msgstr ""
 
@@ -973,11 +974,11 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
-#: src/args.c:687 src/filemanager/boxes.c:676
+#: src/args.c:687 src/filemanager/boxes.c:715
 msgid "Main options"
 msgstr ""
 
@@ -1009,7 +1010,7 @@ msgstr ""
 msgid "Reading failed"
 msgstr ""
 
-#: src/background.c:221 src/filemanager/file.c:851 src/filemanager/file.c:943
+#: src/background.c:221 src/filemanager/file.c:848 src/filemanager/file.c:940
 msgid "Background process error"
 msgstr ""
 
@@ -1037,8 +1038,8 @@ msgid "Enter search string:"
 msgstr ""
 
 #: src/diffviewer/search.c:93 src/editor/editsearch.c:97
-#: src/editor/editsearch.c:704 src/filemanager/boxes.c:669
-#: src/filemanager/boxes.c:885 src/filemanager/find.c:581
+#: src/editor/editsearch.c:704 src/filemanager/boxes.c:708
+#: src/filemanager/boxes.c:924 src/filemanager/find.c:581
 #: src/viewer/dialogs.c:87
 msgid "Cas&e sensitive"
 msgstr ""
@@ -1074,180 +1075,178 @@ msgstr ""
 msgid "Search is disabled"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:178
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#: src/diffviewer/ydiff.c:179
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #: src/diffviewer/ydiff.c:2132
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2141
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#: src/diffviewer/ydiff.c:2140
+msgid "Cannot create temporary merge file"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2334
+#: src/diffviewer/ydiff.c:2332
 msgid "&Fastest (Assume large files)"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2335
+#: src/diffviewer/ydiff.c:2333
 msgid "&Minimal (Find a smaller set of change)"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2340
+#: src/diffviewer/ydiff.c:2338
 msgid "Diff algorithm"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2343
+#: src/diffviewer/ydiff.c:2341
 msgid "Diff extra options"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2344
+#: src/diffviewer/ydiff.c:2342
 msgid "&Ignore case"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2345
+#: src/diffviewer/ydiff.c:2343
 msgid "Ignore tab &expansion"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2346
+#: src/diffviewer/ydiff.c:2344
 msgid "Ignore &space change"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2347
+#: src/diffviewer/ydiff.c:2345
 msgid "Ignore all &whitespace"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2348
+#: src/diffviewer/ydiff.c:2346
 msgid "Strip &trailing carriage return"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2360
+#: src/diffviewer/ydiff.c:2358
 msgid "Diff Options"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2844
+#: src/diffviewer/ydiff.c:2842
 msgid "Edit"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2844
+#: src/diffviewer/ydiff.c:2842
 msgid "Edit is disabled"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2877
+#: src/diffviewer/ydiff.c:2875
 msgid "Goto line (left)"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2878
+#: src/diffviewer/ydiff.c:2876
 msgid "Goto line (right)"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2884 src/editor/editcmd.c:1661
+#: src/diffviewer/ydiff.c:2882 src/editor/editcmd.c:1661
 msgid "Enter line:"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2923 src/editor/editwidget.c:667
-#: src/filemanager/filemanager.c:1605 src/filemanager/tree.c:1164
+#: src/diffviewer/ydiff.c:2921 src/editor/editwidget.c:669
+#: src/filemanager/filemanager.c:1608 src/filemanager/tree.c:1167
 #: src/help.c:1168 src/viewer/display.c:83
 msgid "ButtonBar|Help"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2924 src/editor/editwidget.c:668
+#: src/diffviewer/ydiff.c:2922 src/editor/editwidget.c:670
 #: src/viewer/display.c:95
 msgid "ButtonBar|Save"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2925 src/filemanager/filemanager.c:1608
+#: src/diffviewer/ydiff.c:2923 src/filemanager/filemanager.c:1611
 #: src/viewer/display.c:90
 msgid "ButtonBar|Edit"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2926
+#: src/diffviewer/ydiff.c:2924
 msgid "ButtonBar|Merge"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2927 src/editor/editwidget.c:673
+#: src/diffviewer/ydiff.c:2925 src/editor/editwidget.c:675
 #: src/viewer/display.c:105
 msgid "ButtonBar|Search"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2928
+#: src/diffviewer/ydiff.c:2926
 msgid "ButtonBar|Options"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2929 src/editor/editwidget.c:676
-#: src/filemanager/filemanager.c:1614 src/help.c:1177 src/viewer/display.c:114
+#: src/diffviewer/ydiff.c:2927 src/editor/editwidget.c:678
+#: src/filemanager/filemanager.c:1617 src/help.c:1177 src/viewer/display.c:114
 #: src/viewer/display.c:118
 msgid "ButtonBar|Quit"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2975 src/editor/editcmd.c:1479
-#: src/viewer/actions_cmd.c:596 src/viewer/actions_cmd.c:601
-msgid "Quit"
-msgstr ""
-
-#: src/diffviewer/ydiff.c:2977
+#: src/diffviewer/ydiff.c:2975
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:2978
+#: src/diffviewer/ydiff.c:2976
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:3306 src/diffviewer/ydiff.c:3309
+#: src/diffviewer/ydiff.c:2978 src/editor/editcmd.c:1479
+#: src/viewer/actions_cmd.c:596 src/viewer/actions_cmd.c:604
+msgid "Quit"
+msgstr ""
+
+#: src/diffviewer/ydiff.c:3306 src/diffviewer/ydiff.c:3316
 msgid "Diff:"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:3435 src/diffviewer/ydiff.c:3451
+#: src/diffviewer/ydiff.c:3442 src/diffviewer/ydiff.c:3457
 msgid "File name is empty!"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:3443 src/diffviewer/ydiff.c:3458
-#: src/diffviewer/ydiff.c:3478 src/diffviewer/ydiff.c:3495
-#, c-format
-msgid "\"%s\" is a directory"
-msgstr ""
-
-#: src/diffviewer/ydiff.c:3484 src/diffviewer/ydiff.c:3501
-#: src/filemanager/file.c:1833 src/viewer/mcviewer.c:347
+#: src/diffviewer/ydiff.c:3450 src/diffviewer/ydiff.c:3464
+#: src/diffviewer/ydiff.c:3483 src/diffviewer/ydiff.c:3499
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"%s\n"
+"is a directory"
+msgstr ""
+
+#: src/diffviewer/ydiff.c:3489 src/diffviewer/ydiff.c:3505
+#: src/editor/edit.c:321 src/filemanager/file.c:1837 src/viewer/mcviewer.c:345
+#, c-format
+msgid ""
+"Cannot stat\n"
 "%s"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:3510
+#: src/diffviewer/ydiff.c:3513
 msgid "Diff viewer: invalid mode"
 msgstr ""
 
-#: src/diffviewer/ydiff.c:3536
+#: src/diffviewer/ydiff.c:3539
 msgid "Two files are needed to compare"
 msgstr ""
 
-#: src/editor/edit.c:160
+#: src/editor/edit.c:161
 #, c-format
 msgid "Loading: %3d%%"
 msgstr ""
 
-#: src/editor/edit.c:163
+#: src/editor/edit.c:164
 msgid "Loading..."
 msgstr ""
 
-#: src/editor/edit.c:200 src/editor/edit.c:310
+#: src/editor/edit.c:201 src/editor/edit.c:310 src/viewer/mcviewer.c:332
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 #: src/editor/edit.c:209
@@ -1259,41 +1258,40 @@ msgstr ""
 msgid "Error reading %s"
 msgstr ""
 
-#: src/editor/edit.c:322
+#: src/editor/edit.c:329
 #, c-format
-msgid "Cannot get size/permissions for %s"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
-#: src/editor/edit.c:331
-#, c-format
-msgid "\"%s\" is not a regular file"
-msgstr ""
-
-#: src/editor/edit.c:356
+#: src/editor/edit.c:354
 #, c-format
 msgid ""
 "File \"%s\" is too large.\n"
 "Open it anyway?"
 msgstr ""
 
-#: src/editor/edit.c:358 src/editor/editcmd.c:174 src/editor/editcmd.c:196
+#: src/editor/edit.c:356 src/editor/editcmd.c:174 src/editor/editcmd.c:196
 #: src/editor/editcmd.c:362 src/editor/editcmd.c:508 src/editor/editcmd.c:945
 #: src/editor/editcmd.c:1962 src/editor/editcmd.c:1991 src/editor/etags.c:367
-#: src/execute.c:137 src/filemanager/ext.c:775 src/filemanager/file.c:2571
-#: src/filemanager/panel.c:4716 src/help.c:363 src/learn.c:122 src/main.c:385
+#: src/execute.c:137 src/filemanager/ext.c:774 src/filemanager/file.c:2569
+#: src/filemanager/panel.c:4716 src/help.c:363 src/learn.c:122 src/main.c:389
 #: src/subshell/common.c:1883 src/vfs/sftpfs/connection.c:569
 #: src/viewer/actions_cmd.c:403
 msgid "Warning"
 msgstr ""
 
-#: src/editor/edit.c:1988
+#: src/editor/edit.c:1986
 #, c-format
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#: src/editor/edit.c:1994
+#: src/editor/edit.c:1992 src/editor/editcmd.c:269
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 #: src/editor/editcmd.c:174
@@ -1309,14 +1307,12 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr ""
 
-#: src/editor/editcmd.c:269
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
 #: src/editor/editcmd.c:308
 #, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 #: src/editor/editcmd.c:363
@@ -1377,8 +1373,12 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-#: src/editor/editcmd.c:931
-msgid "Cannot save: destination is not a regular file"
+#: src/editor/editcmd.c:930
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 #: src/editor/editcmd.c:945
@@ -1441,7 +1441,7 @@ msgstr ""
 msgid "&Local"
 msgstr ""
 
-#: src/editor/editcmd.c:1454 src/editor/editwidget.c:387
+#: src/editor/editcmd.c:1454 src/editor/editwidget.c:389
 msgid "[NoName]"
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgstr ""
 #: src/editor/editcmd.c:1477
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Collect completions"
 msgstr ""
 
-#: src/editor/editdraw.c:250 src/editor/editwidget.c:334
+#: src/editor/editdraw.c:250 src/editor/editwidget.c:336
 msgid "NoName"
 msgstr ""
 
@@ -1630,11 +1630,11 @@ msgstr ""
 msgid "&User menu..."
 msgstr ""
 
-#: src/editor/editmenu.c:86
+#: src/editor/editmenu.c:86 src/filemanager/filemanager.c:333
 msgid "A&bout..."
 msgstr ""
 
-#: src/editor/editmenu.c:88 src/filemanager/find.c:189 src/main.c:388
+#: src/editor/editmenu.c:88 src/filemanager/find.c:189 src/main.c:389
 msgid "&Quit"
 msgstr ""
 
@@ -1674,8 +1674,8 @@ msgstr ""
 msgid "Mo&ve"
 msgstr ""
 
-#: src/editor/editmenu.c:113 src/filemanager/file.c:2826
-#: src/filemanager/file.c:2887 src/filemanager/filemanager.c:247
+#: src/editor/editmenu.c:113 src/filemanager/file.c:2822
+#: src/filemanager/file.c:2883 src/filemanager/filemanager.c:247
 msgid "&Delete"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "&Save setup"
 msgstr ""
 
-#: src/editor/editmenu.c:272 src/filemanager/filemanager.c:343
+#: src/editor/editmenu.c:272 src/filemanager/filemanager.c:345
 msgid "&File"
 msgstr ""
 
@@ -1883,7 +1883,7 @@ msgstr ""
 msgid "&Search"
 msgstr ""
 
-#: src/editor/editmenu.c:278 src/filemanager/filemanager.c:345
+#: src/editor/editmenu.c:278 src/filemanager/filemanager.c:347
 msgid "&Command"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "&Window"
 msgstr ""
 
-#: src/editor/editmenu.c:284 src/filemanager/filemanager.c:347
+#: src/editor/editmenu.c:284 src/filemanager/filemanager.c:349
 msgid "&Options"
 msgstr ""
 
@@ -1935,7 +1935,7 @@ msgstr ""
 msgid "Tab spacing:"
 msgstr ""
 
-#: src/editor/editoptions.c:168 src/filemanager/boxes.c:526
+#: src/editor/editoptions.c:168 src/filemanager/boxes.c:584
 #: src/filemanager/layout.c:497
 msgid "Other options"
 msgstr ""
@@ -2024,13 +2024,13 @@ msgstr ""
 msgid "&Replace"
 msgstr ""
 
-#: src/editor/editsearch.c:777 src/filemanager/file.c:1000
+#: src/editor/editsearch.c:777 src/filemanager/file.c:998
 #: src/filemanager/filegui.c:490
 msgid "A&ll"
 msgstr ""
 
 #: src/editor/editsearch.c:778 src/editor/spell.c:352
-#: src/filemanager/file.c:882 src/filemanager/file.c:3384
+#: src/filemanager/file.c:879 src/filemanager/file.c:3375
 #: src/filemanager/filegui.c:241
 msgid "&Skip"
 msgstr ""
@@ -2044,50 +2044,47 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
-#: src/editor/editwidget.c:148
+#: src/editor/editwidget.c:143
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 
-#: src/editor/editwidget.c:152
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
-
-#: src/editor/editwidget.c:162
+#: src/editor/editwidget.c:163 src/filemanager/boxes.c:528
 msgid "About"
 msgstr ""
 
-#: src/editor/editwidget.c:325
+#: src/editor/editwidget.c:327
 msgid "Open files"
 msgstr ""
 
-#: src/editor/editwidget.c:391 src/editor/editwidget.c:394
+#: src/editor/editwidget.c:393 src/editor/editwidget.c:396
 msgid "Edit: "
 msgstr ""
 
-#: src/editor/editwidget.c:669
+#: src/editor/editwidget.c:671
 msgid "ButtonBar|Mark"
 msgstr ""
 
-#: src/editor/editwidget.c:670
+#: src/editor/editwidget.c:672
 msgid "ButtonBar|Replac"
 msgstr ""
 
-#: src/editor/editwidget.c:671 src/filemanager/filemanager.c:1609
-#: src/filemanager/tree.c:1170
+#: src/editor/editwidget.c:673 src/filemanager/filemanager.c:1612
+#: src/filemanager/tree.c:1173
 msgid "ButtonBar|Copy"
 msgstr ""
 
-#: src/editor/editwidget.c:672
+#: src/editor/editwidget.c:674
 msgid "ButtonBar|Move"
 msgstr ""
 
-#: src/editor/editwidget.c:674 src/filemanager/filemanager.c:1612
+#: src/editor/editwidget.c:676 src/filemanager/filemanager.c:1615
 msgid "ButtonBar|Delete"
 msgstr ""
 
-#: src/editor/editwidget.c:675 src/filemanager/filemanager.c:1613
+#: src/editor/editwidget.c:677 src/filemanager/filemanager.c:1616
 msgid "ButtonBar|PullDn"
 msgstr ""
 
@@ -2211,31 +2208,31 @@ msgstr ""
 msgid "Select language"
 msgstr ""
 
-#: src/editor/syntax.c:1461
+#: src/editor/syntax.c:1463
 msgid "Choose syntax highlighting"
 msgstr ""
 
-#: src/editor/syntax.c:1462
+#: src/editor/syntax.c:1464
 msgid "< Auto >"
 msgstr ""
 
-#: src/editor/syntax.c:1463
+#: src/editor/syntax.c:1465
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-#: src/editor/syntax.c:1564 src/editor/syntax.c:1570
-msgid "Load syntax file"
-msgstr ""
-
-#: src/editor/syntax.c:1564 src/help.c:1104 src/usermenu.c:1009
-#: src/usermenu.c:1040
+#: src/editor/syntax.c:1566 src/help.c:1104 src/usermenu.c:1008
+#: src/usermenu.c:1038
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
 msgstr ""
 
-#: src/editor/syntax.c:1570
+#: src/editor/syntax.c:1571
+msgid "Load syntax file"
+msgstr ""
+
+#: src/editor/syntax.c:1571
 #, c-format
 msgid "Error in file %s on line %d"
 msgstr ""
@@ -2248,7 +2245,7 @@ msgid ""
 "extra access permissions with the \"su\" command?"
 msgstr ""
 
-#: src/execute.c:198 src/filemanager/ext.c:670
+#: src/execute.c:198 src/filemanager/ext.c:669
 #, c-format
 msgid "Cannot fetch a local copy of %s"
 msgstr ""
@@ -2264,83 +2261,76 @@ msgid ""
 msgstr ""
 
 #: src/execute.c:508
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
-#: src/filemanager/achown.c:84 src/filemanager/chattr.c:225
-#: src/filemanager/chmod.c:107 src/filemanager/chown.c:82
+#: src/filemanager/achown.c:86 src/filemanager/chattr.c:226
+#: src/filemanager/chmod.c:109 src/filemanager/chown.c:83
 msgid "Set &all"
 msgstr ""
 
-#: src/filemanager/achown.c:85
+#: src/filemanager/achown.c:87
 msgid "S&kip"
 msgstr ""
 
-#: src/filemanager/achown.c:86 src/filemanager/chattr.c:229
-#: src/filemanager/chmod.c:111 src/filemanager/chown.c:85
+#: src/filemanager/achown.c:88 src/filemanager/chattr.c:230
+#: src/filemanager/chmod.c:113 src/filemanager/chown.c:86
 msgid "&Set"
 msgstr ""
 
-#: src/filemanager/achown.c:285 src/filemanager/achown.c:292
-#: src/filemanager/achown.c:544
+#: src/filemanager/achown.c:287 src/filemanager/achown.c:294
+#: src/filemanager/achown.c:546
 msgid "owner"
 msgstr ""
 
-#: src/filemanager/achown.c:287 src/filemanager/achown.c:294
-#: src/filemanager/achown.c:549
+#: src/filemanager/achown.c:289 src/filemanager/achown.c:296
+#: src/filemanager/achown.c:551
 msgid "group"
 msgstr ""
 
-#: src/filemanager/achown.c:289
+#: src/filemanager/achown.c:291
 msgid "other"
 msgstr ""
 
-#: src/filemanager/achown.c:297
+#: src/filemanager/achown.c:299
 msgid "Flag"
 msgstr ""
 
-#: src/filemanager/achown.c:307
+#: src/filemanager/achown.c:309
 #, c-format
 msgid "Permissions (octal): %o"
 msgstr ""
 
-#: src/filemanager/achown.c:748
+#: src/filemanager/achown.c:750
 msgid "Chown advanced command"
 msgstr ""
 
-#: src/filemanager/achown.c:838 src/filemanager/achown.c:1034
-#: src/filemanager/chmod.c:425 src/filemanager/chmod.c:569
+#: src/filemanager/achown.c:841 src/filemanager/chmod.c:428
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+
+#: src/filemanager/achown.c:873 src/filemanager/chown.c:294
+#, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#: src/filemanager/achown.c:1028 src/filemanager/chmod.c:567
+#, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/achown.c:839 src/filemanager/achown.c:875
-#: src/filemanager/chattr.c:1099 src/filemanager/chmod.c:426
-#: src/filemanager/chown.c:293 src/filemanager/file.c:946
-#: src/filemanager/file.c:950 src/vfs/sftpfs/connection.c:569
-#: src/vfs/sftpfs/connection.c:582
-msgid "&Ignore"
-msgstr ""
-
-#: src/filemanager/achown.c:839 src/filemanager/achown.c:875
-#: src/filemanager/chattr.c:1099 src/filemanager/chmod.c:426
-#: src/filemanager/chown.c:293
-msgid "Ignore &all"
-msgstr ""
-
-#: src/filemanager/achown.c:840 src/filemanager/achown.c:876
-#: src/filemanager/chattr.c:1100 src/filemanager/chmod.c:427
-#: src/filemanager/chown.c:294 src/filemanager/file.c:947 src/viewer/hex.c:419
-msgid "&Retry"
-msgstr ""
-
-#: src/filemanager/achown.c:874 src/filemanager/achown.c:1038
-#: src/filemanager/chown.c:292 src/filemanager/chown.c:457
+#: src/filemanager/achown.c:1031 src/filemanager/chown.c:454
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -2360,228 +2350,232 @@ msgstr ""
 msgid "Stopped"
 msgstr ""
 
-#: src/filemanager/boxes.c:494
-msgid "&Never"
-msgstr ""
-
-#: src/filemanager/boxes.c:495
-msgid "On dum&b terminals"
-msgstr ""
-
-#: src/filemanager/boxes.c:496
-msgid "Alwa&ys"
-msgstr ""
-
-#: src/filemanager/boxes.c:507
-msgid "File operations"
-msgstr ""
-
-#: src/filemanager/boxes.c:508
-msgid "&Verbose operation"
-msgstr ""
-
-#: src/filemanager/boxes.c:509
-msgid "Compute tota&ls"
-msgstr ""
-
-#: src/filemanager/boxes.c:510
-msgid "Classic pro&gressbar"
-msgstr ""
-
-#: src/filemanager/boxes.c:511
-msgid "Mkdi&r autoname"
-msgstr ""
-
-#: src/filemanager/boxes.c:512
-msgid "&Preallocate space"
-msgstr ""
-
-#: src/filemanager/boxes.c:515
-msgid "Esc key mode"
-msgstr ""
-
-#: src/filemanager/boxes.c:516
-msgid "S&ingle press"
-msgstr ""
-
-#: src/filemanager/boxes.c:517
-msgid "Timeout:"
-msgstr ""
-
-#: src/filemanager/boxes.c:522
-msgid "Pause after run"
-msgstr ""
-
-#: src/filemanager/boxes.c:527
-msgid "Use internal edi&t"
-msgstr ""
-
-#: src/filemanager/boxes.c:528
-msgid "Use internal vie&w"
-msgstr ""
-
-#: src/filemanager/boxes.c:529
-msgid "A&sk new file name"
-msgstr ""
-
-#: src/filemanager/boxes.c:531
-msgid "Auto m&enus"
-msgstr ""
-
-#: src/filemanager/boxes.c:532
-msgid "&Drop down menus"
-msgstr ""
-
-#: src/filemanager/boxes.c:533
-msgid "S&hell patterns"
-msgstr ""
-
-#: src/filemanager/boxes.c:534
-msgid "Co&mplete: show all"
-msgstr ""
-
-#: src/filemanager/boxes.c:536
-msgid "Rotating d&ash"
-msgstr ""
-
-#: src/filemanager/boxes.c:537
-msgid "Cd follows lin&ks"
-msgstr ""
-
-#: src/filemanager/boxes.c:538
-msgid "Sa&fe delete"
-msgstr ""
-
-#: src/filemanager/boxes.c:539
-msgid "Safe overwrite"
-msgstr ""
-
-#: src/filemanager/boxes.c:540
-msgid "A&uto save setup"
-msgstr ""
-
-#: src/filemanager/boxes.c:554
-msgid "Configure options"
-msgstr ""
-
-#: src/filemanager/boxes.c:604
+#: src/filemanager/boxes.c:503
 msgid "No translation"
 msgstr ""
 
-#: src/filemanager/boxes.c:607
+#: src/filemanager/boxes.c:506
 msgid "Detected display codepage"
 msgstr ""
 
-#: src/filemanager/boxes.c:609
+#: src/filemanager/boxes.c:508
 msgid "Selected source (file I/O) codepage"
 msgstr ""
 
-#: src/filemanager/boxes.c:615
+#: src/filemanager/boxes.c:513
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
+
+#: src/filemanager/boxes.c:552
+msgid "&Never"
+msgstr ""
+
+#: src/filemanager/boxes.c:553
+msgid "On dum&b terminals"
+msgstr ""
+
+#: src/filemanager/boxes.c:554
+msgid "Alwa&ys"
+msgstr ""
+
+#: src/filemanager/boxes.c:565
+msgid "File operations"
+msgstr ""
+
+#: src/filemanager/boxes.c:566
+msgid "&Verbose operation"
+msgstr ""
+
+#: src/filemanager/boxes.c:567
+msgid "Compute tota&ls"
+msgstr ""
+
+#: src/filemanager/boxes.c:568
+msgid "Classic pro&gressbar"
+msgstr ""
+
+#: src/filemanager/boxes.c:569
+msgid "Mkdi&r autoname"
+msgstr ""
+
+#: src/filemanager/boxes.c:570
+msgid "&Preallocate space"
+msgstr ""
+
+#: src/filemanager/boxes.c:573
+msgid "Esc key mode"
+msgstr ""
+
+#: src/filemanager/boxes.c:574
+msgid "S&ingle press"
+msgstr ""
+
+#: src/filemanager/boxes.c:575
+msgid "Timeout:"
+msgstr ""
+
+#: src/filemanager/boxes.c:580
+msgid "Pause after run"
+msgstr ""
+
+#: src/filemanager/boxes.c:585
+msgid "Use internal edi&t"
+msgstr ""
+
+#: src/filemanager/boxes.c:586
+msgid "Use internal vie&w"
+msgstr ""
+
+#: src/filemanager/boxes.c:587
+msgid "A&sk new file name"
+msgstr ""
+
+#: src/filemanager/boxes.c:589
+msgid "Auto m&enus"
+msgstr ""
+
+#: src/filemanager/boxes.c:590
+msgid "&Drop down menus"
+msgstr ""
+
+#: src/filemanager/boxes.c:591
+msgid "S&hell patterns"
+msgstr ""
+
+#: src/filemanager/boxes.c:592
+msgid "Co&mplete: show all"
+msgstr ""
+
+#: src/filemanager/boxes.c:594
+msgid "Rotating d&ash"
+msgstr ""
+
+#: src/filemanager/boxes.c:595
+msgid "Cd follows lin&ks"
+msgstr ""
+
+#: src/filemanager/boxes.c:596
+msgid "Sa&fe delete"
+msgstr ""
+
+#: src/filemanager/boxes.c:597
+msgid "Safe overwrite"
+msgstr ""
+
+#: src/filemanager/boxes.c:598
+msgid "A&uto save setup"
+msgstr ""
+
+#: src/filemanager/boxes.c:612
+msgid "Configure options"
+msgstr ""
+
+#: src/filemanager/boxes.c:659
 msgid "Skin:"
 msgstr ""
 
-#: src/filemanager/boxes.c:621
+#: src/filemanager/boxes.c:665
 msgid "&Shadows"
 msgstr ""
 
-#: src/filemanager/boxes.c:634
+#: src/filemanager/boxes.c:675
 msgid "Appearance"
 msgstr ""
 
-#: src/filemanager/boxes.c:668
+#: src/filemanager/boxes.c:707
 msgid "Case &insensitive"
 msgstr ""
 
-#: src/filemanager/boxes.c:670
+#: src/filemanager/boxes.c:709
 msgid "Use panel sort mo&de"
 msgstr ""
 
-#: src/filemanager/boxes.c:677
+#: src/filemanager/boxes.c:716
 msgid "Show mi&ni-status"
 msgstr ""
 
-#: src/filemanager/boxes.c:678
+#: src/filemanager/boxes.c:717
 msgid "Use SI si&ze units"
 msgstr ""
 
-#: src/filemanager/boxes.c:679
+#: src/filemanager/boxes.c:718
 msgid "Mi&x all files"
 msgstr ""
 
-#: src/filemanager/boxes.c:680
+#: src/filemanager/boxes.c:719
 msgid "Show &backup files"
 msgstr ""
 
-#: src/filemanager/boxes.c:681
+#: src/filemanager/boxes.c:720
 msgid "Show &hidden files"
 msgstr ""
 
-#: src/filemanager/boxes.c:682
+#: src/filemanager/boxes.c:721
 msgid "&Fast dir reload"
 msgstr ""
 
-#: src/filemanager/boxes.c:683
+#: src/filemanager/boxes.c:722
 msgid "Ma&rk moves down"
 msgstr ""
 
-#: src/filemanager/boxes.c:684
+#: src/filemanager/boxes.c:723
 msgid "Re&verse files only"
 msgstr ""
 
-#: src/filemanager/boxes.c:686
+#: src/filemanager/boxes.c:725
 msgid "Simple s&wap"
 msgstr ""
 
-#: src/filemanager/boxes.c:687
+#: src/filemanager/boxes.c:726
 msgid "A&uto save panels setup"
 msgstr ""
 
-#: src/filemanager/boxes.c:694
+#: src/filemanager/boxes.c:733
 msgid "Navigation"
 msgstr ""
 
-#: src/filemanager/boxes.c:695
+#: src/filemanager/boxes.c:734
 msgid "L&ynx-like motion"
 msgstr ""
 
-#: src/filemanager/boxes.c:697
+#: src/filemanager/boxes.c:736
 msgid "Pa&ge scrolling"
 msgstr ""
 
-#: src/filemanager/boxes.c:698
+#: src/filemanager/boxes.c:737
 msgid "Center &scrolling"
 msgstr ""
 
-#: src/filemanager/boxes.c:699
+#: src/filemanager/boxes.c:738
 msgid "&Mouse page scrolling"
 msgstr ""
 
-#: src/filemanager/boxes.c:702
+#: src/filemanager/boxes.c:741
 msgid "File highlight"
 msgstr ""
 
-#: src/filemanager/boxes.c:703
+#: src/filemanager/boxes.c:742
 msgid "File &types"
 msgstr ""
 
-#: src/filemanager/boxes.c:704
+#: src/filemanager/boxes.c:743
 msgid "&Permissions"
 msgstr ""
 
-#: src/filemanager/boxes.c:706
+#: src/filemanager/boxes.c:745
 msgid "Quick search"
 msgstr ""
 
-#: src/filemanager/boxes.c:720
+#: src/filemanager/boxes.c:759
 msgid "Panel options"
 msgstr ""
 
-#: src/filemanager/boxes.c:735 src/filemanager/info.c:86
+#: src/filemanager/boxes.c:774 src/filemanager/info.c:86
 #: src/vfs/sftpfs/connection.c:428
 msgid "Information"
 msgstr ""
 
-#: src/filemanager/boxes.c:736
+#: src/filemanager/boxes.c:775
 msgid ""
 "Using the fast reload option may not reflect the exact\n"
 "directory contents. In this case you'll need to do a\n"
@@ -2589,144 +2583,144 @@ msgid ""
 "the details."
 msgstr ""
 
-#: src/filemanager/boxes.c:771
+#: src/filemanager/boxes.c:810
 msgid "&Full file list"
 msgstr ""
 
-#: src/filemanager/boxes.c:772
+#: src/filemanager/boxes.c:811
 msgid "&Brief file list:"
 msgstr ""
 
-#: src/filemanager/boxes.c:773
+#: src/filemanager/boxes.c:812
 msgid "&Long file list"
 msgstr ""
 
-#: src/filemanager/boxes.c:774
+#: src/filemanager/boxes.c:813
 msgid "&User defined:"
 msgstr ""
 
-#: src/filemanager/boxes.c:783
+#: src/filemanager/boxes.c:822
 msgid "columns"
 msgstr ""
 
-#: src/filemanager/boxes.c:790
+#: src/filemanager/boxes.c:829
 msgid "User &mini status"
 msgstr ""
 
-#: src/filemanager/boxes.c:802
+#: src/filemanager/boxes.c:841
 msgid "Listing format"
 msgstr ""
 
-#: src/filemanager/boxes.c:884
+#: src/filemanager/boxes.c:923
 msgid "Executable &first"
 msgstr ""
 
-#: src/filemanager/boxes.c:886
+#: src/filemanager/boxes.c:925
 msgid "&Reverse"
 msgstr ""
 
-#: src/filemanager/boxes.c:897
+#: src/filemanager/boxes.c:936
 msgid "Sort order"
 msgstr ""
 
 #. TRANSLATORS: no need to translate 'Confirmation', it's just a context prefix
-#: src/filemanager/boxes.c:923
+#: src/filemanager/boxes.c:962
 msgid "Confirmation|&Delete"
 msgstr ""
 
-#: src/filemanager/boxes.c:924
+#: src/filemanager/boxes.c:963
 msgid "Confirmation|O&verwrite"
 msgstr ""
 
-#: src/filemanager/boxes.c:925
+#: src/filemanager/boxes.c:964
 msgid "Confirmation|&Execute"
 msgstr ""
 
-#: src/filemanager/boxes.c:926
+#: src/filemanager/boxes.c:965
 msgid "Confirmation|E&xit"
 msgstr ""
 
-#: src/filemanager/boxes.c:927
+#: src/filemanager/boxes.c:966
 msgid "Confirmation|Di&rectory hotlist delete"
 msgstr ""
 
-#: src/filemanager/boxes.c:929
+#: src/filemanager/boxes.c:968
 msgid "Confirmation|&History cleanup"
 msgstr ""
 
-#: src/filemanager/boxes.c:939 src/filemanager/cmd.c:137
+#: src/filemanager/boxes.c:978 src/filemanager/cmd.c:137
 msgid "Confirmation"
 msgstr ""
 
-#: src/filemanager/boxes.c:967 src/filemanager/tree.c:1119
+#: src/filemanager/boxes.c:1006 src/filemanager/tree.c:1122
 msgid "Directory tree"
 msgstr ""
 
-#: src/filemanager/boxes.c:1017
+#: src/filemanager/boxes.c:1056
 msgid "Timeout for freeing VFSs (sec):"
 msgstr ""
 
-#: src/filemanager/boxes.c:1022
+#: src/filemanager/boxes.c:1061
 msgid "FTP anonymous password:"
 msgstr ""
 
-#: src/filemanager/boxes.c:1025
+#: src/filemanager/boxes.c:1064
 msgid "FTP directory cache timeout (sec):"
 msgstr ""
 
-#: src/filemanager/boxes.c:1028
+#: src/filemanager/boxes.c:1067
 msgid "&Always use ftp proxy:"
 msgstr ""
 
-#: src/filemanager/boxes.c:1032
+#: src/filemanager/boxes.c:1071
 msgid "&Use ~/.netrc"
 msgstr ""
 
-#: src/filemanager/boxes.c:1033
+#: src/filemanager/boxes.c:1072
 msgid "Use &passive mode"
 msgstr ""
 
-#: src/filemanager/boxes.c:1034
+#: src/filemanager/boxes.c:1073
 msgid "Use passive mode over pro&xy"
 msgstr ""
 
-#: src/filemanager/boxes.c:1045
+#: src/filemanager/boxes.c:1084
 msgid "Virtual File System Setting"
 msgstr ""
 
-#: src/filemanager/boxes.c:1101
+#: src/filemanager/boxes.c:1140
 msgid "cd"
 msgstr ""
 
-#: src/filemanager/boxes.c:1110
+#: src/filemanager/boxes.c:1149
 msgid "Quick cd"
 msgstr ""
 
-#: src/filemanager/boxes.c:1127
+#: src/filemanager/boxes.c:1166
 msgid "Existing filename (filename symlink will point to):"
 msgstr ""
 
-#: src/filemanager/boxes.c:1131
+#: src/filemanager/boxes.c:1170
 msgid "Symbolic link filename:"
 msgstr ""
 
-#: src/filemanager/boxes.c:1142
+#: src/filemanager/boxes.c:1181
 msgid "Symbolic link"
 msgstr ""
 
-#: src/filemanager/boxes.c:1170
+#: src/filemanager/boxes.c:1209
 msgid "&Stop"
 msgstr ""
 
-#: src/filemanager/boxes.c:1171
+#: src/filemanager/boxes.c:1210
 msgid "&Resume"
 msgstr ""
 
-#: src/filemanager/boxes.c:1172
+#: src/filemanager/boxes.c:1211
 msgid "&Kill"
 msgstr ""
 
-#: src/filemanager/boxes.c:1201
+#: src/filemanager/boxes.c:1240
 msgid "Background jobs"
 msgstr ""
 
@@ -2734,254 +2728,260 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
-msgstr ""
-
-#: src/filemanager/chattr.c:141
-msgid "Secure deletion"
 msgstr ""
 
 #: src/filemanager/chattr.c:142
-msgid "Undelete"
+msgid "Secure deletion"
 msgstr ""
 
 #: src/filemanager/chattr.c:143
-msgid "Synchronous updates"
+msgid "Undelete"
 msgstr ""
 
 #: src/filemanager/chattr.c:144
-msgid "Synchronous directory updates"
+msgid "Synchronous updates"
 msgstr ""
 
 #: src/filemanager/chattr.c:145
-msgid "Immutable"
+msgid "Synchronous directory updates"
 msgstr ""
 
 #: src/filemanager/chattr.c:146
-msgid "Append only"
+msgid "Immutable"
 msgstr ""
 
 #: src/filemanager/chattr.c:147
-msgid "No dump"
+msgid "Append only"
 msgstr ""
 
 #: src/filemanager/chattr.c:148
-msgid "No update atime"
+msgid "No dump"
 msgstr ""
 
 #: src/filemanager/chattr.c:149
+msgid "No update atime"
+msgstr ""
+
+#: src/filemanager/chattr.c:150
 msgid "Compress"
 msgstr ""
 
-#: src/filemanager/chattr.c:153
+#: src/filemanager/chattr.c:154
 msgid "Compressed clusters"
 msgstr ""
 
-#: src/filemanager/chattr.c:158
+#: src/filemanager/chattr.c:159
 msgid "Compressed dirty file"
 msgstr ""
 
-#: src/filemanager/chattr.c:163
+#: src/filemanager/chattr.c:164
 msgid "Compression raw access"
 msgstr ""
 
-#: src/filemanager/chattr.c:166
+#: src/filemanager/chattr.c:167
 msgid "Encrypted inode"
 msgstr ""
 
-#: src/filemanager/chattr.c:168
+#: src/filemanager/chattr.c:169
 msgid "Journaled data"
 msgstr ""
 
-#: src/filemanager/chattr.c:169
+#: src/filemanager/chattr.c:170
 msgid "Indexed directory"
 msgstr ""
 
-#: src/filemanager/chattr.c:170
+#: src/filemanager/chattr.c:171
 msgid "No tail merging"
 msgstr ""
 
-#: src/filemanager/chattr.c:171
+#: src/filemanager/chattr.c:172
 msgid "Top of directory hierarchies"
 msgstr ""
 
-#: src/filemanager/chattr.c:172
+#: src/filemanager/chattr.c:173
 msgid "Inode uses extents"
 msgstr ""
 
-#: src/filemanager/chattr.c:176
+#: src/filemanager/chattr.c:177
 msgid "Huge_file"
 msgstr ""
 
-#: src/filemanager/chattr.c:178
+#: src/filemanager/chattr.c:179
 msgid "No COW"
 msgstr ""
 
-#: src/filemanager/chattr.c:182
+#: src/filemanager/chattr.c:183
 msgid "Direct access for files"
 msgstr ""
 
-#: src/filemanager/chattr.c:187
+#: src/filemanager/chattr.c:188
 msgid "Casefolded file"
 msgstr ""
 
-#: src/filemanager/chattr.c:190
+#: src/filemanager/chattr.c:191
 msgid "Inode has inline data"
 msgstr ""
 
-#: src/filemanager/chattr.c:196
+#: src/filemanager/chattr.c:197
 msgid "Project hierarchy"
 msgstr ""
 
-#: src/filemanager/chattr.c:203
+#: src/filemanager/chattr.c:204
 msgid "Verity protected inode"
 msgstr ""
 
-#: src/filemanager/chattr.c:226 src/filemanager/chmod.c:108
+#: src/filemanager/chattr.c:227 src/filemanager/chmod.c:110
 msgid "&Marked all"
 msgstr ""
 
-#: src/filemanager/chattr.c:227 src/filemanager/chmod.c:109
+#: src/filemanager/chattr.c:228 src/filemanager/chmod.c:111
 msgid "S&et marked"
 msgstr ""
 
-#: src/filemanager/chattr.c:228 src/filemanager/chmod.c:110
+#: src/filemanager/chattr.c:229 src/filemanager/chmod.c:112
 msgid "C&lear marked"
 msgstr ""
 
-#: src/filemanager/chattr.c:991
+#: src/filemanager/chattr.c:992
 msgid "Chattr command"
 msgstr ""
 
-#: src/filemanager/chattr.c:1098 src/filemanager/chattr.c:1243
+#: src/filemanager/chattr.c:1100
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#: src/filemanager/chattr.c:1215
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/chattr.c:1218
+#: src/filemanager/chattr.c:1239
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
-msgstr ""
-
-#: src/filemanager/chmod.c:74
-msgid "set &user ID on execution"
-msgstr ""
-
-#: src/filemanager/chmod.c:75
-msgid "set &group ID on execution"
 msgstr ""
 
 #: src/filemanager/chmod.c:76
-msgid "stick&y bit"
+msgid "set &user ID on execution"
 msgstr ""
 
 #: src/filemanager/chmod.c:77
-msgid "&read by owner"
+msgid "set &group ID on execution"
 msgstr ""
 
 #: src/filemanager/chmod.c:78
-msgid "&write by owner"
+msgid "stick&y bit"
 msgstr ""
 
 #: src/filemanager/chmod.c:79
-msgid "e&xecute/search by owner"
+msgid "&read by owner"
 msgstr ""
 
 #: src/filemanager/chmod.c:80
-msgid "rea&d by group"
+msgid "&write by owner"
 msgstr ""
 
 #: src/filemanager/chmod.c:81
-msgid "write by grou&p"
+msgid "e&xecute/search by owner"
 msgstr ""
 
 #: src/filemanager/chmod.c:82
-msgid "execu&te/search by group"
+msgid "rea&d by group"
 msgstr ""
 
 #: src/filemanager/chmod.c:83
-msgid "read &by others"
+msgid "write by grou&p"
 msgstr ""
 
 #: src/filemanager/chmod.c:84
-msgid "wr&ite by others"
+msgid "execu&te/search by group"
 msgstr ""
 
 #: src/filemanager/chmod.c:85
+msgid "read &by others"
+msgstr ""
+
+#: src/filemanager/chmod.c:86
+msgid "wr&ite by others"
+msgstr ""
+
+#: src/filemanager/chmod.c:87
 msgid "execute/searc&h by others"
 msgstr ""
 
-#: src/filemanager/chmod.c:91
+#: src/filemanager/chmod.c:93
 msgid "Name:"
 msgstr ""
 
-#: src/filemanager/chmod.c:92
+#: src/filemanager/chmod.c:94
 msgid "Permissions (octal):"
 msgstr ""
 
-#: src/filemanager/chmod.c:93
+#: src/filemanager/chmod.c:95
 msgid "Owner name:"
 msgstr ""
 
-#: src/filemanager/chmod.c:94
+#: src/filemanager/chmod.c:96
 msgid "Group name:"
 msgstr ""
 
-#: src/filemanager/chmod.c:330
+#: src/filemanager/chmod.c:332
 msgid "Chmod command"
 msgstr ""
 
-#: src/filemanager/chmod.c:336 src/filemanager/chown.c:157
+#: src/filemanager/chmod.c:338 src/filemanager/chown.c:158
 #: src/filemanager/panel.c:205
 msgid "Permission"
 msgstr ""
 
-#: src/filemanager/chmod.c:345 src/filemanager/chown.c:223
+#: src/filemanager/chmod.c:347 src/filemanager/chown.c:224
 msgid "File"
 msgstr ""
 
-#: src/filemanager/chown.c:83
+#: src/filemanager/chown.c:84
 msgid "Set &groups"
 msgstr ""
 
-#: src/filemanager/chown.c:84
+#: src/filemanager/chown.c:85
 msgid "Set &users"
 msgstr ""
 
-#: src/filemanager/chown.c:149
+#: src/filemanager/chown.c:150
 msgid "Name"
 msgstr ""
 
-#: src/filemanager/chown.c:151
+#: src/filemanager/chown.c:152
 msgid "Owner name"
 msgstr ""
 
-#: src/filemanager/chown.c:153 src/filemanager/chown.c:212
+#: src/filemanager/chown.c:154 src/filemanager/chown.c:213
 msgid "Group name"
 msgstr ""
 
-#: src/filemanager/chown.c:155
+#: src/filemanager/chown.c:156
 msgid "Size"
 msgstr ""
 
-#: src/filemanager/chown.c:195
+#: src/filemanager/chown.c:196
 msgid "Chown command"
 msgstr ""
 
-#: src/filemanager/chown.c:201
+#: src/filemanager/chown.c:202
 msgid "User name"
 msgstr ""
 
-#: src/filemanager/chown.c:205
+#: src/filemanager/chown.c:206
 msgid "<Unknown user>"
 msgstr ""
 
-#: src/filemanager/chown.c:216
+#: src/filemanager/chown.c:217
 msgid "<Unknown group>"
 msgstr ""
 
@@ -3004,12 +3004,16 @@ msgstr ""
 
 #: src/filemanager/cmd.c:324
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #: src/filemanager/cmd.c:363
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 #: src/filemanager/cmd.c:588
@@ -3038,6 +3042,13 @@ msgstr ""
 
 #: src/filemanager/cmd.c:754
 msgid "Enter directory name:"
+msgstr ""
+
+#: src/filemanager/cmd.c:778
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 #: src/filemanager/cmd.c:815
@@ -3103,93 +3114,94 @@ msgstr ""
 
 #: src/filemanager/cmd.c:1111
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
-#: src/filemanager/cmd.c:1119
+#: src/filemanager/cmd.c:1118
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
-#: src/filemanager/cmd.c:1156
+#: src/filemanager/cmd.c:1155
 msgid "FTP to machine"
 msgstr ""
 
-#: src/filemanager/cmd.c:1167
+#: src/filemanager/cmd.c:1166
 msgid "SFTP to machine"
 msgstr ""
 
-#: src/filemanager/cmd.c:1179
+#: src/filemanager/cmd.c:1178
 msgid "Shell link to machine"
 msgstr ""
 
-#: src/filemanager/cmd.c:1190
+#: src/filemanager/cmd.c:1189
 msgid "Undelete files on an ext2 file system"
 msgstr ""
 
-#: src/filemanager/cmd.c:1191
+#: src/filemanager/cmd.c:1190
 msgid ""
 "Enter device (without /dev/) to undelete\n"
 "files on: (F1 for details)"
 msgstr ""
 
-#: src/filemanager/cmd.c:1253 src/filemanager/cmd.c:1287
-#: src/filemanager/file.c:759
+#: src/filemanager/cmd.c:1252 src/filemanager/cmd.c:1286
+#: src/filemanager/file.c:756
 msgid "Directory scanning"
 msgstr ""
 
-#: src/filemanager/cmd.c:1334 src/filemanager/cmd.c:1336
+#: src/filemanager/cmd.c:1333 src/filemanager/cmd.c:1335
 msgid "Setup"
 msgstr ""
 
-#: src/filemanager/cmd.c:1334
+#: src/filemanager/cmd.c:1333
 #, c-format
 msgid "Setup saved to %s"
 msgstr ""
 
-#: src/filemanager/cmd.c:1336
+#: src/filemanager/cmd.c:1335
 #, c-format
 msgid "Unable to save setup to %s"
 msgstr ""
 
-#: src/filemanager/command.c:119 src/usermenu.c:997
+#: src/filemanager/command.c:119 src/usermenu.c:996
 msgid "Cannot execute commands on non-local filesystems"
 msgstr ""
 
-#: src/filemanager/ext.c:248 src/usermenu.c:497
+#: src/filemanager/ext.c:248 src/usermenu.c:496
 msgid "Parameter"
 msgstr ""
 
 #: src/filemanager/ext.c:460 src/usermenu.c:468
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
-#: src/filemanager/ext.c:739
+#: src/filemanager/ext.c:738
 msgid "Pipe failed"
 msgstr ""
 
-#: src/filemanager/ext.c:776
+#: src/filemanager/ext.c:775
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
-#: src/filemanager/ext.c:827
+#: src/filemanager/ext.c:826
 #, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
-#: src/filemanager/ext.c:843
+#: src/filemanager/ext.c:842
 #, c-format
 msgid ""
 "The format of the\n"
@@ -3200,104 +3212,99 @@ msgid ""
 "or use that file as an example of how to write it."
 msgstr ""
 
-#: src/filemanager/file.c:94 src/filemanager/file.c:2825
-#: src/filemanager/file.c:2886 src/filemanager/tree.c:719
+#: src/filemanager/file.c:95 src/filemanager/file.c:2821
+#: src/filemanager/file.c:2882 src/filemanager/tree.c:720
 msgid "DialogTitle|Copy"
 msgstr ""
 
-#: src/filemanager/file.c:95 src/filemanager/tree.c:750
+#: src/filemanager/file.c:96 src/filemanager/tree.c:751
 msgid "DialogTitle|Move"
 msgstr ""
 
-#: src/filemanager/file.c:96 src/filemanager/hotlist.c:1153
-#: src/filemanager/hotlist.c:1170 src/filemanager/tree.c:817
+#: src/filemanager/file.c:97 src/filemanager/hotlist.c:1153
+#: src/filemanager/hotlist.c:1170 src/filemanager/tree.c:820
 msgid "DialogTitle|Delete"
 msgstr ""
 
-#: src/filemanager/file.c:150
+#: src/filemanager/file.c:151
 msgid "FileOperation|Copy"
 msgstr ""
 
-#: src/filemanager/file.c:151
+#: src/filemanager/file.c:152
 msgid "FileOperation|Move"
 msgstr ""
 
-#: src/filemanager/file.c:152
+#: src/filemanager/file.c:153
 msgid "FileOperation|Delete"
 msgstr ""
 
-#: src/filemanager/file.c:165
+#: src/filemanager/file.c:166
 #, no-c-format
 msgid "%o %f%n\"%s\"%m"
 msgstr ""
 
-#: src/filemanager/file.c:167
+#: src/filemanager/file.c:168
 #, no-c-format
 msgid "%o %d %f%m"
 msgstr ""
 
-#: src/filemanager/file.c:170
+#: src/filemanager/file.c:171
 msgid "files"
 msgstr ""
 
-#: src/filemanager/file.c:170
+#: src/filemanager/file.c:171
 msgid "directory"
 msgstr ""
 
-#: src/filemanager/file.c:170
+#: src/filemanager/file.c:171
 msgid "directories"
 msgstr ""
 
-#: src/filemanager/file.c:170
+#: src/filemanager/file.c:171
 msgid "files/directories"
 msgstr ""
 
 #. TRANSLATORS: keep leading space here to split words in Copy/Move dialog
-#: src/filemanager/file.c:172
+#: src/filemanager/file.c:173
 msgid " with source mask:"
 msgstr ""
 
 #: src/filemanager/file.c:404
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:424
+#: src/filemanager/file.c:423 src/filemanager/file.c:458
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:459
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#: src/filemanager/file.c:523
+#: src/filemanager/file.c:521
 #, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:537
+#: src/filemanager/file.c:535
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
 "\n"
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#: src/filemanager/file.c:608
+#: src/filemanager/file.c:605
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:922
+#: src/filemanager/file.c:919
 #, c-format
 msgid ""
 "\"%s\"\n"
@@ -3306,7 +3313,7 @@ msgid ""
 "are the same directory"
 msgstr ""
 
-#: src/filemanager/file.c:924
+#: src/filemanager/file.c:921
 #, c-format
 msgid ""
 "\"%s\"\n"
@@ -3315,282 +3322,300 @@ msgid ""
 "are the same file"
 msgstr ""
 
-#: src/filemanager/file.c:946 src/filemanager/file.c:950
+#: src/filemanager/file.c:943 src/filemanager/file.c:947
+#: src/vfs/sftpfs/connection.c:569 src/vfs/sftpfs/connection.c:582
+msgid "&Ignore"
+msgstr ""
+
+#: src/filemanager/file.c:943 src/filemanager/file.c:947
 msgid "Ignore a&ll"
 msgstr ""
 
-#: src/filemanager/file.c:992
+#: src/filemanager/file.c:944 src/viewer/hex.c:419
+msgid "&Retry"
+msgstr ""
+
+#: src/filemanager/file.c:989
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
-#: src/filemanager/file.c:993
+#: src/filemanager/file.c:990
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
-#: src/filemanager/file.c:1000 src/filemanager/filegui.c:494
+#: src/filemanager/file.c:998 src/filemanager/filegui.c:494
 msgid "Non&e"
 msgstr ""
 
-#: src/filemanager/file.c:1182
+#: src/filemanager/file.c:1188
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:1238
+#: src/filemanager/file.c:1244
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:1254
+#: src/filemanager/file.c:1260
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr ""
 
-#: src/filemanager/file.c:1305
+#: src/filemanager/file.c:1311
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:1419
+#: src/filemanager/file.c:1425
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:1514
+#: src/filemanager/file.c:1520
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:1684 src/filemanager/file.c:2329
+#: src/filemanager/file.c:1689 src/filemanager/file.c:2332
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:1686
+#: src/filemanager/file.c:1691
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:1708
+#: src/filemanager/file.c:1712
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:1822
+#: src/filemanager/file.c:1826
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
-#: src/filemanager/file.c:2349
+#: src/filemanager/file.c:2351
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2380
+#: src/filemanager/file.c:2382
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2451 src/filemanager/file.c:2528
+#: src/filemanager/file.c:2453 src/filemanager/file.c:2528
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2477
+#: src/filemanager/file.c:2479
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2491 src/filemanager/file.c:2904
+#: src/filemanager/file.c:2492 src/filemanager/file.c:2899
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2507 src/filemanager/file.c:2926
+#: src/filemanager/file.c:2507 src/filemanager/file.c:2920
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2559
+#: src/filemanager/file.c:2557
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2571
+#: src/filemanager/file.c:2569
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
-#: src/filemanager/file.c:2583
+#: src/filemanager/file.c:2580
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2616
+#: src/filemanager/file.c:2613
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2649
+#: src/filemanager/file.c:2645
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2670
+#: src/filemanager/file.c:2666
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2727
+#: src/filemanager/file.c:2723
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2767
+#: src/filemanager/file.c:2763
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2805
+#: src/filemanager/file.c:2801
 msgid "(stalled)"
 msgstr ""
 
-#: src/filemanager/file.c:2825 src/filemanager/file.c:2886
+#: src/filemanager/file.c:2821 src/filemanager/file.c:2882
 msgid "Incomplete file was retrieved"
 msgstr ""
 
-#: src/filemanager/file.c:2826 src/filemanager/file.c:2887
+#: src/filemanager/file.c:2822 src/filemanager/file.c:2883
 msgid "&Keep"
 msgstr ""
 
-#: src/filemanager/file.c:2826
+#: src/filemanager/file.c:2822
 msgid "&Continue copy"
 msgstr ""
 
-#: src/filemanager/file.c:2862
+#: src/filemanager/file.c:2858
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2874
+#: src/filemanager/file.c:2870
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:2970
+#: src/filemanager/file.c:2964
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:3034
+#: src/filemanager/file.c:3027
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:3055
+#: src/filemanager/file.c:3048
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:3104
+#: src/filemanager/file.c:3097
 #, c-format
 msgid ""
 "Source \"%s\" is not a directory\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:3116
+#: src/filemanager/file.c:3109
 #, c-format
 msgid ""
 "Cannot copy cyclic symbolic link\n"
 "\"%s\""
 msgstr ""
 
-#: src/filemanager/file.c:3155 src/filemanager/file.c:3656
-#: src/filemanager/tree.c:764
+#: src/filemanager/file.c:3148 src/filemanager/file.c:3647
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:3187
+#: src/filemanager/file.c:3179
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:3212
+#: src/filemanager/file.c:3203
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/file.c:3428
+#: src/filemanager/file.c:3419
 #, c-format
 msgid "Directories: %zu, total size: %s"
 msgstr ""
 
-#: src/filemanager/file.c:3571
+#: src/filemanager/file.c:3562
 msgid "Sorry, I could not put the job in background"
 msgstr ""
 
@@ -3997,55 +4022,50 @@ msgstr ""
 msgid "&Virtual FS..."
 msgstr ""
 
-#: src/filemanager/filemanager.c:430
+#: src/filemanager/filemanager.c:432
 msgid "Panels:"
 msgstr ""
 
-#: src/filemanager/filemanager.c:1026
+#: src/filemanager/filemanager.c:1028
 #, c-format
 msgid "You have %zu opened screen. Quit anyway?"
 msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/filemanager/filemanager.c:1030 src/filemanager/filemanager.c:1037
-#: src/filemanager/panel.c:2897
-msgid "The Midnight Commander"
-msgstr ""
-
 #: src/filemanager/filemanager.c:1038
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
-#: src/filemanager/filemanager.c:1592
+#: src/filemanager/filemanager.c:1595
 msgid "&Above"
 msgstr ""
 
-#: src/filemanager/filemanager.c:1592
+#: src/filemanager/filemanager.c:1595
 msgid "&Left"
 msgstr ""
 
-#: src/filemanager/filemanager.c:1593
+#: src/filemanager/filemanager.c:1596
 msgid "&Below"
 msgstr ""
 
-#: src/filemanager/filemanager.c:1593
+#: src/filemanager/filemanager.c:1596
 msgid "&Right"
 msgstr ""
 
-#: src/filemanager/filemanager.c:1606
+#: src/filemanager/filemanager.c:1609
 msgid "ButtonBar|Menu"
 msgstr ""
 
-#: src/filemanager/filemanager.c:1607 src/viewer/display.c:88
+#: src/filemanager/filemanager.c:1610 src/viewer/display.c:88
 msgid "ButtonBar|View"
 msgstr ""
 
-#: src/filemanager/filemanager.c:1610 src/filemanager/tree.c:1171
+#: src/filemanager/filemanager.c:1613 src/filemanager/tree.c:1174
 msgid "ButtonBar|RenMov"
 msgstr ""
 
-#: src/filemanager/filemanager.c:1611 src/filemanager/tree.c:1174
+#: src/filemanager/filemanager.c:1614 src/filemanager/tree.c:1177
 msgid "ButtonBar|Mkdir"
 msgstr ""
 
@@ -4057,7 +4077,7 @@ msgstr ""
 msgid "&Again"
 msgstr ""
 
-#: src/filemanager/find.c:191 src/filemanager/panelize.c:167
+#: src/filemanager/find.c:191 src/filemanager/panelize.c:170
 msgid "Pane&lize"
 msgstr ""
 
@@ -4190,7 +4210,7 @@ msgstr ""
 msgid "&Insert"
 msgstr ""
 
-#: src/filemanager/hotlist.c:194 src/filemanager/panelize.c:168
+#: src/filemanager/hotlist.c:194 src/filemanager/panelize.c:171
 msgid "&Remove"
 msgstr ""
 
@@ -4625,112 +4645,118 @@ msgstr ""
 msgid "User supplied format looks invalid, reverting to default."
 msgstr ""
 
-#: src/filemanager/panelize.c:169
+#: src/filemanager/panelize.c:172
 msgid "&Add new"
 msgstr ""
 
-#: src/filemanager/panelize.c:201 src/filemanager/panelize.c:307
+#: src/filemanager/panelize.c:204 src/filemanager/panelize.c:310
 msgid "External panelize"
 msgstr ""
 
-#: src/filemanager/panelize.c:210 src/filemanager/panelize.c:287
-#: src/filemanager/panelize.c:496 src/filemanager/panelize.c:553
+#: src/filemanager/panelize.c:213 src/filemanager/panelize.c:290
+#: src/filemanager/panelize.c:499 src/filemanager/panelize.c:556
 msgid "Other command"
 msgstr ""
 
-#: src/filemanager/panelize.c:214
+#: src/filemanager/panelize.c:217
 msgid "Command"
 msgstr ""
 
-#: src/filemanager/panelize.c:273
+#: src/filemanager/panelize.c:276
 msgid "Add to external panelize"
 msgstr ""
 
-#: src/filemanager/panelize.c:273
+#: src/filemanager/panelize.c:276
 msgid "Enter command label:"
 msgstr ""
 
-#: src/filemanager/panelize.c:333 src/filemanager/panelize.c:339
+#: src/filemanager/panelize.c:336 src/filemanager/panelize.c:342
 #, c-format
 msgid ""
 "External panelize:\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/panelize.c:350
-#, c-format
+#: src/filemanager/panelize.c:353
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
-#: src/filemanager/panelize.c:439
+#: src/filemanager/panelize.c:442
 msgid "Cannot run external panelize in a non-local directory"
 msgstr ""
 
-#: src/filemanager/panelize.c:500
+#: src/filemanager/panelize.c:503
 msgid "Modified git files"
 msgstr ""
 
-#: src/filemanager/panelize.c:501
+#: src/filemanager/panelize.c:504
 msgid "Find rejects after patching"
 msgstr ""
 
-#: src/filemanager/panelize.c:503
+#: src/filemanager/panelize.c:506
 msgid "Find *.orig after patching"
 msgstr ""
 
-#: src/filemanager/panelize.c:505
+#: src/filemanager/panelize.c:508
 msgid "Find SUID and SGID programs"
 msgstr ""
 
-#: src/filemanager/tree.c:176
+#: src/filemanager/tree.c:177
 #, c-format
 msgid ""
 "Cannot open the %s file for writing:\n"
 "%s\n"
 msgstr ""
 
-#: src/filemanager/tree.c:717
+#: src/filemanager/tree.c:718
 #, c-format
 msgid "Copy \"%s\" directory to:"
 msgstr ""
 
-#: src/filemanager/tree.c:748
+#: src/filemanager/tree.c:749
 #, c-format
 msgid "Move \"%s\" directory to:"
 msgstr ""
 
-#: src/filemanager/tree.c:761
+#: src/filemanager/tree.c:762
 #, c-format
 msgid ""
 "Cannot stat the destination\n"
 "%s"
 msgstr ""
 
-#: src/filemanager/tree.c:815
+#: src/filemanager/tree.c:766
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+
+#: src/filemanager/tree.c:818
 #, c-format
 msgid "Delete %s?"
 msgstr ""
 
-#: src/filemanager/tree.c:969 src/filemanager/tree.c:1168
+#: src/filemanager/tree.c:972 src/filemanager/tree.c:1171
 msgid "ButtonBar|Static"
 msgstr ""
 
-#: src/filemanager/tree.c:969 src/filemanager/tree.c:1168
+#: src/filemanager/tree.c:972 src/filemanager/tree.c:1171
 msgid "ButtonBar|Dynamc"
 msgstr ""
 
-#: src/filemanager/tree.c:1165
+#: src/filemanager/tree.c:1168
 msgid "ButtonBar|Rescan"
 msgstr ""
 
-#: src/filemanager/tree.c:1166
+#: src/filemanager/tree.c:1169
 msgid "ButtonBar|Forget"
 msgstr ""
 
-#: src/filemanager/tree.c:1178
+#: src/filemanager/tree.c:1181
 msgid "ButtonBar|Rmdir"
 msgstr ""
 
@@ -4834,13 +4860,14 @@ msgid "Home directory path is not absolute"
 msgstr ""
 
 #: src/main.c:386
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
 
-#: src/main.c:519
+#: src/main.c:521
 #, c-format
 msgid ""
 "\n"
@@ -5015,41 +5042,41 @@ msgstr ""
 msgid "False:"
 msgstr ""
 
-#: src/usermenu.c:602
+#: src/usermenu.c:601
 msgid "Error calling program"
 msgstr ""
 
-#: src/usermenu.c:630
+#: src/usermenu.c:629
 msgid "Warning -- ignoring file"
 msgstr ""
 
-#: src/usermenu.c:631
+#: src/usermenu.c:630
 #, c-format
 msgid ""
 "File %s is not owned by root or you or is world writable.\n"
 "Using it may compromise your security"
 msgstr ""
 
-#: src/usermenu.c:743
+#: src/usermenu.c:742
 msgid "Format error on file Extensions File"
 msgstr ""
 
-#: src/usermenu.c:744
+#: src/usermenu.c:743
 #, c-format
 msgid "The %%var macro has no default"
 msgstr ""
 
-#: src/usermenu.c:745
+#: src/usermenu.c:744
 #, c-format
 msgid "The %%var macro has no variable"
 msgstr ""
 
-#: src/usermenu.c:1130
+#: src/usermenu.c:1127
 #, c-format
 msgid "No suitable entries found in %s"
 msgstr ""
 
-#: src/usermenu.c:1143
+#: src/usermenu.c:1140
 msgid "User menu"
 msgstr ""
 
@@ -5660,9 +5687,10 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
-#: src/viewer/actions_cmd.c:602
+#: src/viewer/actions_cmd.c:603
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -5726,11 +5754,8 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#: src/viewer/growbuf.c:209
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#: src/viewer/growbuf.c:208
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #: src/viewer/hex.c:407
@@ -5748,25 +5773,24 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/viewer/lib.c:390 src/viewer/lib.c:392
+#: src/viewer/lib.c:392 src/viewer/lib.c:394
 msgid "View: "
 msgstr ""
 
-#: src/viewer/mcviewer.c:332
+#: src/viewer/mcviewer.c:357
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
-#: src/viewer/mcviewer.c:362
-msgid "Cannot view: not a regular file"
-msgstr ""
-
-#: src/viewer/mcviewer.c:397
+#: src/viewer/mcviewer.c:394
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/mn.po
+++ b/po/mn.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Shuree Nyam-Oidov <99shuree@gmail.com>, 2020\n"
 "Language-Team: Mongolian (http://app.transifex.com/mc/mc/language/mn/)\n"
@@ -48,6 +48,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -729,7 +732,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -795,24 +798,22 @@ msgstr "Хайх"
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
 msgid "&Fastest (Assume large files)"
 msgstr ""
@@ -880,16 +881,17 @@ msgstr "Сонглт"
 msgid "ButtonBar|Quit"
 msgstr "Гарах"
 
-msgid "Quit"
-msgstr "Гарах"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
+
+msgid "Quit"
+msgstr "Гарах"
 
 msgid "Diff:"
 msgstr ""
@@ -897,15 +899,17 @@ msgstr ""
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"%s\n"
+"is a directory"
+msgstr "өгөгдөлийн лавлахын нэрийг харуулах"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat\n"
 "%s"
-msgstr ""
+msgstr "Анализ хийж чадсангүй:"
 
 msgid "Diff viewer: invalid mode"
 msgstr ""
@@ -920,9 +924,13 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#, c-format
-msgid "Cannot open %s for reading"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
+"tar-архивыг нээж чадсангүй\n"
+"%s"
 
 msgid "Load file"
 msgstr ""
@@ -932,11 +940,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -952,9 +958,13 @@ msgstr "Анхааруулга"
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
+" %s файлыг уншихаар нээж чадсангүй:\n"
+"%s\n"
 
 msgid "File has hard-links. Detach before saving?"
 msgstr ""
@@ -966,13 +976,14 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
-msgstr ""
+" %s файлыг уншихаар нээж чадсангүй:\n"
+"%s\n"
 
 msgid "The file you are saving does not end with a newline."
 msgstr ""
@@ -1016,7 +1027,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1076,7 +1091,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1512,12 +1527,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1646,13 +1659,15 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+"tar-архивыг нээж чадсангүй\n"
+"%s"
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1678,7 +1693,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1711,22 +1727,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
-msgstr "&Дахих"
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1741,6 +1760,20 @@ msgstr ""
 
 msgid "Stopped"
 msgstr "Зогссон"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Хөрвүүлэгдэхгүй >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Кодлогдсон оролт/гаралт: "
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Хэзээч"
@@ -1819,17 +1852,6 @@ msgstr "А&вто тохируулгыг хадгалах"
 
 msgid "Configure options"
 msgstr "Тохиргуулгын параметрүүд"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Хөрвүүлэгдэхгүй >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Кодлогдсон оролт/гаралт: "
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr ""
@@ -2022,12 +2044,11 @@ msgstr "&Устгах"
 msgid "Background jobs"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
-msgstr ""
+msgstr "Хавтасны доторхыг уншиж чадсангүй"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2116,17 +2137,25 @@ msgstr "Тэмдэглэгдсэнг &устгах"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
-msgstr ""
+"Cannot chattr\n"
+"%sn%s"
+msgstr "Анализ хийж чадсангүй:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"tar-архивыг нээж чадсангүй\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Анализ хийж чадсангүй:"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2228,12 +2257,18 @@ msgstr "%s руу холбох:"
 msgid "Link"
 msgstr ""
 
-#, c-format
-msgid "link: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2256,6 +2291,12 @@ msgstr " Шинэ лавлах үүсгэх "
 
 msgid "Enter directory name:"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Хавтасны доторхыг уншиж чадсангүй"
 
 msgid "Extension file edit"
 msgstr " Засварлагдах файлын өргөтгөл "
@@ -2304,12 +2345,16 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
-#, c-format
-msgid "edit symlink: %s"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
+msgstr "&Symlink-ийг засварлах"
 
 msgid "FTP to machine"
 msgstr ""
@@ -2348,11 +2393,9 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
-msgstr ""
+#, fuzzy
+msgid "Cannot create temporary command file"
+msgstr "Хавтасны доторхыг уншиж чадсангүй"
 
 msgid "Pipe failed"
 msgstr ""
@@ -2360,7 +2403,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2370,7 +2413,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2425,27 +2468,27 @@ msgstr "файлууд/лавлахууд"
 msgid " with source mask:"
 msgstr " эх маскийн хамт:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot read source link \"%s\"\n"
+"tar-архивыг нээж чадсангүй\n"
 "%s"
-msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot read source link\n"
+"%s"
+msgstr "Хавтасны доторхыг уншиж чадсангүй"
 
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
@@ -2453,11 +2496,13 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
 #, c-format
 msgid ""
@@ -2475,160 +2520,208 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
 msgstr ""
 
+msgid "&Retry"
+msgstr "&Дахих"
+
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 msgid "Non&e"
 msgstr "&үгүй"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
-msgstr ""
+msgstr "Хавтасны доторхыг уншиж чадсангүй"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Хавтасны доторхыг уншиж чадсангүй"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
+msgstr "Хавтасны доторхыг уншиж чадсангүй"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
-msgstr ""
+msgstr "Хавтасны доторхыг уншиж чадсангүй"
 
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
+"tar-архивыг нээж чадсангүй\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
+"tar-архивыг нээж чадсангүй\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
+"cpio-архивыг нээж чадсангүй\n"
+"%s"
 
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
 
 msgid "(stalled)"
 msgstr "(гацсан)"
@@ -2642,33 +2735,39 @@ msgstr "&Хадгалах"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
+"cpio-архивыг нээж чадсангүй\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot close target file\n"
+"%s"
+msgstr ""
+"tar-архивыг нээж чадсангүй\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot set ext2 attributes for target file\n"
+"%s"
+msgstr ""
+" %s файл руу бичиж чадсангүй:\n"
+"%s\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat source directory\n"
+"%s"
+msgstr "Хавтасны доторхыг уншиж чадсангүй"
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot stat source directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2686,21 +2785,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
-msgstr ""
+msgstr "Хавтасны доторхыг уншиж чадсангүй"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
+"tar-архивыг нээж чадсангүй\n"
+"%s"
 
 #, c-format
 msgid "Directories: %zu, total size: %s"
@@ -3023,10 +3126,7 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3520,11 +3620,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3562,6 +3660,13 @@ msgstr " \"%s\" лавлахыг ийшээ зөөж байна:"
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3678,8 +3783,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4350,8 +4456,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4400,10 +4507,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr "Формат"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4424,18 +4528,20 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
-msgid "Cannot view: not a regular file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
+"tar-архивыг нээж чадсангүй\n"
+"%s"
 
 msgid "Search done"
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Norwegian Bokmål (http://app.transifex.com/mc/mc/language/"
@@ -54,6 +54,9 @@ msgstr "Klarte ikke lage hendelsesgruppa «%s»."
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Klarte ikke lage hendelse «%s»."
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr "Opphavsrett (C) 1996-2025 Free Software Foundation"
 
 #, c-format
 msgid ""
@@ -793,10 +796,10 @@ msgstr "fil1 fil2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[denne mappa] [mappa i det andre panelet]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -867,28 +870,23 @@ msgstr "Søk"
 msgid "Search is disabled"
 msgstr "Søk er slått av"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Klarte ikke opprette midlertidig diff-fil\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Klarte ikke opprette reservekopi\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Klarte ikke opprette midlertidig flettefil\n"
 "%s"
@@ -959,20 +957,21 @@ msgstr "ButtonBar|Innst"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Avslut"
 
-msgid "Quit"
-msgstr "Avslutt"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 "En eller flere filer er endret.\n"
 "Lagre før avslutning?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander avsluttes.\n"
 "En eller flere filer er endret. Lagre?"
+
+msgid "Quit"
+msgstr "Avslutt"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -980,13 +979,15 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr "Filnavnet er tomt!"
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "«%s» er en mappe"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "stat() mislyktes for «%s»\n"
@@ -1005,9 +1006,13 @@ msgstr "Laster: %3d%%"
 msgid "Loading..."
 msgstr "Laster ..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Klarte ikke åpne lesetilgang til %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Klarte ikke åpne «%s»\n"
+"%s"
 
 msgid "Load file"
 msgstr "Last fil"
@@ -1016,12 +1021,10 @@ msgstr "Last fil"
 msgid "Error reading %s"
 msgstr "Klarte ikke lese %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Klarte ikke hente størrelsen/rettighetene til %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "«%s» er ikke en vanlig fil"
 
 #, c-format
@@ -1039,8 +1042,10 @@ msgstr "Advarsel"
 msgid "Error reading from pipe: %s"
 msgstr "Klarte ikke lese fra rør: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Klarte ikke åpne lesetilgang til rør: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1053,12 +1058,11 @@ msgstr "Fila har i mellomtida blitt endret. Lagre den likevel?"
 msgid "Error writing to pipe: %s"
 msgstr "Klarte ikke skrive til rør: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Klarte ikke åpne skrivetilgang til rør: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Klarte ikke åpne skrivetilgang til fil: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1103,8 +1107,12 @@ msgstr "Sjekk om linjeskift avslutter fil (&POSIX)"
 msgid "Edit Save Mode"
 msgstr "Rediger lagringsinnstillinger"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Kan ikke lagre: Målet er ikke en vanlig fil"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Klarte ikke vise: Dette er ikke en vanlig fil"
 
 msgid "A file already exists with this name"
 msgstr "Det finnes allerede en fil som heter dette"
@@ -1163,9 +1171,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Lukk fil"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander avsluttes.\n"
@@ -1608,15 +1616,13 @@ msgstr "Bekreft erstatning"
 msgid "%ld replacements made"
 msgstr "Erstattet %ld forekomster"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Et brukervennlig skriveprogram\n"
 "skrevet for Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr "Opphavsrett (C) 1996-2025 Free Software Foundation"
 
 msgid "About"
 msgstr "Om"
@@ -1744,16 +1750,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Last gjeldende syntaks på nytt >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Klarte ikke åpne fila %s"
+
 msgid "Load syntax file"
 msgstr "Last syntaksfil"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Klarte ikke åpne fila %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1784,7 +1788,8 @@ msgstr ""
 "Ikke en xterm eller Linux-konsoll;\n"
 "kan ikke bytte om underskallet."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Skriv «exit» for å gå tilbake til Midnight Commander"
 
 msgid "Set &all"
@@ -1815,26 +1820,33 @@ msgstr "Rettigheter (oktale):%o"
 msgid "Chown advanced command"
 msgstr "Avansert chown-kommando"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"chmod mislyktes for «%s»\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"chmod mislyktes for «%s»\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "chmod mislyktes for «%s»\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignorer"
-
-msgid "Ignore &all"
-msgstr "Ignorer &alle"
-
-msgid "&Retry"
-msgstr "&Prøv igjen"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "chmod mislyktes for «%s»\n"
@@ -1851,6 +1863,20 @@ msgstr "Kjører"
 
 msgid "Stopped"
 msgstr "Pause"
+
+#, fuzzy
+msgid "No translation"
+msgstr "- < Ingen oversettelse >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Tegnkoding for inndata/visning:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "Aldr&i"
@@ -1929,17 +1955,6 @@ msgstr "Autolagre o&ppsettet"
 
 msgid "Configure options"
 msgstr "Sett opp innstillinger"
-
-#, fuzzy
-msgid "No translation"
-msgstr "- < Ingen oversettelse >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Tegnkoding for inndata/visning:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Drakt:"
@@ -2136,10 +2151,9 @@ msgstr "&Tving stopp"
 msgid "Background jobs"
 msgstr "Bakgrunnsjobber"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "Kan ikke endre mappe til\n"
@@ -2233,20 +2247,28 @@ msgstr "B&lank ut markerte"
 msgid "Chattr command"
 msgstr "Chattr-kommando"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "chattr mislyktes for «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 "Klarte ikke hente ext2-attributtene til «%s»\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"chattr mislyktes for «%s»\n"
 "%s"
 
 msgid "set &user ID on execution"
@@ -2349,13 +2371,21 @@ msgstr "Lag lenke fra %s til:"
 msgid "Link"
 msgstr "Lenke"
 
-#, c-format
-msgid "link: %s"
-msgstr "lenke: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Klarte ikke opprette symlenkas mål «%s»\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "symlenke: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Klarte ikke kopiere syklisk symlenke\n"
+"«%s»"
 
 msgid "View file"
 msgstr "Vis fil"
@@ -2377,6 +2407,12 @@ msgstr "Opprett en ny mappe"
 
 msgid "Enter directory name:"
 msgstr "Skriv inn mappenavn:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Klarte ikke opprette mappa %s"
 
 msgid "Extension file edit"
 msgstr "Rediger utvidelsesfil"
@@ -2426,12 +2462,16 @@ msgstr "Symlenke «%s» peker til:"
 msgid "Edit symlink"
 msgstr "Rediger symlenke"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "redigere symlenke: klarte ikke fjerne %s: %s "
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "redigere symlenke: %s"
 
 msgid "FTP to machine"
@@ -2473,10 +2513,8 @@ msgstr "Kan ikke kjøre kommandoer i eksterne filsystemer"
 msgid "Parameter"
 msgstr "Parameter"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Klarte ikke opprette midlertidig kommandofil\n"
 "%s"
@@ -2484,23 +2522,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "pipe() mislyktes"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "Fila %s er utdatert.\n"
 "Midnight Commandor bruker nå fila %s.\n"
 "Kopier ev. endringer i den gamle fila til den nye."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "Formatet til fila\n"
 "%s%s\n"
@@ -2566,29 +2604,23 @@ msgstr "filer/mapper"
 msgid " with source mask:"
 msgstr " med kildemaske:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "stat() mislyktes for den harde lenkas kildefil «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Klarte ikke opprette den harde lenkas målfil «%s»\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Klarte ikke opprette den harde lenkas målfil «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Klarte ikke lese lenkas kilde «%s»\n"
@@ -2603,9 +2635,9 @@ msgstr ""
 "\n"
 "Innstillingen «Fiks symlenker» slås av"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Klarte ikke opprette symlenkas mål «%s»\n"
@@ -2635,21 +2667,31 @@ msgstr ""
 "«%s»\n"
 "er samme fil"
 
+msgid "&Ignore"
+msgstr "&Ignorer"
+
 msgid "Ignore a&ll"
 msgstr "Ignorer a&lle"
 
-#, c-format
+msgid "&Retry"
+msgstr "&Prøv igjen"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Mappa «%s» er ikke tom.\n"
 "Vil du slette den med alt innhold?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Bakgrunnsprosess:\n"
@@ -2659,17 +2701,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "&Ingen"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Klarte ikke slette fila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "stat() mislyktes for fila «%s»\n"
@@ -2679,108 +2721,110 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Klarte ikke overskrive mappa «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Klarte ikke flytte fila «%s» til «%s»\n"
+"Klarte ikke slette fila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Klarte ikke slette mappa «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 "Kan ikke åpne mappa «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Klarte ikke overskrive mappa «%s»\n"
-"%s"
+msgstr "Klarte ikke overskrive mappa «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Klarte ikke overskrive fila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Klarte ikke flytte mappa «%s» til «%s»\n"
+"Klarte ikke slette mappa «%s»\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Kan ikke gjøre noe med «..»."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "stat() mislyktes for kildefila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 "Klarte ikke hente ext2-attributtene til kildefila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 "Klarte ikke skrive ext2-attributtene til målfila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Klarte ikke opprette spesialfila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "chown mislyktes for fila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "chmod mislyktes for fila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Klarte ikke åpne kildefila «%s»\n"
@@ -2789,49 +2833,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Klarte ikke flette og skal nå overskrive fila"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "fstat() mislyktes for kildefila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Klarte ikke opprette målfila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "fstat() mislyktes for målfila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Klarte ikke forhåndsreserve plass til målfila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Klarte ikke lese kildefila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Klarte ikke skrive målfila «%s»\n"
@@ -2849,41 +2893,41 @@ msgstr "&Behold"
 msgid "&Continue copy"
 msgstr "Fortsett &kopiering"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Klarte ikke lukke kildefila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Klarte ikke lukke målfila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 "Klarte ikke skrive ext2-attributtene til målfila «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "stat() mislyktes for kildemappa «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 "Klarte ikke hente ext2-attributtene til kildemappa «%s»\n"
@@ -2905,25 +2949,27 @@ msgstr ""
 "Klarte ikke kopiere syklisk symlenke\n"
 "«%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Målet «%s» må være en mappe\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Klarte ikke opprette målmappa «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "chown mislyktes for målmappa «%s»\n"
@@ -3251,11 +3297,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "Det er %zu åpen modul. Avslutte likevel?"
 msgstr[1] "Det er %zu åpne moduler. Avslutte likevel?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "VIl du avslutte Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Vil du kjøre?"
 
 msgid "&Above"
 msgstr "&Øverst"
@@ -3754,11 +3798,10 @@ msgstr ""
 "Legg til eksternt i panel:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Legg til eksternt i panel:\n"
 "klarte ikke lese data fra barnets stdout:\n"
@@ -3801,6 +3844,15 @@ msgid ""
 "%s"
 msgstr ""
 "stat() mislyktes for målet\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Målet «%s» må være en mappe\n"
 "%s"
 
 #, c-format
@@ -3923,8 +3975,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Stien til hjemmemappa er ikke absolutt"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4644,8 +4697,9 @@ msgstr "Fila er endret. Lagre før avslutning?"
 msgid "&Cancel quit"
 msgstr "Av&bryt avslutning"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander avsluttes.\n"
@@ -4696,10 +4750,8 @@ msgstr "ButtonBar|IkForm"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Format"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Klarte ikke lese data fra barnets stdout:\n"
 "%s"
@@ -4725,20 +4777,18 @@ msgstr ""
 msgid "View: "
 msgstr "Vis:  "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Klarte ikke åpne «%s»\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Klarte ikke vise: Dette er ikke en vanlig fil"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Klarte ikke åpne «%s» fortolket:\n"
@@ -4752,6 +4802,78 @@ msgstr "Fortsett fra begynnelsen?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Klarte ikke hente en lokal kopi av /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "VIl du avslutte Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Klarte ikke åpne lesetilgang til %s"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Klarte ikke hente størrelsen/rettighetene til %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Klarte ikke åpne skrivetilgang til rør: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Kan ikke lagre: Målet er ikke en vanlig fil"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Klarte ikke åpne fila %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignorer &alle"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "lenke: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "symlenke: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Klarte ikke opprette den harde lenkas målfil «%s»\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Klarte ikke flytte fila «%s» til «%s»\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Klarte ikke overskrive mappa «%s»\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Klarte ikke flytte mappa «%s» til «%s»\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Andre 8-biters"

--- a/po/nl.po
+++ b/po/nl.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2016-2017,2025\n"
 "Language-Team: Dutch (http://app.transifex.com/mc/mc/language/nl/)\n"
@@ -55,6 +55,9 @@ msgstr "Niet in staat groep '%s' voor bewerking aan te maken!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Niet in staat bewerking '%s' aan te maken!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -769,10 +772,10 @@ msgstr "bestand1 bestand2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[deze map] [ander paneel map]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -841,28 +844,23 @@ msgstr "Zoeken"
 msgid "Search is disabled"
 msgstr "Zoekfunctie is uitgeschakeld"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 " Kan geen tijdelijk diff-bestand maken \n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Backup-bestand kan niet gecreëerd worden\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 " Kan geen tijdelijk samenvoegbestand maken \n"
 " %s"
@@ -933,18 +931,19 @@ msgstr " Opties"
 msgid "ButtonBar|Quit"
 msgstr " Afsltn"
 
-msgid "Quit"
-msgstr "Afsltn"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Bestand(en) is/zijn gewijzigd. Opslaan met afsluiten?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander wordt afgesloten.\n"
 "Wijzigingen in bestand(en) opslaan?"
+
+msgid "Quit"
+msgstr "Afsltn"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -952,13 +951,15 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" is een map"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Kan niet stat  \"%s\"\n"
@@ -977,9 +978,13 @@ msgstr "Laden: %3d%%"
 msgid "Loading..."
 msgstr "Laden..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Kan %s niet openen om te lezen"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Kan bestand %s niet openen\n"
+"%s"
 
 msgid "Load file"
 msgstr "Laden bestand"
@@ -988,12 +993,10 @@ msgstr "Laden bestand"
 msgid "Error reading %s"
 msgstr "Fout bij het lezen van %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Kan geen grootte-/rechteninformatie verkrijgen voor %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" is geen normaal bestand"
 
 #, c-format
@@ -1011,8 +1014,10 @@ msgstr "Waarschuwing"
 msgid "Error reading from pipe: %s"
 msgstr "Probleem bij het lezen van pipe: %s "
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Openen van pipe voor lezen mislukt: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1025,12 +1030,11 @@ msgstr "Bestand is in de tussentijd veranderd. Toch opslaan?"
 msgid "Error writing to pipe: %s"
 msgstr "Fout bij het schrijven naar pipe: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Openen van pipe voor lezen mislukt: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Openen van bestand voor schrijven mislukt: %s "
 
 msgid "The file you are saving does not end with a newline."
@@ -1075,8 +1079,12 @@ msgstr "Controleer &POSIX nieuwe regel"
 msgid "Edit Save Mode"
 msgstr "Bewerk Opslag-modus"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Opslaan niet mogelijk: bestemming is geen gewoon bestand"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Kan het niet bekijken: geen normaal bestand"
 
 msgid "A file already exists with this name"
 msgstr "Er bestaat al een bestand met die naam."
@@ -1133,9 +1141,9 @@ msgstr "Bestand %s is gewijzigd. Opslaan voordat wordt afgesloten?"
 msgid "Close file"
 msgstr "Bestand sluiten"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander wordt afgesloten.\n"
@@ -1577,15 +1585,13 @@ msgstr "Vervangen bevestigen"
 msgid "%ld replacements made"
 msgstr "%ld vervangingen doorgevoerd"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Een gebruikersvriendelijke tekstbewerker\n"
 "geschreven voor de Midnight Commander"
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Over"
@@ -1713,16 +1719,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Herlaadt Huidige Syntax >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Kan bestand %s niet openen"
+
 msgid "Load syntax file"
 msgstr "Laad syntaxbestand"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Kan bestand %s niet openen\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1753,7 +1757,8 @@ msgstr ""
 "Geen xterm of Linux-console;\n"
 "de subshell kan niet getoggled worden."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Typ 'exit' om naar de Midnight Commander terug te keren"
 
 msgid "Set &all"
@@ -1784,26 +1789,33 @@ msgstr "Permissies (octaal): %o"
 msgid "Chown advanced command"
 msgstr "Uitgebreide opdracht 'chown'"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"chmod \"%s\" mislukt \n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"chown voor \"%s\" mislukt \n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "chmod \"%s\" mislukt \n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Negeren"
-
-msgid "Ignore &all"
-msgstr "&Alles negeren"
-
-msgid "&Retry"
-msgstr "&Nogmaals"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "chown voor \"%s\" mislukt \n"
@@ -1820,6 +1832,20 @@ msgstr "Aan het draaien"
 
 msgid "Stopped"
 msgstr "Gestopt"
+
+#, fuzzy
+msgid "No translation"
+msgstr "- < Geen vertaling >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Invoer / weergave karakterset:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Nooit"
@@ -1898,17 +1924,6 @@ msgstr "A&utomatisch instellingen opslaan"
 
 msgid "Configure options"
 msgstr "Instellingen"
-
-#, fuzzy
-msgid "No translation"
-msgstr "- < Geen vertaling >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Invoer / weergave karakterset:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Skin:"
@@ -2106,12 +2121,13 @@ msgstr "&Kill"
 msgid "Background jobs"
 msgstr "Achtergrondtaken"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"'chown' van doelmap \"%s\" mislukt \n"
+"%s "
 
 msgid "Secure deletion"
 msgstr "Secure verwijderen"
@@ -2200,19 +2216,29 @@ msgstr "Mar&kering opheffen"
 msgid "Chattr command"
 msgstr "Chattr commando"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Kan niet chattr \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Openen tar-archief mislukt\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Kan niet chattr \"%s\"\n"
+"%s"
 
 msgid "set &user ID on execution"
 msgstr "zet gebr&uikers-ID bij uitvoering"
@@ -2314,13 +2340,21 @@ msgstr "%s verbinden met:"
 msgid "Link"
 msgstr "Link"
 
-#, c-format
-msgid "link: %s"
-msgstr "link: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Maken van doel van symbolische link \"%s\" mislukt \n"
+"%s "
 
-#, c-format
-msgid "symlink: %s"
-msgstr "symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Een cyclische symbolische link kan niet gekopieerd worden \n"
+"`%s' "
 
 msgid "View file"
 msgstr "Bestand bekijken"
@@ -2342,6 +2376,12 @@ msgstr "Maak een nieuwe map"
 
 msgid "Enter directory name:"
 msgstr "Geef mapnaam:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Aanmaken van map %s mislukt"
 
 msgid "Extension file edit"
 msgstr "Bewerken uitbreidingsbestand"
@@ -2391,12 +2431,16 @@ msgstr "Symlink '%s' verwijst naar:"
 msgid "Edit symlink"
 msgstr "Bewerken symlink"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "bewerken symbolische link, kan %s niet verwijderen: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "symbolische link bewerken: %s"
 
 msgid "FTP to machine"
@@ -2438,10 +2482,8 @@ msgstr "U kunt geen opdrachten uitvoeren op non-lokale bestandssystemen"
 msgid "Parameter"
 msgstr "Parameter"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Kan geen tijdelijk opdrachtbestand maken \n"
 "%s "
@@ -2449,10 +2491,10 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Pijp mislukt"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "U heeft een verouderd %s bestand.\n"
@@ -2465,7 +2507,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2520,29 +2562,23 @@ msgstr "bestanden/mappen"
 msgid " with source mask:"
 msgstr " met bronmasker:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Kan hardlink-bronbestand  \"%s\" niet inspecteren\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Kan doel hardlink \"%s\" niet aanmaken\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Kan doel hardlink \"%s\" niet aanmaken"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Bron-link \"%s\" lezen mislukt \n"
@@ -2558,9 +2594,9 @@ msgstr ""
 "\n"
 " De optie 'stabiele symbolische links' wordt uitgeschakeld "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Maken van doel van symbolische link \"%s\" mislukt \n"
@@ -2590,21 +2626,31 @@ msgstr ""
 "`%s' \n"
 "zijn hetzelfde bestand "
 
+msgid "&Ignore"
+msgstr "&Negeren"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "&Nogmaals"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Map \"%s\" is niet leeg.   \n"
 "Recursief verwijderen? "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Achtergrondproces: \n"
@@ -2614,17 +2660,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Ge&en"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Verwijderen van bestand \"%s\" mislukt \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Bestand \"%s\" kan niet geïnspecteerd worden \n"
@@ -2634,102 +2680,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Overschrijven van map \"%s\" mislukt"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Verplaatsen van \"%s\" naar \"%s\" mislukt \n"
+"Verwijderen van bestand \"%s\" mislukt \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Kan map \"%s\" niet verwijderen \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Overschrijven van map \"%s\" mislukt"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Map \"%s\" kan niet overschreven worden \n"
-"%s "
+msgstr "Overschrijven van map \"%s\" mislukt"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Kan bestand \"%s\" niet overschrijven\n"
 "%s "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Kan map  \"%s\" niet naar \"%s\" verplaatsen \n"
-"%s "
+"Kan map \"%s\" niet verwijderen \n"
+"%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Opereren op \"..\" is niet mogelijk! "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Bronbestand \"%s\" kan niet geïnspecteerd worden \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Kan hardlink-bronbestand  \"%s\" niet inspecteren\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"fstat werkt niet op doelbestand \"%s\" \n"
+"%s "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Maken van speciaal bestand \"%s\" mislukt \n"
 "%s "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "'chown' van doelbestand \"%s\" mislukt \n"
 "%s "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "'chmod' van doelbestand \"%s\" mislukt \n"
 "%s "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Openen van bronbestand \"%s\" mislukt \n"
@@ -2738,49 +2790,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "'Reget' mislukt, bestand wordt overschreven"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "fstat werkt niet op bronbestand \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Doelbestand \"%s\" kan niet aangemaakt worden \n"
 "%s "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "fstat werkt niet op doelbestand \"%s\" \n"
 "%s "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Kan geen ruimte voor doelbestand \"%s\" prealloceren\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Bronbestand \"%s\" kan niet gelezen worden \n"
 "%s "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Doelbestand \"%s\" kan niet beschreven worden \n"
@@ -2798,41 +2850,45 @@ msgstr "&Behouden"
 msgid "&Continue copy"
 msgstr "&Ga door met kopiëren"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Bronbestand \"%s\" kan niet gesloten worden \n"
 "%s "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Doelbestand \"%s\" kan niet gesloten worden \n"
 "%s "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Kan geen ruimte voor doelbestand \"%s\" prealloceren\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Bronmap \"%s\" kan niet geïnspecteerd worden\n"
 "%s "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Bronmap \"%s\" kan niet geïnspecteerd worden\n"
+"%s "
 
 #, c-format
 msgid ""
@@ -2850,25 +2906,27 @@ msgstr ""
 "Een cyclische symbolische link kan niet gekopieerd worden \n"
 "`%s' "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Doel \"%s\" moet een map zijn \n"
 "%s "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Doelmap \"%s\" kan niet gecreëerd worden \n"
 "%s "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "'chown' van doelmap \"%s\" mislukt \n"
@@ -3196,11 +3254,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "Je hebt %zu geopende scherm. Toch stoppen?"
 msgstr[1] "Je hebt %zu geopende schermen. Toch stoppen?"
 
-msgid "The Midnight Commander"
-msgstr "The Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Wilt u echt de Midnight Commander afsluiten?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Wilt u die opdracht echt uitvoeren? "
 
 msgid "&Above"
 msgstr "&Boven"
@@ -3700,11 +3756,10 @@ msgstr ""
 "Externe panelen:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Externe panelen:\n"
 "kon gegevens van kind stdout\n"
@@ -3748,6 +3803,15 @@ msgid ""
 msgstr ""
 "Inspecteren van het doel mislukt\n"
 "%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Doel \"%s\" moet een map zijn \n"
+"%s "
 
 #, c-format
 msgid "Delete %s?"
@@ -3869,8 +3933,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Pad van thuismap is niet absoluut"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4576,8 +4641,9 @@ msgstr "Bestand is gewijzigd. Opslaan met afsluiten?"
 msgid "&Cancel quit"
 msgstr "&Annuleren afsluiten"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander wordt afgesloten. \n"
@@ -4628,10 +4694,8 @@ msgstr "Ongfrm"
 msgid "ButtonBar|Format"
 msgstr "Format"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Kon geen data lezen van child stdout:\n"
 "%s"
@@ -4653,20 +4717,18 @@ msgstr "Kon bestand %s niet opslaan"
 msgid "View: "
 msgstr "Bekijken :"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Kan bestand %s niet openen\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Kan het niet bekijken: geen normaal bestand"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Kan \"%s\" niet openen in parsemodus\n"
@@ -4680,6 +4742,78 @@ msgstr "Doorgaan vanaf het begin?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Kan geen lokale versie van /ftp://some.host/editme.txt ophalen"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "The Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Wilt u echt de Midnight Commander afsluiten?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Kan %s niet openen om te lezen"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Kan geen grootte-/rechteninformatie verkrijgen voor %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Openen van pipe voor lezen mislukt: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Opslaan niet mogelijk: bestemming is geen gewoon bestand"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kan bestand %s niet openen\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "&Alles negeren"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "link: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "symlink: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kan doel hardlink \"%s\" niet aanmaken\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Verplaatsen van \"%s\" naar \"%s\" mislukt \n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Map \"%s\" kan niet overschreven worden \n"
+#~ "%s "
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kan map  \"%s\" niet naar \"%s\" verplaatsen \n"
+#~ "%s "
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Andere 8 bits"

--- a/po/nl_BE.po
+++ b/po/nl_BE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Dutch (Belgium) (http://app.transifex.com/mc/mc/language/"
@@ -47,6 +47,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -726,7 +729,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -792,23 +795,16 @@ msgstr ""
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -877,15 +873,16 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr ""
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Diff:"
@@ -895,12 +892,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -918,7 +917,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -929,11 +930,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -950,7 +949,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -964,11 +965,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1013,7 +1013,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1073,7 +1077,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1509,12 +1513,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1643,13 +1645,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1675,7 +1677,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1708,22 +1711,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1737,6 +1743,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1815,15 +1833,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2020,7 +2029,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2113,13 +2121,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2224,11 +2238,15 @@ msgid "Link"
 msgstr ""
 
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2250,6 +2268,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2299,11 +2323,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2343,10 +2371,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2355,7 +2380,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2365,7 +2390,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2422,23 +2447,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2450,7 +2471,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2470,19 +2491,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2491,13 +2522,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2507,37 +2538,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2546,43 +2581,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2591,37 +2626,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2639,31 +2674,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2681,19 +2716,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3018,10 +3055,7 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3515,11 +3549,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3555,6 +3587,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3657,8 +3696,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4308,8 +4348,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4358,10 +4399,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4382,16 +4420,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Polish (http://app.transifex.com/mc/mc/language/pl/)\n"
@@ -53,6 +53,9 @@ msgstr "Nie można utworzyć grupy „%s” dla zdarzeń."
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Nie można utworzyć zdarzenia „%s”."
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr "Copyright © 1996-2025 Free Software Foundation"
 
 #, c-format
 msgid ""
@@ -795,10 +798,10 @@ msgstr "plik1 plik2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[ten_katalog] [katalog_w_drugim_panelu]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -870,28 +873,23 @@ msgstr "Wyszukiwanie"
 msgid "Search is disabled"
 msgstr "Wyszukiwanie jest wyłączone"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Nie można utworzyć tymczasowego pliku różnicy\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Nie można utworzyć pliku zapasowego\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Nie można utworzyć tymczasowego pliku łączenia\n"
 "%s"
@@ -962,18 +960,19 @@ msgstr "Opcje"
 msgid "ButtonBar|Quit"
 msgstr "Kończ"
 
-msgid "Quit"
-msgstr "Zakończ"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Plik został zmodyfikowany. Zapisać przez zakończeniem?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Program Midnight Commander jest wyłączany.\n"
 "Zapisać zmodyfikowane pliki?"
+
+msgid "Quit"
+msgstr "Zakończ"
 
 msgid "Diff:"
 msgstr "Różnica:"
@@ -981,13 +980,15 @@ msgstr "Różnica:"
 msgid "File name is empty!"
 msgstr "Nazwa pliku jest pusta."
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "„%s” jest katalogiem"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Nie można wykonać polecenia stat na „%s”\n"
@@ -1006,9 +1007,13 @@ msgstr "Wczytywanie: %3d%%"
 msgid "Loading..."
 msgstr "Wczytywanie…"
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Nie można otworzyć %s do odczytania"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Nie można otworzyć „%s”\n"
+"%s"
 
 msgid "Load file"
 msgstr "Wczytaj plik"
@@ -1017,12 +1022,10 @@ msgstr "Wczytaj plik"
 msgid "Error reading %s"
 msgstr "Błąd podczas odczytywania %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Nie można uzyskać rozmiaru/uprawnień dla %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "„%s” nie jest zwykłym plikiem"
 
 #, c-format
@@ -1040,8 +1043,10 @@ msgstr "Ostrzeżenie"
 msgid "Error reading from pipe: %s"
 msgstr "Błąd podczas odczytywania potoku: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Nie można otworzyć potoku do odczytania: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1054,12 +1059,11 @@ msgstr "Plik został zmodyfikowany przez inny program. Zapisać mimo to?"
 msgid "Error writing to pipe: %s"
 msgstr "Błąd podczas zapisywania do potoku: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Nie można otworzyć potoku do zapisywania: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Nie można otworzyć pliku do zapisywania: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1104,8 +1108,12 @@ msgstr "Sprawdź nowe wiersze &POSIX"
 msgid "Edit Save Mode"
 msgstr "Modyfikuj tryb zapisu"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Nie można zapisać: cel nie jest zwykłym plikiem"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Nie można wyświetlić: nie jest zwykłym plikiem"
 
 msgid "A file already exists with this name"
 msgstr "Plik o tej nazwie już istnieje."
@@ -1164,9 +1172,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Zamknięcie pliku"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Program Midnight Commander jest zamykany.\n"
@@ -1609,15 +1617,13 @@ msgstr "Potwierdź zastąpienie"
 msgid "%ld replacements made"
 msgstr "Wykonano %ld zastąpień"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Łatwy w obsłudze edytor tekstu,\n"
 "napisany dla programu Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr "Copyright © 1996-2025 Free Software Foundation"
 
 msgid "About"
 msgstr "O programie"
@@ -1745,16 +1751,14 @@ msgstr "< Automatycznie >"
 msgid "< Reload Current Syntax >"
 msgstr "< Ponownie wczytaj składnię >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Nie można otworzyć pliku %s"
+
 msgid "Load syntax file"
 msgstr "Wczytaj plik składni"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Nie można otworzyć pliku %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1784,7 +1788,8 @@ msgstr ""
 "Podpowłoka może być przełączana tylko\n"
 "na konsoli xterm lub Linux."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Wpisanie „exit” powróci do programu Midnight Commander"
 
 msgid "Set &all"
@@ -1815,26 +1820,33 @@ msgstr "Uprawnienia (ósemkowe): %o"
 msgid "Chown advanced command"
 msgstr "Zaawansowane polecenie chown"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Nie można wykonać chmod na „%s”\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Nie można wykonać chown na „%s”\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Nie można wykonać chmod na „%s”\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "Z&ignoruj"
-
-msgid "Ignore &all"
-msgstr "Zignoruj &wszystko"
-
-msgid "&Retry"
-msgstr "P&onów"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Nie można wykonać chown na „%s”\n"
@@ -1851,6 +1863,20 @@ msgstr "Wykonywanie"
 
 msgid "Stopped"
 msgstr "Zatrzymano"
+
+#, fuzzy
+msgid "No translation"
+msgstr "—  < Bez tłumaczenia >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Strona kodowa wejściowa/wyjściowa:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Nigdy"
@@ -1929,17 +1955,6 @@ msgstr "Auto&m. zapis ustawień"
 
 msgid "Configure options"
 msgstr "Konfiguracja"
-
-#, fuzzy
-msgid "No translation"
-msgstr "—  < Bez tłumaczenia >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Strona kodowa wejściowa/wyjściowa:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Skórka:"
@@ -2136,10 +2151,9 @@ msgstr "Za&bij"
 msgid "Background jobs"
 msgstr "Zadania w tle"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "Nie można zmienić katalogu na\n"
@@ -2233,20 +2247,28 @@ msgstr "&Wyczyść zaznaczone"
 msgid "Chattr command"
 msgstr "Polecenie chattr"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Nie można wykonać polecenia chattr na „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 "Nie można uzyskać atrybutów ext2 „%s”\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Nie można wykonać polecenia chattr na „%s”\n"
 "%s"
 
 msgid "set &user ID on execution"
@@ -2349,13 +2371,21 @@ msgstr "Dowiązanie %s do:"
 msgid "Link"
 msgstr "Dowiąż"
 
-#, c-format
-msgid "link: %s"
-msgstr "dowiązanie: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Nie można utworzyć docelowego dowiązania symbolicznego „%s”\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "dowiązanie symboliczne: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Nie można skopiować zapętlonego dowiązania symbolicznego\n"
+"„%s”"
 
 msgid "View file"
 msgstr "Podgląd pliku"
@@ -2377,6 +2407,12 @@ msgstr "Tworzenie nowego katalogu"
 
 msgid "Enter directory name:"
 msgstr "Nazwa katalogu:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Nie można utworzyć katalogu %s"
 
 msgid "Extension file edit"
 msgstr "Modyfikacja pliku rozszerzeń"
@@ -2426,12 +2462,16 @@ msgstr "Dowiązanie symboliczne „%s” wskazuje na:"
 msgid "Edit symlink"
 msgstr "Modyfikuj dowiązanie symboliczne"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "modyfikacja dowiązania symbolicznego, nie można usunąć %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "modyfikacja dowiązania symbolicznego: %s"
 
 msgid "FTP to machine"
@@ -2473,10 +2513,8 @@ msgstr "Polecenia można wykonywać tylko na lokalnym systemie plików"
 msgid "Parameter"
 msgstr "Parametr"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Nie można utworzyć tymczasowego pliku polecenia\n"
 "%s"
@@ -2484,23 +2522,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Potok się nie powiódł"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "Plik %s jest przestarzały.\n"
 "Midnight Commander używa teraz pliku %s.\n"
 "Proszę skopiować wprowadzone zmiany z poprzedniego pliku do nowego."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "Format pliku\n"
 "%s%s\n"
@@ -2566,30 +2604,24 @@ msgstr "pliki/katalogi"
 msgid " with source mask:"
 msgstr " z maską źródłową:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Nie można wykonać polecenia stat na twardym dowiązaniu pliku źródłowego "
 "„%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Nie można utworzyć docelowego twardego dowiązania „%s”\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Nie można utworzyć docelowego twardego dowiązania „%s”"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Nie można odczytać dowiązania źródłowego „%s”\n"
@@ -2604,9 +2636,9 @@ msgstr ""
 "\n"
 "Opcja „Zachowanie dowiązań symbolicznych” zostanie wyłączona"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Nie można utworzyć docelowego dowiązania symbolicznego „%s”\n"
@@ -2636,21 +2668,31 @@ msgstr ""
 "„%s”\n"
 "to ten sam plik"
 
+msgid "&Ignore"
+msgstr "Z&ignoruj"
+
 msgid "Ignore a&ll"
 msgstr "Zignoruj &wszystko"
 
-#, c-format
+msgid "&Retry"
+msgstr "P&onów"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Katalog „%s” nie jest pusty.\n"
 "Usunąć go rekurencyjnie?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Proces w tle:\n"
@@ -2660,17 +2702,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Br&ak"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Nie można usunąć pliku „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Nie można wykonać polecenia stat na pliku „%s”\n"
@@ -2680,108 +2722,110 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Nie można zastąpić katalogu „%s”"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Nie można przenieść pliku „%s” do „%s”\n"
+"Nie można usunąć pliku „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Nie można usunąć katalogu „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 "Nie można przejść do katalogu „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Nie można zastąpić katalogu „%s”\n"
-"%s"
+msgstr "Nie można zastąpić katalogu „%s”"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Nie można zastąpić pliku „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Nie można przenieść katalogu „%s” do „%s”\n"
+"Nie można usunąć katalogu „%s”\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Nie można wykonać działania na „..”."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Nie można wykonać polecenia stat na pliku źródłowym „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 "Nie można uzyskać atrybutów ext2 pliku źródłowego „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 "Nie można ustawić atrybutów ext2 pliku docelowego „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Nie można utworzyć specjalnego pliku „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Nie można zmienić właściciela pliku docelowego „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Nie można zmienić uprawnień pliku docelowego „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Nie można otworzyć pliku źródłowego „%s”\n"
@@ -2790,49 +2834,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Polecenie reget się nie powiodło, plik zostanie zastąpiony"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Nie można wykonać polecenia fstat na pliku źródłowym „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Nie można utworzyć pliku docelowego „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Nie można wykonać polecenia stat na pliku docelowym „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Nie można wcześniej przydzielić miejsca dla pliku docelowego „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Nie można odczytać pliku źródłowego „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Nie można zapisać do pliku docelowego „%s”\n"
@@ -2850,41 +2894,41 @@ msgstr "&Zachowaj"
 msgid "&Continue copy"
 msgstr "&Kontynuuj kopiowanie"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Nie można zamknąć pliku źródłowego „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Nie można zamknąć pliku docelowego „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 "Nie można ustawić atrybutów ext2 dla pliku docelowego „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Nie można wykonać polecenia stat na katalogu źródłowym „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 "Nie można uzyskać atrybutów ext2 katalogu źródłowego „%s”\n"
@@ -2906,25 +2950,27 @@ msgstr ""
 "Nie można skopiować zapętlonego dowiązania symbolicznego\n"
 "„%s”"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Plik docelowy „%s” musi być katalogiem\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Nie można utworzyć katalogu docelowego „%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Nie można zmienić właściciela katalogu docelowego „%s”\n"
@@ -3254,11 +3300,9 @@ msgstr[1] "Pozostały %zu otwarte ekrany. Zakończyć mimo to?"
 msgstr[2] "Pozostało %zu otwartych ekranów. Zakończyć mimo to?"
 msgstr[3] "Pozostało %zu otwartych ekranów. Zakończyć mimo to?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Na pewno zakończyć program Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Na pewno wykonać?"
 
 msgid "&Above"
 msgstr "P&owyżej"
@@ -3764,11 +3808,10 @@ msgstr ""
 "Filtr zewnętrzny:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Filtr zewnętrzny:\n"
 "odczytanie danych z potomnego standardowego wyjścia się nie powiodło:\n"
@@ -3811,6 +3854,15 @@ msgid ""
 "%s"
 msgstr ""
 "Nie można wykonać polecenia stat na pliku docelowym\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Plik docelowy „%s” musi być katalogiem\n"
 "%s"
 
 #, c-format
@@ -3935,8 +3987,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Ścieżka do katalogu domowego nie jest bezwzględna"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4657,8 +4710,9 @@ msgstr "Plik został zmodyfikowany. Zapisać przed zakończeniem?"
 msgid "&Cancel quit"
 msgstr "N&ie zamykaj"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Program Midnight Commander kończy działanie.\n"
@@ -4709,10 +4763,8 @@ msgstr "BezFrm"
 msgid "ButtonBar|Format"
 msgstr "Format"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Odczytanie danych z potomnego standardowego wyjścia się nie powiodło:\n"
 "%s"
@@ -4738,20 +4790,18 @@ msgstr ""
 msgid "View: "
 msgstr "Podgląd: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Nie można otworzyć „%s”\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Nie można wyświetlić: nie jest zwykłym plikiem"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Nie można otworzyć „%s” w trybie przetwarzania\n"
@@ -4766,6 +4816,78 @@ msgstr "Kontynuować od początku?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
 "Nie można pobrać lokalnej kopii /ftp://jakiś.komputer/modyfikuj_mnie.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Na pewno zakończyć program Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Nie można otworzyć %s do odczytania"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Nie można uzyskać rozmiaru/uprawnień dla %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Nie można otworzyć potoku do zapisywania: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Nie można zapisać: cel nie jest zwykłym plikiem"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nie można otworzyć pliku %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Zignoruj &wszystko"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "dowiązanie: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "dowiązanie symboliczne: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nie można utworzyć docelowego twardego dowiązania „%s”\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nie można przenieść pliku „%s” do „%s”\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nie można zastąpić katalogu „%s”\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nie można przenieść katalogu „%s” do „%s”\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Inne 8-bitowe"

--- a/po/pt.po
+++ b/po/pt.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Portuguese (http://app.transifex.com/mc/mc/language/pt/)\n"
@@ -54,6 +54,9 @@ msgstr "Não é possível criar grupo '%s' para eventos!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Não é possível criar evento '%s'!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr "Copyright (C) 1996-2025 the Free Software Foundation"
 
 #, c-format
 msgid ""
@@ -793,10 +796,10 @@ msgstr "file1 file2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[este_dir] [outro_painel_dir]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -868,28 +871,23 @@ msgstr "Procurar"
 msgid "Search is disabled"
 msgstr "Pesquisa está desabilitada"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Não é possível criar ficheiro temporario diff\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Não é possível criar ficheiro de backup\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Não é possível criar ficheiro temporário de fusão\n"
 "%s"
@@ -960,18 +958,19 @@ msgstr "ButtonBar|Opções"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Sair"
 
-msgid "Quit"
-msgstr "Sair"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Ficheiro(s) foram modificados. Guardar e sair?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander está a terminar.\n"
 "Guardar ficheiro(s) modificado(s)?"
+
+msgid "Quit"
+msgstr "Sair"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -979,13 +978,15 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr "Nome do ficheiro está vazio!"
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" é um diretório"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Não é possível efetuar stat \"%s\"\n"
@@ -1004,9 +1005,13 @@ msgstr "A carregar: %3d%%"
 msgid "Loading..."
 msgstr "A carregar..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Não é possível abrir %s para leitura"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Não é possível abrir \"%s\"\n"
+"%s"
 
 msgid "Load file"
 msgstr "Carregar ficheiro"
@@ -1015,12 +1020,10 @@ msgstr "Carregar ficheiro"
 msgid "Error reading %s"
 msgstr "Erro de leitura %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Não é possível obter tamanho/permissões para %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" não é um ficheiro regular"
 
 #, c-format
@@ -1038,8 +1041,10 @@ msgstr "Aviso"
 msgid "Error reading from pipe: %s"
 msgstr "Erro ao ler do pipe: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Não é possível abrir pipe para leitura: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1052,12 +1057,11 @@ msgstr "O ficheiro foi modificado entretanto. Sair na mesma?"
 msgid "Error writing to pipe: %s"
 msgstr "Erro ao escrever para o pipe: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Não é possível abrir o pipe para escrita: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Não é possível abrir o ficheiro para escrita: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1102,8 +1106,12 @@ msgstr "Verificar nova linha &POSIX"
 msgid "Edit Save Mode"
 msgstr "Editar Modo de Gravação"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Não é possível guardar: destino não é um ficheiro regular"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Não é possível visualizar: não é um ficheiro regular"
 
 msgid "A file already exists with this name"
 msgstr "Já existe um ficheiro com este nome"
@@ -1162,9 +1170,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Fechar ficheiro"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander está a terminar.\n"
@@ -1607,15 +1615,13 @@ msgstr "Confirmar substituição"
 msgid "%ld replacements made"
 msgstr "%ld substituições efetuadas"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Um editor de texto amigo do utilizador\n"
 "escrito para o Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr "Copyright (C) 1996-2025 the Free Software Foundation"
 
 msgid "About"
 msgstr "Acerca"
@@ -1743,16 +1749,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Carrega Syntax Atual>"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Não é possível abrir ficheiro %s"
+
 msgid "Load syntax file"
 msgstr "Carregar ficheiro de sintaxe"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Não é possível abrir ficheiro %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1783,7 +1787,8 @@ msgstr ""
 "Não é um xterm or consola Linux;\n"
 "a subshell não pode ser comutada."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Digite 'exit' para voltar ao Midnight Commander"
 
 msgid "Set &all"
@@ -1814,26 +1819,33 @@ msgstr "Permissões (octal): %o"
 msgid "Chown advanced command"
 msgstr "Comando avançado chown"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Não é possível efetuar chmod \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Não é possível efetuar chown \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Não é possível efetuar chmod \"%s\"\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignorar"
-
-msgid "Ignore &all"
-msgstr "Ignor&ar tudo"
-
-msgid "&Retry"
-msgstr "&Repetir"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Não é possível efetuar chown \"%s\"\n"
@@ -1850,6 +1862,20 @@ msgstr "A executar"
 
 msgid "Stopped"
 msgstr "Parado"
+
+#, fuzzy
+msgid "No translation"
+msgstr "- < Sem tradução >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Entrada / mostrar página de codificação:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Nunca"
@@ -1928,17 +1954,6 @@ msgstr "Guardar setup a&uto"
 
 msgid "Configure options"
 msgstr "Opções de configuração"
-
-#, fuzzy
-msgid "No translation"
-msgstr "- < Sem tradução >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Entrada / mostrar página de codificação:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Skin:"
@@ -2135,10 +2150,9 @@ msgstr "&Matar"
 msgid "Background jobs"
 msgstr "Jobs em background"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "Não é possível alterar directório para\n"
@@ -2232,20 +2246,28 @@ msgstr "&Limpar marcados"
 msgid "Chattr command"
 msgstr "Comando chattr"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Não é possível chattr \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 "Não é possível obter atributos ext2 de \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Não é possível chattr \"%s\"\n"
 "%s"
 
 msgid "set &user ID on execution"
@@ -2348,13 +2370,21 @@ msgstr "Ligar %s a:"
 msgid "Link"
 msgstr "Ligar"
 
-#, c-format
-msgid "link: %s"
-msgstr "ligar: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Não é possível criar symlink alvo \"%s\"\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Não é possível copiar ligação simbólica ciclíca\n"
+"\"%s\""
 
 msgid "View file"
 msgstr "Ver ficheiro"
@@ -2376,6 +2406,12 @@ msgstr "Criar novo Diretório"
 
 msgid "Enter directory name:"
 msgstr "Inserir nome de diretório:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Não é possível criar diretório %s"
 
 msgid "Extension file edit"
 msgstr "Editar ficheiro de extensão"
@@ -2425,12 +2461,16 @@ msgstr "Symlink '%s' aponta para:"
 msgid "Edit symlink"
 msgstr "Ediart symlink"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "editar symlink, não é possível remover %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "editar symlink: %s"
 
 msgid "FTP to machine"
@@ -2472,10 +2512,8 @@ msgstr "Não é possível executar comandos em sistemas de ficheiros não locais
 msgid "Parameter"
 msgstr "Parâmetro"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Não é possível criar ficheiro de comando temporário\n"
 "%s"
@@ -2483,23 +2521,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Falha de Pipe"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "Tem um ficheiro %s desactualizado.\n"
 "Midnight Commander agora usa ficheiro %s.\n"
 "Por favor copie as suas modificações do ficheiro antigo para o novo."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "O formato do ficheiro\n"
 "%s%s\n"
@@ -2565,29 +2603,23 @@ msgstr "ficheiros/diretórios"
 msgid " with source mask:"
 msgstr " com máscara na origem:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Não é possível efetuar stat no hardlink do ficheiro fonte \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Não é possível criar o hardlink alvo \"%s\"\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Não é possível criar o hardlink alvo \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Não é possível ler a ligação fonte \"%s\"\n"
@@ -2603,9 +2635,9 @@ msgstr ""
 "\n"
 "Opção Symlinks Estáveis será desativada"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Não é possível criar symlink alvo \"%s\"\n"
@@ -2635,21 +2667,31 @@ msgstr ""
 "\"%s\"\n"
 "são o mesmo ficheiro"
 
+msgid "&Ignore"
+msgstr "&Ignorar"
+
 msgid "Ignore a&ll"
 msgstr "Ignora&r tudo"
 
-#, c-format
+msgid "&Retry"
+msgstr "&Repetir"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Directório \"%s\" não vazio.\n"
 "Apagá-lo recursivamente?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Processo em background :\n"
@@ -2659,17 +2701,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "N&enhum"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Não é possível remover o ficheiro \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Não é possível efetuar stat no ficheiro \"%s\"\n"
@@ -2679,108 +2721,110 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Não é possível escrever por cima do diretório \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Não é possível mover o ficheiro \"%s\" para \"%s\"\n"
+"Não é possível remover o ficheiro \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Não é possível remover o diretório \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 "Não é possível entrar no directório \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Não é possível escrever por cima do diretório \"%s\"\n"
-"%s"
+msgstr "Não é possível escrever por cima do diretório \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Não é possível escrever por cima do ficheiro \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Não é possível mover diretório \"%s\" para \"%s\"\n"
+"Não é possível remover o diretório \"%s\"\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Não é possível operar em \"..\"!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Não é possível efetuar stat no ficheiro fonte \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 "Não é possível obter atributos ext2 de ficheiro fonte \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 "Não é possível acertar atributos ext2 do ficheiro alvo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Não é possível criar ficheiro especial \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Não é possível efetuar chown no ficheiro alvo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Não é possível efetuar chmod no ficheiro alvo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Não é possível abrir o ficheiro fonte \"%s\"\n"
@@ -2789,49 +2833,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Reget falhou, prestes a escrever por cima do ficheiro"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Não é possível efetuar fstat no ficheiro fonte \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Não é possível criar ficheiro alvo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Não é possível efetuar fstat no ficheiro alvo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Não é possível pre-alocar espaço para o ficheiro alvo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Não é possível ler o ficheiro fonte \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Não é possível escrever no ficheiro alvo \"%s\"\n"
@@ -2849,41 +2893,41 @@ msgstr "&Manter"
 msgid "&Continue copy"
 msgstr "&Continuar a copiar"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Não é possível fechar o ficheiro fonte \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Não é possível fechar o ficheiro alvo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 "Não é possível acertar atributos ext2 para o ficheiro alvo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Não é possível efetuar stat no diretório fonte \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 "Não é possível obter atributos ext2 do directorio fonte \"%s\"\n"
@@ -2905,25 +2949,27 @@ msgstr ""
 "Não é possível copiar ligação simbólica ciclíca\n"
 "\"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Destino \"%s\" deve ser um diretório\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Não é possível criar diretório alvo \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Não é possível efetuar chown no diretório alvo \"%s\"\n"
@@ -3252,11 +3298,9 @@ msgstr[0] "Tem %zu ecrã aberto. Terminar de qualquer modo?"
 msgstr[1] "Tem %zu ecrãs abertos. Terminar de qualquer modo?"
 msgstr[2] "Tem %zu ecrãs abertos. Terminar de qualquer modo?"
 
-msgid "The Midnight Commander"
-msgstr "O Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Deseja mesmo sair do Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Deseja mesmo executar?"
 
 msgid "&Above"
 msgstr "&Acima"
@@ -3759,11 +3803,10 @@ msgstr ""
 "Exterior Em Painel:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Exterior Em Painel:\n"
 "falha ao ler dados a partir do stdout encaixado:\n"
@@ -3806,6 +3849,15 @@ msgid ""
 "%s"
 msgstr ""
 "Não é possível efetuar stat no destino\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Destino \"%s\" deve ser um diretório\n"
 "%s"
 
 #, c-format
@@ -3929,8 +3981,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Caminho do diretório home não é absoluto"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4648,8 +4701,9 @@ msgstr "Ficheiro foi modificado. Guardar ao sair?"
 msgid "&Cancel quit"
 msgstr "&Cancelar saída"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander está a terminar.\n"
@@ -4700,10 +4754,8 @@ msgstr "ButtonBar|Unform"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Format"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Falha ao ler dados a partir do child stdout:\n"
 "%s"
@@ -4729,20 +4781,18 @@ msgstr ""
 msgid "View: "
 msgstr "Ver: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Não é possível abrir \"%s\"\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Não é possível visualizar: não é um ficheiro regular"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Não foi possível abrir \"%s\" em modo parse\n"
@@ -4756,6 +4806,78 @@ msgstr "Continuar do início?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Não é possível obter uma cópia local de /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "O Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Deseja mesmo sair do Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Não é possível abrir %s para leitura"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Não é possível obter tamanho/permissões para %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Não é possível abrir o pipe para escrita: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Não é possível guardar: destino não é um ficheiro regular"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Não é possível abrir ficheiro %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignor&ar tudo"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "ligar: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "symlink: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Não é possível criar o hardlink alvo \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Não é possível mover o ficheiro \"%s\" para \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Não é possível escrever por cima do diretório \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Não é possível mover diretório \"%s\" para \"%s\"\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Outros 8 bit"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Portuguese (Brazil) (http://app.transifex.com/mc/mc/language/"
@@ -60,6 +60,9 @@ msgstr "Não foi possível criar o grupo '%s' para os eventos!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Não foi possível criar o evento '%s'!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr "Todos os direitos reservados (C) 1996-2025 a Free Software Foundation"
 
 #, c-format
 msgid ""
@@ -811,10 +814,10 @@ msgstr "arquivo 1 arquivo 2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[este_diretório] [outro_painel_do_diretório]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -890,28 +893,23 @@ msgstr "Pesquisar"
 msgid "Search is disabled"
 msgstr "A pesquisa está desativada"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Não foi possível criar o arquivo diff temporário\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Não é possível criar o arquivo de segurança\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Não é possível criar o arquivo de mesclagem temporário\n"
 "%s"
@@ -982,18 +980,19 @@ msgstr "ButtonBar|Opções"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Sair"
 
-msgid "Quit"
-msgstr "Sair"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "O(s) arquivo(s) foi(ram) modificado(s). Você quer salvar e sair?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "O Midnight Commander está sendo desligado. Você quer salvar o(s) arquivo(s) "
 "modificado(s)?"
+
+msgid "Quit"
+msgstr "Sair"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -1001,13 +1000,15 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr "O nome do arquivo está vazio!"
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "‘%s’ é um diretório"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Não é possível efetuar o estado ‘%s’\n"
@@ -1026,9 +1027,13 @@ msgstr "Carregando: %3d%%"
 msgid "Loading..."
 msgstr "Carregando..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Não foi possível abrir %s para leitura"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Não foi possível abrir ‘%s’\n"
+"%s"
 
 msgid "Load file"
 msgstr "Abrir o arquivo"
@@ -1037,12 +1042,10 @@ msgstr "Abrir o arquivo"
 msgid "Error reading %s"
 msgstr "Ocorreu um erro de leitura de %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Não foi possível obter tamanho/permissões para %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "‘%s’ não é um arquivo regular"
 
 #, c-format
@@ -1060,8 +1063,10 @@ msgstr "Aviso"
 msgid "Error reading from pipe: %s"
 msgstr "Ocorreu um erro de leitura a partir do canal: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Não foi possível abrir o canal para leitura: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1078,12 +1083,11 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr "Ocorreu um erro de escrita para o canal: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Não foi possível abrir o canal para a escrita: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Não foi possível abrir o arquivo para a escrita: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1128,8 +1132,12 @@ msgstr "Verificar a nova linha &POSIX"
 msgid "Edit Save Mode"
 msgstr "Editar o Modo de Salvar"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Não foi possível salvar o destino porque não é um arquivo normal"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Não é possível visualizar porque não é um arquivo normal"
 
 msgid "A file already exists with this name"
 msgstr "Já existe um arquivo com este nome"
@@ -1188,9 +1196,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Fechar arquivo"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "O Midnight Commander está fechando.\n"
@@ -1633,15 +1641,13 @@ msgstr "Confirmar a substituição"
 msgid "%ld replacements made"
 msgstr "%ld substituições foram realizadas"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Um editor de texto amigável\n"
 "escrito para o Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr "Todos os direitos reservados (C) 1996-2025 a Free Software Foundation"
 
 msgid "About"
 msgstr "Sobre"
@@ -1769,16 +1775,14 @@ msgstr "< Automático >"
 msgid "< Reload Current Syntax >"
 msgstr "< Recarregar a Sintaxe Atual >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Não foi possível abrir o arquivo %s"
+
 msgid "Load syntax file"
 msgstr "Carregar a sintaxe do arquivo"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Não foi possível abrir o arquivo %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1810,7 +1814,8 @@ msgstr ""
 "Não é um console xterm ou GNU/Linux;\n"
 "o subshell não pode ser alternado."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Insira o comando 'exit' para retornar ao Midnight Commander"
 
 msgid "Set &all"
@@ -1841,26 +1846,33 @@ msgstr "Permissões (octal): %o"
 msgid "Chown advanced command"
 msgstr "Comando avançado do ‘chown’"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Não foi possível executar o chmod ‘%s’\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Não foi possível executar o ‘chown’ do ‘%s’\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Não foi possível executar o chmod ‘%s’\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignorar"
-
-msgid "Ignore &all"
-msgstr "Ignor&ar tudo"
-
-msgid "&Retry"
-msgstr "&Tentar novamente"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Não foi possível executar o ‘chown’ do ‘%s’\n"
@@ -1877,6 +1889,20 @@ msgstr "Em execução"
 
 msgid "Stopped"
 msgstr "Parado"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Sem tradução >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Inserir / Exibir a página de codificação:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Nunca"
@@ -1955,17 +1981,6 @@ msgstr "Config&urações de salvamento automático"
 
 msgid "Configure options"
 msgstr "Configurar as opções"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Sem tradução >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Inserir / Exibir a página de codificação:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Visual:"
@@ -2166,10 +2181,9 @@ msgstr "&Finalizar"
 msgid "Background jobs"
 msgstr "Trabalhos em segundo plano"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "Não foi possível alterar o diretório de\n"
@@ -2264,20 +2278,28 @@ msgstr "Lim&par o item &selecionado"
 msgid "Chattr command"
 msgstr "Comando chattr"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Não foi possível executar o comando chattr ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 "Não foi possível obter os atributos do ‘ext2’ de ‘%s’\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Não foi possível executar o comando chattr ‘%s’\n"
 "%s"
 
 msgid "set &user ID on execution"
@@ -2381,13 +2403,21 @@ msgstr "Vínculo %s para:"
 msgid "Link"
 msgstr "Vínculo"
 
-#, c-format
-msgid "link: %s"
-msgstr "Vínculo: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Não foi possível criar o destino do vínculo simbólico (symlink) ‘%s’\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "Vínculo simbólico: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Não foi possível copiar vínculo simbólico cíclico\n"
+"‘%s’"
 
 msgid "View file"
 msgstr "Visualizar o arquivo"
@@ -2409,6 +2439,12 @@ msgstr "Criar um novo diretório"
 
 msgid "Enter directory name:"
 msgstr "Insira o nome do diretório"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Não foi possível criar o diretório %s"
 
 msgid "Extension file edit"
 msgstr "Editar a extensão do arquivo"
@@ -2458,12 +2494,16 @@ msgstr "O vínculo simbólico '%s' aponta para:"
 msgid "Edit symlink"
 msgstr "Editar o vínculo simbólico"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "Ao editar o vínculo simbólico, não foi possível remover o %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "Editar o vínculo simbólico: %s"
 
 msgid "FTP to machine"
@@ -2507,10 +2547,8 @@ msgstr ""
 msgid "Parameter"
 msgstr "Parâmetro"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Não foi possível criar o arquivo do comando\n"
 "temporário%s"
@@ -2518,10 +2556,10 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "O canal falhou"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "Você tem um arquivo %s desatualizado.\n"
@@ -2530,13 +2568,13 @@ msgstr ""
 "Por favor, copie as suas modificações do arquivo\n"
 "antigo para o novo arquivo de configurações."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "O formato do arquivo\n"
 "%s%s\n"
@@ -2602,30 +2640,24 @@ msgstr "arquivos/diretórios"
 msgid " with source mask:"
 msgstr " com máscara da origem:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Não foi possível estabelecer o vínculo rígido (hardlink) do arquivo da "
 "origem ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Não foi possível criar o vínculo rígido (hardlink) do destino ‘%s’\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Não foi possível criar o vínculo rígido (hardlink) do destino ‘%s’"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Não foi possível ler o vínculo (link) da origem ‘%s’\n"
@@ -2641,9 +2673,9 @@ msgstr ""
 "\n"
 "A opção dos vínculos simbólicos (Symlinks) estáveis será desativada"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Não foi possível criar o destino do vínculo simbólico (symlink) ‘%s’\n"
@@ -2673,21 +2705,31 @@ msgstr ""
 "‘%s’\n"
 "são o mesmo arquivo"
 
+msgid "&Ignore"
+msgstr "&Ignorar"
+
 msgid "Ignore a&ll"
 msgstr "Ignorar &tudo"
 
-#, c-format
+msgid "&Retry"
+msgstr "&Tentar novamente"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "O diretório ‘%s’ não está vazio.\n"
 "Você quer excluir recursivamente?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Processo que está sendo executado em segundo plano:\n"
@@ -2697,17 +2739,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "&Nenhum"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Não foi possível remover o arquivo ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Não foi possível obter o estado do arquivo ‘%s’\n"
@@ -2717,108 +2759,110 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Não foi possível sobrescrever o diretório ‘%s’"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Não foi possível mover o arquivo ‘%s’ para ‘%s’\n"
+"Não foi possível remover o arquivo ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Não foi possível remover o diretório ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 "Não foi possível entrar no diretório ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Não foi possível sobrescrever o diretório ‘%s’\n"
-"%s"
+msgstr "Não foi possível sobrescrever o diretório ‘%s’"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Não foi possível sobrescrever o arquivo ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Não foi possível mover o diretório ‘%s’ para ‘%s’\n"
+"Não foi possível remover o diretório ‘%s’\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Não foi possível operar no ‘..’"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Não foi possível obter o estado do arquivo da origem ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 "Não foi possível obter os atributos do ‘ext2’ do arquivo de origem ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 "Não foi possível definir os atributos do ‘ext2’ do arquivo do destino ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Não foi possível criar o arquivo especial ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Não foi possível executar o ‘chown’ no arquivo do destino ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Não foi possível executar chmod no arquivo alvo ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Não foi possível abrir o arquivo da origem ‘%s’\n"
@@ -2827,49 +2871,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "A nova obtenção falhou ao sobrescrever o arquivo"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Não foi possível executar o fstat no arquivo da origem ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Não foi possível o criar arquivo no destino ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Não foi possível executar o ‘fstat’ no arquivo do destino ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Não foi possível pré-alocar o espaço para o arquivo do destino ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Não foi possível ler o arquivo da origem ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Não foi possível escrever no arquivo do destino ‘%s’\n"
@@ -2887,42 +2931,42 @@ msgstr "&Manter"
 msgid "&Continue copy"
 msgstr "&Continuar a cópia"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Não foi possível fechar o arquivo da origem ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Não foi possível fechar o arquivo do destino ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 "Não foi possível definir os atributos do ‘ext2’ para o arquivo do destino "
 "‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Não foi possível obter o estado do diretório ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 "Não foi possível obter os atributos do ‘ext2’ do diretório de origem ‘%s’\n"
@@ -2944,25 +2988,27 @@ msgstr ""
 "Não foi possível copiar vínculo simbólico cíclico\n"
 "‘%s’"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "O destino ‘%s’ deve ser um diretório\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Não foi possível criar um diretório no destino ‘%s’\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Não foi possível executar o ‘chown’ no diretório do destino ‘%s’\n"
@@ -3294,11 +3340,9 @@ msgstr[0] "Você tem %zu tela aberta. Você quer finalizar mesmo assim?"
 msgstr[1] "Você têm %zu telas abertas. Você quer finalizar mesmo assim?"
 msgstr[2] "Você têm %zu telas abertas. Você quer finalizar mesmo assim?"
 
-msgid "The Midnight Commander"
-msgstr "O Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Você realmente quer sair do Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Você realmente quer executar?"
 
 msgid "&Above"
 msgstr "&Acima"
@@ -3804,11 +3848,10 @@ msgstr ""
 "Painel externo:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Painel externo:\n"
 "Ocorreu uma falha ao ler os dados do stdout filho:\n"
@@ -3853,6 +3896,15 @@ msgid ""
 "%s"
 msgstr ""
 "Não foi possível estabelecer o destino\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"O destino ‘%s’ deve ser um diretório\n"
 "%s"
 
 #, c-format
@@ -3980,8 +4032,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "O caminho do diretório pessoal não é absoluto"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4726,8 +4779,9 @@ msgstr "O arquivo foi modificado. Você quer salvar e sair?"
 msgid "&Cancel quit"
 msgstr "&Cancelar a saída"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "O Midnight Commander está sendo finalizado.\n"
@@ -4778,10 +4832,8 @@ msgstr "ButtonBar|Desenformar"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Formatar"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Falha ao ler os dados do stdout filho:\n"
 "%s"
@@ -4807,20 +4859,18 @@ msgstr ""
 msgid "View: "
 msgstr "Visualizar:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Não foi possível abrir ‘%s’\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Não é possível visualizar porque não é um arquivo normal"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Não foi possível abrir ‘%s’ no modo de análise\n"
@@ -4834,6 +4884,78 @@ msgstr "Você quer continuar a partir do início?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Não foi possível obter uma cópia local do /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "O Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Você realmente quer sair do Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Não foi possível abrir %s para leitura"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Não foi possível obter tamanho/permissões para %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Não foi possível abrir o canal para a escrita: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Não foi possível salvar o destino porque não é um arquivo normal"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Não foi possível abrir o arquivo %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignor&ar tudo"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "Vínculo: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "Vínculo simbólico: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Não foi possível criar o vínculo rígido (hardlink) do destino ‘%s’\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Não foi possível mover o arquivo ‘%s’ para ‘%s’\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Não foi possível sobrescrever o diretório ‘%s’\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Não foi possível mover o diretório ‘%s’ para ‘%s’\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Outros de 8 bit"

--- a/po/ro.po
+++ b/po/ro.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Romanian (http://app.transifex.com/mc/mc/language/ro/)\n"
@@ -58,6 +58,9 @@ msgstr "Nu se poate crea grupul '%s' pentru evenimente!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Nu se poate crea evenimentul '%s'!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -774,10 +777,10 @@ msgstr "file1 file2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[acest_dir] [celălalt_panou_dir]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -849,28 +852,23 @@ msgstr "Caută"
 msgid "Search is disabled"
 msgstr "Căutarea este dezactivată"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Nu se poate crea fișierul temporare de diferențe\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Nu se poate crea fișierul pentru copia de siguranță\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Nu se poate crea fișierul temporar pentru unire\n"
 "%s"
@@ -941,18 +939,19 @@ msgstr "ButtonBar|Opțiuni"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Ieșire"
 
-msgid "Quit"
-msgstr "Ieși"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Fișierul a fost modificat. Salvezi la ieșire?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander este în curs de închidere.\n"
 "Salvezi fișierul modificat?"
+
+msgid "Quit"
+msgstr "Ieși"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -960,13 +959,15 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" este un dosar"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Nu se poate găsi \"%s\"\n"
@@ -985,9 +986,13 @@ msgstr "Se încarcă: %3d%%"
 msgid "Loading..."
 msgstr "Se încarcă..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Nu se poate deschide %s pentru citire"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Nu se poate deschide \"%s\"\n"
+"%s"
 
 msgid "Load file"
 msgstr "Încărcare fișier"
@@ -996,12 +1001,10 @@ msgstr "Încărcare fișier"
 msgid "Error reading %s"
 msgstr "Eroare la citirea %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Nu se pot obține mărimea/permisiunile pentru %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" nu este un fișier obișnuit"
 
 #, c-format
@@ -1019,8 +1022,10 @@ msgstr "Atenție"
 msgid "Error reading from pipe: %s"
 msgstr "Eroare la citirea din pipe: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Nu se poate deschide pipe pentru citire: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1033,12 +1038,11 @@ msgstr "Fișierul a fost modificat între timp. Salvezi oricum?"
 msgid "Error writing to pipe: %s"
 msgstr "Eroare la scrierea în pipe: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Nu se poate pipe pentru scriere: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Nu se poate deschide fișierul pentru scriere: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1083,8 +1087,12 @@ msgstr "Verificare &POSIX pentru o noua linie"
 msgid "Edit Save Mode"
 msgstr "Editare mod salvare"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Nu se poate salva: destinația nu este un fișier obișnuit"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Nu se poate vizualiza: nu este un fișier regulat"
 
 msgid "A file already exists with this name"
 msgstr "Deja există un fișier cu acest nume"
@@ -1143,9 +1151,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Închide fișier"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander este în curs de închidere.\n"
@@ -1588,15 +1596,13 @@ msgstr "Confirmă înlocuirea"
 msgid "%ld replacements made"
 msgstr "%ld înlocuiri efectuate"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Un editor de text ușor de utilizat\n"
 "creat pentru Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Despre"
@@ -1724,16 +1730,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Reîncarcă sintaxa curentă >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Nu se poate deschide fișierul %s"
+
 msgid "Load syntax file"
 msgstr "Încarcă fișier de sintaxă"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Nu se poate deschide fișierul %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1764,7 +1768,8 @@ msgstr ""
 "Nu o consolă xterm sau Linux;\n"
 "subshell-ul nu poate fi comutat."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Tastați `exit' pentru a reveni în Midnight Commander"
 
 msgid "Set &all"
@@ -1795,26 +1800,33 @@ msgstr "Permisiuni (octal): %o"
 msgid "Chown advanced command"
 msgstr "Comandă avansată chown"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Nu se poate aplica chmod \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Nu se poate aplica chown \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Nu se poate aplica chmod \"%s\"\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignoră"
-
-msgid "Ignore &all"
-msgstr "Ignoră &tot"
-
-msgid "&Retry"
-msgstr "&Reîncearcă"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Nu se poate aplica chown \"%s\"\n"
@@ -1831,6 +1843,20 @@ msgstr "Rulează"
 
 msgid "Stopped"
 msgstr "Oprit"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Fără translatare >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Intrare / cod de afișare:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Niciodată"
@@ -1909,17 +1935,6 @@ msgstr "Auto-salvare a configurației"
 
 msgid "Configure options"
 msgstr "Opțiuni de configurare"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Fără translatare >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Intrare / cod de afișare:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Tematică:"
@@ -2116,12 +2131,13 @@ msgstr "&Omoară"
 msgid "Background jobs"
 msgstr "Sarcini în fundal"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"Nu se poate aplica chown pe dosarul destinație \"%s\"\n"
+"%s"
 
 msgid "Secure deletion"
 msgstr "Ștergere securizată"
@@ -2210,19 +2226,29 @@ msgstr "Şter&g marc."
 msgid "Chattr command"
 msgstr "Comanda Chattr"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Nu se poate chattr \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Nu pot deschide arhiva tar\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Nu se poate chattr \"%s\"\n"
+"%s"
 
 msgid "set &user ID on execution"
 msgstr "Setează ID &proprietar la executare"
@@ -2324,13 +2350,21 @@ msgstr "Leagă %s la:"
 msgid "Link"
 msgstr "Legătură"
 
-#, c-format
-msgid "link: %s"
-msgstr "legătură: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Nu se poate crea legătura destinație \"%s\"\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "legătură: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Nu se poate copia legătura simbolică ciclică\n"
+"\"%s\""
 
 msgid "View file"
 msgstr "Vizualizare fișier"
@@ -2352,6 +2386,12 @@ msgstr "Creează un nou dosar"
 
 msgid "Enter directory name:"
 msgstr "Introdu numele dosarului:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Nu se poate crea dosarul %s"
 
 msgid "Extension file edit"
 msgstr "Editează fișierul de extensii"
@@ -2401,12 +2441,16 @@ msgstr "Legătura '%s' duce către:"
 msgid "Edit symlink"
 msgstr "Editare legătură"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "editare legătură, nu se poate înlătura %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "editare legătură: %s"
 
 msgid "FTP to machine"
@@ -2448,10 +2492,8 @@ msgstr "Nu se pot executa comenzi în sisteme de fișiere ne-locale"
 msgid "Parameter"
 msgstr "Parametru"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Nu se poate crea fișierul temporar pentru linia de comandă\n"
 "%s"
@@ -2459,23 +2501,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Pipe a eșuat"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "Aveți un fișier neactualizat %s.\n"
 "Midnight Commander folosește acum %s fișierul.\n"
 "Vă rugăm să copiați modificările din fișierul vechi în cel nou."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "Formatul de\n"
 "%s%s\n"
@@ -2541,29 +2583,23 @@ msgstr "fișiere/dosare"
 msgid " with source mask:"
 msgstr " cu mască sursă:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Nu se poate obține starea fișierului sursă pentru hardlink \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Nu se poate crea hardlink-ul țintă \"%s\"\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Nu se poate crea hardlink-ul țintă \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Nu se poate citi legătura sursă \"%s\"\n"
@@ -2578,9 +2614,9 @@ msgstr ""
 "\n"
 "Opțiunea symlink-uri stabile va fi dezactivată"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Nu se poate crea legătura destinație \"%s\"\n"
@@ -2610,21 +2646,31 @@ msgstr ""
 "\"%s\"\n"
 "sunt același fișier"
 
+msgid "&Ignore"
+msgstr "&Ignoră"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "&Reîncearcă"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Dosarul \"%s\" nu este gol.\n"
 "Îl ștergi în mod recursiv?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Sarcină în fundal:\n"
@@ -2634,17 +2680,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "&Nimic"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Nu se poate șterge fișierul \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Nu se poate găsi fișierul \"%s\"\n"
@@ -2654,102 +2700,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Nu se poate suprascrie dosarul \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Nu se poate muta fișierul \"%s\" în \"%s\"\n"
+"Nu se poate șterge fișierul \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Nu se poate șterge dosarul \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Nu se poate suprascrie dosarul \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Nu se poate suprascrie dosarul \"%s\"\n"
-"%s"
+msgstr "Nu se poate suprascrie dosarul \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Nu se poate suprascrie fișierul \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Nu se poate muta dosarul \"%s\" în \"%s\"\n"
+"Nu se poate șterge dosarul \"%s\"\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Nu se poate acționa asupra \"..\"!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Nu se poate găsi fișierul sursă \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Nu se poate obține starea fișierului sursă pentru hardlink \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Nu se poate găsi fișierul destinație \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Nu se poate crea fișierul special \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Nu se poate aplica chown pe fișierul destinație \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Nu se poate aplica chmod pe fișierul destinație \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Nu se poate deschide fișierul sursă \"%s\"\n"
@@ -2758,49 +2810,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Re-descărcarea a eșuat, se va suprascrie fișierul"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Nu se poate găsi fișierul sursă \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Nu se poate crea fișierul destinație \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Nu se poate găsi fișierul destinație \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Nu se poate pre-aloca spațiu pentru fișierul destinație \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Nu se poate citi fișierul sursă \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Nu se poate scrie fișierul destinație \"%s\"\n"
@@ -2818,41 +2870,45 @@ msgstr "&Păstrează"
 msgid "&Continue copy"
 msgstr "&Continuați să copiați"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Nu se poate închide fișierul sursă \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Nu se poate închide fișierul destinație \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Nu se poate pre-aloca spațiu pentru fișierul destinație \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Nu se poate găsi dosarul sursă \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Nu se poate găsi dosarul sursă \"%s\"\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2870,25 +2926,27 @@ msgstr ""
 "Nu se poate copia legătura simbolică ciclică\n"
 "\"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Destinația \"%s\" trebuie să fie un dosar\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Nu se poate crea dosarul destinație \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Nu se poate aplica chown pe dosarul destinație \"%s\"\n"
@@ -3217,11 +3275,9 @@ msgstr[0] "Ai %zu ecran deschis. Închizi oricum?"
 msgstr[1] "Ai %zu ecrane deschise. Închizi oricum?"
 msgstr[2] "Ai %zu ecrane deschise. Închizi oricum?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Chiar dorești sa închizi Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Chiar dorești să execuți?"
 
 msgid "&Above"
 msgstr "&Deasupra"
@@ -3724,11 +3780,10 @@ msgstr ""
 "Panouri externe:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Panouri externe:\n"
 "nu a reușit să citească datele din stdout-ul copil:\n"
@@ -3771,6 +3826,15 @@ msgid ""
 "%s"
 msgstr ""
 "Nu se poate găsi destinația\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Destinația \"%s\" trebuie să fie un dosar\n"
 "%s"
 
 #, c-format
@@ -3892,8 +3956,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Calea către dosarul acasă nu este absolută"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4605,8 +4670,9 @@ msgstr "Fișierul a fost modificat. Salvezi la ieșire?"
 msgid "&Cancel quit"
 msgstr "&Renunță la ieșire"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander este în curs de închidere.\n"
@@ -4657,10 +4723,8 @@ msgstr "ButtonBar|Unform"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Format"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Eroare la citirea datelor de la stdout-ul copil:\n"
 "%s"
@@ -4686,20 +4750,18 @@ msgstr ""
 msgid "View: "
 msgstr "Vizualizează: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Nu se poate deschide \"%s\"\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Nu se poate vizualiza: nu este un fișier regulat"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Nu se poate deschide \"%s\" în mod parsare\n"
@@ -4713,6 +4775,78 @@ msgstr "Continuă de la început?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Nu se poate aduce o copie locală a /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Chiar dorești sa închizi Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Nu se poate deschide %s pentru citire"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Nu se pot obține mărimea/permisiunile pentru %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Nu se poate pipe pentru scriere: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Nu se poate salva: destinația nu este un fișier obișnuit"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nu se poate deschide fișierul %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignoră &tot"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "legătură: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "legătură: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nu se poate crea hardlink-ul țintă \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nu se poate muta fișierul \"%s\" în \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nu se poate suprascrie dosarul \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nu se poate muta dosarul \"%s\" în \"%s\"\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Alt 8 biți"

--- a/po/ru.po
+++ b/po/ru.po
@@ -31,7 +31,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Russian (http://app.transifex.com/mc/mc/language/ru/)\n"
@@ -73,6 +73,9 @@ msgstr "Не удаётся создать группу событий \"%s\"!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Не удаётся создать событие \"%s\"!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr "Авторское право (C) 1996-2025 Фонд свободного программного обеспечения"
 
 #, c-format
 msgid ""
@@ -817,10 +820,10 @@ msgstr "файл1 файл2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[этот_каталог] [каталог_другой_панели]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -891,28 +894,23 @@ msgstr "Поиск"
 msgid "Search is disabled"
 msgstr "Поиск запрещён"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Не удалось создать временный файл различий\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Не удалось создать файл с резервной копией\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Не удалось создать временный файл слияния\n"
 "%s"
@@ -983,18 +981,19 @@ msgstr "Настр"
 msgid "ButtonBar|Quit"
 msgstr "Выход"
 
-msgid "Quit"
-msgstr "Выход"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Файл(ы) был(и) изменен(ы). Сохранить при выходе?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander завершается.\n"
 "Сохранить изменённые файлы?"
+
+msgid "Quit"
+msgstr "Выход"
 
 msgid "Diff:"
 msgstr "Различия:"
@@ -1002,13 +1001,15 @@ msgstr "Различия:"
 msgid "File name is empty!"
 msgstr "Пустое имя файла!"
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" является каталогом"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Не удалось получить свойства \"%s\"\n"
@@ -1027,9 +1028,13 @@ msgstr "Загрузка: %3d%%"
 msgid "Loading..."
 msgstr "Загрузка..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Не удалось открыть файл %s для чтения"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Не удалось открыть \"%s\"\n"
+"%s"
 
 msgid "Load file"
 msgstr "Загрузка файла"
@@ -1038,12 +1043,10 @@ msgstr "Загрузка файла"
 msgid "Error reading %s"
 msgstr "Ошибка чтения %s:"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Не удалось получить размер/права доступа для файла %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" не является обычным файлом"
 
 #, c-format
@@ -1061,8 +1064,10 @@ msgstr "Предупреждение"
 msgid "Error reading from pipe: %s"
 msgstr "Ошибка чтения из канала: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Не удалось открыть канал для чтения: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1075,12 +1080,11 @@ msgstr "Файл был изменён внешней программой. Со
 msgid "Error writing to pipe: %s"
 msgstr "Ошибка записи в канал: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Не удалось открыть канал для записи: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Не удалось открыть файл для записи: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1125,8 +1129,12 @@ msgstr "П&роверка перевода строки в конце файла
 msgid "Edit Save Mode"
 msgstr "Режим сохранения"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Не удалось сохранить файл: файл назначения не является обычным файлом"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Просмотр невозможен: необычный файл"
 
 msgid "A file already exists with this name"
 msgstr "Файл с таким именем уже существует"
@@ -1185,9 +1193,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Закрытие файла"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander завершается.\n"
@@ -1628,15 +1636,13 @@ msgstr "Подтвердить замену"
 msgid "%ld replacements made"
 msgstr "Сделано подстановок: %ld"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Удобный текстовый редактор.\n"
 "Создан для Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr "Авторское право (C) 1996-2025 Фонд свободного программного обеспечения"
 
 msgid "About"
 msgstr "О программе"
@@ -1764,16 +1770,14 @@ msgstr "< Автоматически >"
 msgid "< Reload Current Syntax >"
 msgstr "Перезагрузить текущее цветовыделение"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Не удалось открыть файл %s"
+
 msgid "Load syntax file"
 msgstr "Загрузить файл синтаксиса"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Не удалось открыть файл %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1804,7 +1808,8 @@ msgstr ""
 "Это не консоль xterm или Linux;\n"
 "подоболочку нельзя переключить."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Введите \"exit\" для возврата в Midnight Commander"
 
 msgid "Set &all"
@@ -1835,26 +1840,33 @@ msgstr "Доступ (восьмеричный): %o"
 msgid "Chown advanced command"
 msgstr "Расширенная команда chown"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Не удалось изменить режим доступа к \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Не удалось изменить владельца \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Не удалось изменить режим доступа к \"%s\"\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Игнорировать"
-
-msgid "Ignore &all"
-msgstr "Игнорировать в&сё"
-
-msgid "&Retry"
-msgstr "По&вторить"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Не удалось изменить владельца \"%s\"\n"
@@ -1871,6 +1883,20 @@ msgstr "Выполняется"
 
 msgid "Stopped"
 msgstr "Остановлен"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Без перекодировки >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Кодировка ввода/вывода:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Никогда"
@@ -1949,17 +1975,6 @@ msgstr "&Автосохранение настроек"
 
 msgid "Configure options"
 msgstr "Параметры конфигурации"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Без перекодировки >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Кодировка ввода/вывода:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Скин:"
@@ -2156,10 +2171,9 @@ msgstr "&Снять"
 msgid "Background jobs"
 msgstr "Фоновые задания"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 "Не удалось сменить каталог на\n"
@@ -2253,20 +2267,28 @@ msgstr "&Очистить помеченное"
 msgid "Chattr command"
 msgstr "Команда chattr"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Не удалось изменить атрибуты \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 "Не удаётся получить атрибуты ext2 для \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Не удалось изменить атрибуты \"%s\"\n"
 "%s"
 
 msgid "set &user ID on execution"
@@ -2369,13 +2391,21 @@ msgstr "Создать ссылку с %s на:"
 msgid "Link"
 msgstr "Жёсткая ссылка"
 
-#, c-format
-msgid "link: %s"
-msgstr "ссылка: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Не удалось создать целевую симв. ссылку \"%s\"\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "символическая ссылка: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Не удалось скопировать циклическую символическую ссылку\n"
+"\"%s\""
 
 msgid "View file"
 msgstr "Просмотр файла"
@@ -2397,6 +2427,12 @@ msgstr "Создать новый каталог"
 
 msgid "Enter directory name:"
 msgstr "Введите имя каталога:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Не удалось создать каталог \"%s\""
 
 msgid "Extension file edit"
 msgstr "Редактирование файла расширений"
@@ -2446,12 +2482,16 @@ msgstr "Символическая ссылка \"%s\" указывает на:"
 msgid "Edit symlink"
 msgstr "Правка ссылки"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "правка символической ссылки, не удалось удалить %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "правка символической ссылки: %s"
 
 msgid "FTP to machine"
@@ -2493,10 +2533,8 @@ msgstr "Не удалось выполнить команды на нелока�
 msgid "Parameter"
 msgstr "Параметр"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Не удалось создать временный командный файл\n"
 "%s"
@@ -2504,23 +2542,23 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Сбой канала"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "У вас устаревший файл %s.\n"
 "Midnight Commander теперь использует файл %s.\n"
 "Пожалуйста, скопируйте ваши изменения из старого файла в новый."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The format of the\n"
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 "Формат файла \n"
 "%s%s\n"
@@ -2586,29 +2624,23 @@ msgstr "файлы/каталоги"
 msgid " with source mask:"
 msgstr " с исходным шаблоном:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Не удалось получить свойства исходного файла жёст. ссылки \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Не удалось создать целевую жёст. ссылку \"%s\"\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Не удалось создать целевую жёст. ссылку \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Не удалось прочесть исходную ссылку \"%s\"\n"
@@ -2624,9 +2656,9 @@ msgstr ""
 "\n"
 "Опция \"Устойчивые символические ссылки\" будет отменена"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Не удалось создать целевую симв. ссылку \"%s\"\n"
@@ -2656,21 +2688,31 @@ msgstr ""
 "\"%s\"\n"
 "один и тот же файл"
 
+msgid "&Ignore"
+msgstr "&Игнорировать"
+
 msgid "Ignore a&ll"
 msgstr "Игнорироват&ь все"
 
-#, c-format
+msgid "&Retry"
+msgstr "По&вторить"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Каталог \"%s\" не пуст.\n"
 "Удалить его со всем содержимым?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Фоновый процесс:\n"
@@ -2680,17 +2722,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Ни &одного"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Не удалось удалить файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Не удалось получить свойства файла \"%s\"\n"
@@ -2700,108 +2742,110 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Не удалось переписать каталог \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Не удалось переместить файл \"%s\" в \"%s\"\n"
+"Не удалось удалить файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Не удалось удалить каталог \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 "Не удалось войти в каталог \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Не удалось переписать каталог \"%s\"\n"
-"%s"
+msgstr "Не удалось переписать каталог \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Не удалось переписать файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Не удалось переместить каталог \"%s\" в \"%s\"\n"
+"Не удалось удалить каталог \"%s\"\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Эту операцию невозможно выполнить на \"..\"!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Не удалось получить свойства исходного файла \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 "Не удаётся получить атрибуты ext2 для исходного файла \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 "Не удаётся установить атрибуты ext2 для целевого файла \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Не удалось создать специальный файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Не удалось сменить владельца целевого файла \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Не удалось сменить режим доступа к целевому файлу \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Не удалось открыть исходный файл \"%s\"\n"
@@ -2810,49 +2854,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Сбой докачки файла, файл будет переписан"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Не удалось получить свойства исходного файла \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Не удалось создать целевой файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Не удалось получить свойства целевого файла \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Не удалось предвыделить место для файла \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Не удалось прочесть исходный файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Не удалось записать целевой файл \"%s\"\n"
@@ -2870,41 +2914,41 @@ msgstr "&Сохранить"
 msgid "&Continue copy"
 msgstr "&Продолжить копирование"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Не удалось закрыть исходный файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Не удалось закрыть целевой файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 "Не удаётся установить атрибуты ext2 для целевого файла \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Не удалось получить свойства исходного каталога \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 "Не удаётся получить атрибуты ext2 для исходного каталога \"%s\"\n"
@@ -2926,25 +2970,27 @@ msgstr ""
 "Не удалось скопировать циклическую символическую ссылку\n"
 "\"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Назначение \"%s\" должно быть каталогом\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Не удалось создать целевой каталог \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Не удалось сменить владельца целевого каталога \"%s\"\n"
@@ -3274,11 +3320,9 @@ msgstr[1] "У вас %zu открытых экрана. Всё равно вый
 msgstr[2] "У вас %zu открытых экранов. Всё равно выйти?"
 msgstr[3] "У вас %zu открытых экранов. Всё равно выйти?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Вы действительно хотите выйти из Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Вы действительно хотите выполнить это?"
 
 msgid "&Above"
 msgstr "&Верхняя панель"
@@ -3783,11 +3827,10 @@ msgstr ""
 "Внешняя панелизация:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Внешняя панелизация:\n"
 "не удалось прочитать данные из дочернего stdout:\n"
@@ -3831,6 +3874,15 @@ msgid ""
 "%s"
 msgstr ""
 "Не удалось получить свойства места назначения\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Назначение \"%s\" должно быть каталогом\n"
 "%s"
 
 #, c-format
@@ -3954,8 +4006,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Путь домашнего каталога не является абсолютным"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4673,8 +4726,9 @@ msgstr "Файл был изменён. Сохранить при выходе?"
 msgid "&Cancel quit"
 msgstr "&Отменить выход"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander завершается.\n"
@@ -4725,10 +4779,8 @@ msgstr "Не форм"
 msgid "ButtonBar|Format"
 msgstr "Формат"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Не удалось прочитать данные из дочернего stdout:\n"
 "%s"
@@ -4754,20 +4806,18 @@ msgstr ""
 msgid "View: "
 msgstr "Просмотр: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Не удалось открыть \"%s\"\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Просмотр невозможен: необычный файл"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Не удалось открыть \"%s\" в режиме фильтра\n"
@@ -4781,6 +4831,79 @@ msgstr "Продолжить с начала?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Не удалось получить локальную копию /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Вы действительно хотите выйти из Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Не удалось открыть файл %s для чтения"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Не удалось получить размер/права доступа для файла %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Не удалось открыть канал для записи: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr ""
+#~ "Не удалось сохранить файл: файл назначения не является обычным файлом"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не удалось открыть файл %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Игнорировать в&сё"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "ссылка: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "символическая ссылка: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не удалось создать целевую жёст. ссылку \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не удалось переместить файл \"%s\" в \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не удалось переписать каталог \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не удалось переместить каталог \"%s\" в \"%s\"\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Другая 8-битная"

--- a/po/sk.po
+++ b/po/sk.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2016,2025\n"
 "Language-Team: Slovak (http://app.transifex.com/mc/mc/language/sk/)\n"
@@ -56,6 +56,9 @@ msgstr "Nepodarilo sa vytvoriť skupinu „%s“ pre udalosti!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Nepodarilo sa vytvoriť udalosť „%s“!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -764,10 +767,10 @@ msgstr "file1 file2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[tento_adresár] [adresár_v_druhom_paneli]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -838,28 +841,23 @@ msgstr "Hľadať"
 msgid "Search is disabled"
 msgstr "Hľadanie je vypnuté"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Nie je možné vytvoriť dočasný súbor s rozdielom\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Nie je možné vytvoriť záložný súbor\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Nie je možné vytvoriť dočasný súbor na zlúčenie\n"
 "%s"
@@ -930,18 +928,19 @@ msgstr "ButtonBar|Nast."
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Ukončiť"
 
-msgid "Quit"
-msgstr "Ukončiť"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Zmenil(i) sa súbor(y). Uložiť pri ukončení?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander sa vypína.\n"
 "Uložiť zmenené súbory?"
+
+msgid "Quit"
+msgstr "Ukončiť"
 
 msgid "Diff:"
 msgstr "Rozdiel:"
@@ -949,13 +948,15 @@ msgstr "Rozdiel:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "„%s“ je adresár"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Nemožno vykonať stat() „%s“\n"
@@ -974,9 +975,13 @@ msgstr "Načítava sa: %3d%%"
 msgid "Loading..."
 msgstr "Načítava sa..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Nemožno otvoriť %s na čítanie"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Nemožno otvoriť „%s“\n"
+"%s"
 
 msgid "Load file"
 msgstr "Načítať súbor"
@@ -985,12 +990,10 @@ msgstr "Načítať súbor"
 msgid "Error reading %s"
 msgstr "Chyba pri čítaní %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Nemožno zistiť veľkosť/oprávnenia %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "„%s“ nie je obyčajný súbor"
 
 #, c-format
@@ -1008,8 +1011,10 @@ msgstr "Upozornenie"
 msgid "Error reading from pipe: %s"
 msgstr "Chyba pri čítaní z rúry: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Nemožno otvoriť rúru na čítanie: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1022,12 +1027,11 @@ msgstr "Súbor bol medzitým zmenený. Uložiť napriek tomu?"
 msgid "Error writing to pipe: %s"
 msgstr "Chyba pri zapisovaní do rúry: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Nemožno otvoriť rúru na zápis: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Nemožno otvoriť súbor na zápis: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1072,8 +1076,12 @@ msgstr "Kontrolovať nový riadok &POSIX"
 msgid "Edit Save Mode"
 msgstr "Upraviť režim ukladania"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Nie je možné uložiť: cieľ nie je bežný súbor"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Nemožno zobraziť: nie je bežný súbor"
 
 msgid "A file already exists with this name"
 msgstr "Súbor s týmto názvom už existuje"
@@ -1132,9 +1140,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Zatvoriť súbor"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander sa vypína.\n"
@@ -1575,15 +1583,13 @@ msgstr "Potvrdiť nahradenie"
 msgid "%ld replacements made"
 msgstr "Vykonaných %ld náhrad"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Používateľsky prívetivý textový editor\n"
 "napísaný pre Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "O aplikácii"
@@ -1711,16 +1717,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Znovu načítať aktuálnu syntax >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Nie je možné otvoriť súbor %s"
+
 msgid "Load syntax file"
 msgstr "Načítať súbor so syntaxou"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Nemožno otvoriť súbor %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1749,7 +1753,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Napísaním „exit“ sa vrátite do aplikácie Midnight Commander"
 
 msgid "Set &all"
@@ -1780,26 +1785,33 @@ msgstr ""
 msgid "Chown advanced command"
 msgstr "Pokročilý príkaz chown"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Nemožno vykonať chmod „%s“\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Nemožno vykonať chown „%s“\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Nemožno vykonať chmod „%s“\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ignorovať"
-
-msgid "Ignore &all"
-msgstr "Ignorovať &všetky"
-
-msgid "&Retry"
-msgstr "&Zopakovať"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Nemožno vykonať chown „%s“\n"
@@ -1816,6 +1828,20 @@ msgstr "Beží"
 
 msgid "Stopped"
 msgstr "Zastavený"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Žiadny preklad >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Vstupná/zobrazovacia znaková sada:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Nikdy"
@@ -1894,17 +1920,6 @@ msgstr "A&utomaticky ukladať konfiguráciu"
 
 msgid "Configure options"
 msgstr "Konfigurácia"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Žiadny preklad >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Vstupná/zobrazovacia znaková sada:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Téma vzhľadu:"
@@ -2101,12 +2116,13 @@ msgstr "U&končiť"
 msgid "Background jobs"
 msgstr "Úlohy v pozadí"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"Nemožno zmeniť vlastníka cieľového adresára „%s“\n"
+"%s"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2195,17 +2211,27 @@ msgstr "z&Mazať označ."
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
+"Nemožno vykonať stat() „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Nie je možné otvoriť archív .tar\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Nie je možné spracovať:"
 
 msgid "set &user ID on execution"
 msgstr "nastaviť ID po&užívateľa pri spustení"
@@ -2307,13 +2333,21 @@ msgstr "Odkazovať %s na:"
 msgid "Link"
 msgstr "Okaz"
 
-#, c-format
-msgid "link: %s"
-msgstr "odkaz: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Nemožno vytvoriť cieľový sym. odkaz „%s“\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "sym. odkaz: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Nemožno skopírovať cyklický sym. odkaz\n"
+"\"%s\""
 
 msgid "View file"
 msgstr "Zobraziť súbor"
@@ -2335,6 +2369,12 @@ msgstr "Vytvoriť nový adresár"
 
 msgid "Enter directory name:"
 msgstr "Zadajte názov adresára:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Nepodarilo sa vytvoriť adresár %s"
 
 msgid "Extension file edit"
 msgstr "Upraviť príponu názvu súboru"
@@ -2384,12 +2424,16 @@ msgstr "Sym. odkaz „%s“ ukazuje na:"
 msgid "Edit symlink"
 msgstr "Upraviť sym. odkaz"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "upraviť sym. odkaz, nemožno odstrániť %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "upraviť sym. odkaz: %s"
 
 msgid "FTP to machine"
@@ -2431,10 +2475,8 @@ msgstr "Nemožno spúšťať príkazy na súborových systémoch, ktoré nie sú
 msgid "Parameter"
 msgstr "Parameter"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Nemožno vytvoriť dočasný súbor príkazu\n"
 "%s"
@@ -2445,7 +2487,7 @@ msgstr "Pipe zlyhalo"
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2455,7 +2497,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2510,25 +2552,25 @@ msgstr "súbory/adresáre"
 msgid " with source mask:"
 msgstr " so zdrojovou maskou:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"Nemožno vykonať stat() zdrojového súboru „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
+"Nemožno vytvoriť cieľový sym. odkaz „%s“\n"
+"%s"
 
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Nemožno prečítať zdrojový odkaz „%s“\n"
@@ -2544,9 +2586,9 @@ msgstr ""
 "\n"
 "Voľba Stabilné symbolické odkazy bude vypnutá"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Nemožno vytvoriť cieľový sym. odkaz „%s“\n"
@@ -2576,21 +2618,31 @@ msgstr ""
 "„%s“\n"
 "sú rovnaký súbor"
 
+msgid "&Ignore"
+msgstr "&Ignorovať"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "&Zopakovať"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Adresár „%s“ nie je prázdny\n"
 "Chcete ho rekurzívne zmazať?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Proces na pozadí:\n"
@@ -2600,17 +2652,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Žiadn&e"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Nemožno odstrániť súbor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Nemožno vykonať stat() súboru „%s“\n"
@@ -2620,102 +2672,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Nemožno prepísať adresár „%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Nemožno presunúť „%s“ do „%s“\n"
+"Nemožno odstrániť súbor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Nemožno odstrániť adresár „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Nemožno prepísať adresár „%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Nemožno prepísať adresár „%s“\n"
-"%s"
+msgstr "Nemožno prepísať adresár „%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Nemožno prepísať súbor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Nemožno presunúť adresár „%s“ do „%s“\n"
+"Nemožno odstrániť adresár „%s“\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Nemožno vykonať operáciu na „..“!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Nemožno vykonať stat() zdrojového súboru „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Nemožno vykonať stat() zdrojového súboru „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Nemožno vykonať fstat() cieľového súboru „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Nemožno vytvoriť špeciálny súbor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Nemožno zmeniť vlastníka cieľového súboru „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Nemožno zmeniť oprávnenia cieľového súboru „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Nemožno otvoriť cieľový súbor „%s“\n"
@@ -2724,49 +2782,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Znovuzískanie zlyhalo, chystá sa prepísanie súboru"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Nemožno vykonať fstat() zdrojového súboru „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Nemožno vytvoriť cieľový súbor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Nemožno vykonať fstat() cieľového súboru „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Nemožno vopred vyhradiť miesto pre cieľový súbor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Nie je možné čítať zdrojový súbor \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Nemožno zapísať cieľový súbor „%s“\n"
@@ -2784,41 +2842,45 @@ msgstr "Po&nechať"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Nemožno zatvoriť zdrojový súbor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Nemožno zatvoriť cieľový súbor „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Nemožno vopred vyhradiť miesto pre cieľový súbor „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Nemožno vykonať stat() zdrojového adresára „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Nemožno vykonať stat() zdrojového adresára „%s“\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2836,25 +2898,27 @@ msgstr ""
 "Nemožno skopírovať cyklický sym. odkaz\n"
 "\"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Cieľ „%s“ musí byť adresár\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Nemožno vytvoriť cieľový adresár „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Nemožno zmeniť vlastníka cieľového adresára „%s“\n"
@@ -3184,11 +3248,9 @@ msgstr[1] "Máte už %zu otvorené obrazovky. Aj tak odísť?"
 msgstr[2] "Máte už %zu otvorených obrazoviek. Aj tak odísť?"
 msgstr[3] "Máte už %zu otvorených obrazoviek. Aj tak odísť?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Naozaj chcete ukončiť Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Skutočne chcete spustiť?"
 
 msgid "&Above"
 msgstr "N&ad"
@@ -3692,12 +3754,13 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
+"Nepodarilo sa prečítať dáta zo štand. výstupu procesu potomka:\n"
+"%s"
 
 msgid "Cannot run external panelize in a non-local directory"
 msgstr "Nie je možné spustiť panelizáciu v adresári, ktorý nie je lokálny"
@@ -3736,6 +3799,15 @@ msgid ""
 "%s"
 msgstr ""
 "Nemožno vykonať stat() cieľa\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Cieľ „%s“ musí byť adresár\n"
 "%s"
 
 #, c-format
@@ -3858,8 +3930,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Cesta do domovského adresára nie je absolútna"
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4542,8 +4615,9 @@ msgstr "Súbor bol zmenený. Uložiť pri ukončení?"
 msgid "&Cancel quit"
 msgstr "&Zrušiť ukončenie"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander sa vypína.\n"
@@ -4594,10 +4668,8 @@ msgstr "ButtonBar|Neform"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Formát"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Nepodarilo sa prečítať dáta zo štand. výstupu procesu potomka:\n"
 "%s"
@@ -4623,20 +4695,18 @@ msgstr ""
 msgid "View: "
 msgstr "Zobraziť:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Nemožno otvoriť „%s“\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Nemožno zobraziť: nie je bežný súbor"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Nemožno otvoriť „%s“ v režime spracovania\n"
@@ -4650,6 +4720,70 @@ msgstr "Pokračovať od začiatku?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Nemožno stiahnuť lokálnu kópiu /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Naozaj chcete ukončiť Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Nemožno otvoriť %s na čítanie"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Nemožno zistiť veľkosť/oprávnenia %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Nemožno otvoriť rúru na zápis: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Nie je možné uložiť: cieľ nie je bežný súbor"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nemožno otvoriť súbor %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignorovať &všetky"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "odkaz: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "sym. odkaz: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nemožno presunúť „%s“ do „%s“\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nemožno prepísať adresár „%s“\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nemožno presunúť adresár „%s“ do „%s“\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Iné 8-bitové"

--- a/po/sl.po
+++ b/po/sl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Matej Urbančič <>, 2012\n"
 "Language-Team: Slovenian (http://app.transifex.com/mc/mc/language/sl/)\n"
@@ -50,6 +50,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -738,7 +741,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -804,24 +807,22 @@ msgstr "Iskanje"
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
 msgid "&Fastest (Assume large files)"
 msgstr ""
@@ -889,16 +890,17 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr "Končaj"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
+
+msgid "Quit"
+msgstr "Končaj"
 
 msgid "Diff:"
 msgstr ""
@@ -906,15 +908,17 @@ msgstr ""
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"%s\n"
+"is a directory"
+msgstr "Natisne podatkovni imenik"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat\n"
 "%s"
-msgstr ""
+msgstr "Ne morem razčleniti:"
 
 msgid "Diff viewer: invalid mode"
 msgstr ""
@@ -929,9 +933,13 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#, c-format
-msgid "Cannot open %s for reading"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
+"Ne morem odpreti tar arhiva\n"
+"%s"
 
 msgid "Load file"
 msgstr ""
@@ -941,11 +949,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -961,9 +967,13 @@ msgstr "Opozorilo"
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
+"Ne morem odpreti datoteke %s za pisanje:\n"
+"%s\n"
 
 msgid "File has hard-links. Detach before saving?"
 msgstr ""
@@ -975,13 +985,14 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
-msgstr ""
+"Ne morem odpreti datoteke %s za pisanje:\n"
+"%s\n"
 
 msgid "The file you are saving does not end with a newline."
 msgstr ""
@@ -1025,7 +1036,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1085,7 +1100,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1521,12 +1536,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1655,13 +1668,15 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+"Ne morem odpreti tar arhiva\n"
+"%s"
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1687,7 +1702,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1720,22 +1736,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
-msgstr "Poskusi &znova"
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1750,6 +1769,20 @@ msgstr ""
 
 msgid "Stopped"
 msgstr "Ustavljen"
+
+#, fuzzy
+msgid "No translation"
+msgstr "- < Brez prevoda >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Vhodni / zaslonski nabor znakov:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Nikoli"
@@ -1828,17 +1861,6 @@ msgstr ""
 
 msgid "Configure options"
 msgstr "Nastavi"
-
-#, fuzzy
-msgid "No translation"
-msgstr "- < Brez prevoda >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Vhodni / zaslonski nabor znakov:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr ""
@@ -2031,12 +2053,11 @@ msgstr "&Ubij"
 msgid "Background jobs"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
-msgstr ""
+msgstr "Ne morem prebrati vsebine imenika"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2125,17 +2146,25 @@ msgstr "&Počisti označeno"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
-msgstr ""
+"Cannot chattr\n"
+"%sn%s"
+msgstr "Ne morem razčleniti:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Ne morem odpreti tar arhiva\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Ne morem razčleniti:"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2237,12 +2266,18 @@ msgstr "Poveži %s na:"
 msgid "Link"
 msgstr ""
 
-#, c-format
-msgid "link: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2265,6 +2300,12 @@ msgstr "Ustvari nov Imenik"
 
 msgid "Enter directory name:"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Ne morem prebrati vsebine imenika"
 
 msgid "Extension file edit"
 msgstr "Uredi datoteko s priponami"
@@ -2313,11 +2354,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2357,11 +2402,9 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
-msgstr ""
+#, fuzzy
+msgid "Cannot create temporary command file"
+msgstr "Ne morem prebrati vsebine imenika"
 
 msgid "Pipe failed"
 msgstr ""
@@ -2369,7 +2412,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2379,7 +2422,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2434,27 +2477,27 @@ msgstr "datoteke/imeniki"
 msgid " with source mask:"
 msgstr " z masko izvira:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot read source link \"%s\"\n"
+"Ne morem odpreti tar arhiva\n"
 "%s"
-msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot read source link\n"
+"%s"
+msgstr "Ne morem prebrati vsebine imenika"
 
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
@@ -2462,11 +2505,13 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
 #, c-format
 msgid ""
@@ -2484,160 +2529,208 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
 msgstr ""
 
+msgid "&Retry"
+msgstr "Poskusi &znova"
+
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 msgid "Non&e"
 msgstr "&Brez"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
-msgstr ""
+msgstr "Ne morem prebrati vsebine imenika"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Ne morem prebrati vsebine imenika"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
+msgstr "Ne morem prebrati vsebine imenika"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
-msgstr ""
+msgstr "Ne morem prebrati vsebine imenika"
 
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
+"Ne morem odpreti tar arhiva\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
+"Ne morem odpreti tar arhiva\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
+"Ne morem odpreti cpio arhiva\n"
+"%s"
 
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
 
 msgid "(stalled)"
 msgstr "(zastoj)"
@@ -2651,33 +2744,39 @@ msgstr "&Obdrži"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
+"Ne morem odpreti cpio arhiva\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot close target file\n"
+"%s"
+msgstr ""
+"Ne morem odpreti tar arhiva\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot set ext2 attributes for target file\n"
+"%s"
+msgstr ""
+"Ne morem pisati v datoteko %s:\n"
+"%s\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat source directory\n"
+"%s"
+msgstr "Ne morem prebrati vsebine imenika"
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot stat source directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2695,21 +2794,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
-msgstr ""
+msgstr "Ne morem prebrati vsebine imenika"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
+"Ne morem odpreti tar arhiva\n"
+"%s"
 
 #, c-format
 msgid "Directories: %zu, total size: %s"
@@ -3034,10 +3137,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3538,11 +3638,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3580,6 +3678,13 @@ msgstr "Prestavi imenik \"%s\" v:"
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3696,8 +3801,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4368,8 +4474,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4418,10 +4525,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4442,18 +4546,20 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
-msgid "Cannot view: not a regular file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
+"Ne morem odpreti tar arhiva\n"
+"%s"
 
 msgid "Search done"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Serbian (http://app.transifex.com/mc/mc/language/sr/)\n"
@@ -51,6 +51,9 @@ msgstr "Не могу да направим групу „%s“ за догађ�
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Не могу направим догађај „%s“!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -752,10 +755,10 @@ msgstr ""
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[овај_дир] [други_дир_панела]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -826,28 +829,23 @@ msgstr "Тражи"
 msgid "Search is disabled"
 msgstr "Претрага је искључена"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Не могу да направим привремену датотеку разлика\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Не могу да направим датотеку резерве\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Не могу да направим привремену датотеку стапања\n"
 "%s"
@@ -918,18 +916,19 @@ msgstr "Опције"
 msgid "ButtonBar|Quit"
 msgstr "Изађи"
 
-msgid "Quit"
-msgstr "Заврши"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Датотека је измењена. Да сачувам при изласку?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Поноћни наредник је угашен.\n"
 "Да сачувам измењену датотеку?"
+
+msgid "Quit"
+msgstr "Заврши"
 
 msgid "Diff:"
 msgstr "Разлике:"
@@ -937,13 +936,15 @@ msgstr "Разлике:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "„%s“ је директоријум"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Не могу да добијем податке о „%s“\n"
@@ -962,9 +963,13 @@ msgstr "Учитавам: %3d%%"
 msgid "Loading..."
 msgstr "Учитавам..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Не могу да отворим „%s“ за читање"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Не могу да отворим „%s“\n"
+"%s"
 
 msgid "Load file"
 msgstr "Учитај датотеку"
@@ -973,12 +978,10 @@ msgstr "Учитај датотеку"
 msgid "Error reading %s"
 msgstr "Грешка читања „%s“"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Не могу да добавим величину/овлашћења за „%s“"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "„%s“ није обична датотека"
 
 #, c-format
@@ -996,8 +999,10 @@ msgstr "Упозорење"
 msgid "Error reading from pipe: %s"
 msgstr "Грешка читања из спојке: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Не могу да отворим спојку за читање: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1010,12 +1015,11 @@ msgstr "Датотека је измењена у међувремену. Да �
 msgid "Error writing to pipe: %s"
 msgstr "Грешка писања у спојку: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Не могу да отворим спојку за писање: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Не могу да отворим датотеку за писање: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1060,8 +1064,12 @@ msgstr "Провери нови ред &ПОСИКС-а"
 msgid "Edit Save Mode"
 msgstr "Уредите режим чувања"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Не могу да сачувам: одредиште није обична датотека"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Не могу да прикажем: није обична датотека"
 
 msgid "A file already exists with this name"
 msgstr "Већ постоји датотека под овим називом"
@@ -1120,9 +1128,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Затвори датотеку"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Поноћни наредник је угашен.\n"
@@ -1563,15 +1571,13 @@ msgstr "Потврди замену"
 msgid "%ld replacements made"
 msgstr "%ld одрађене замене"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Уређивач текста наклоњен кориснику\n"
 "написан за Поноћног наредника."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "О програму"
@@ -1699,16 +1705,14 @@ msgstr "< Самостално >"
 msgid "< Reload Current Syntax >"
 msgstr "< Учитај текућу синтаксу >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Не могу да отворим датотеку „%s“"
+
 msgid "Load syntax file"
 msgstr "Учитај датотеку синтаксе"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Не могу да отворим датотеку „%s“\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1737,7 +1741,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Укуцајте „exit“ да се вратите Поноћном нареднику"
 
 msgid "Set &all"
@@ -1768,26 +1773,33 @@ msgstr ""
 msgid "Chown advanced command"
 msgstr "Напредна наредба промене власника"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Не могу да променим режим „%s“\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Не могу да променим власника „%s“\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Не могу да променим режим „%s“\n"
 "%s"
 
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
-msgstr "Пробај &поново"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Не могу да променим власника „%s“\n"
@@ -1804,6 +1816,20 @@ msgstr "Покренут"
 
 msgid "Stopped"
 msgstr "Заустављен"
+
+#, fuzzy
+msgid "No translation"
+msgstr "—  < Без претварања >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Кодна страна улаза и приказа:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Никад"
@@ -1882,17 +1908,6 @@ msgstr "&Сам сачувај подешавања"
 
 msgid "Configure options"
 msgstr "Опције подешавања"
-
-#, fuzzy
-msgid "No translation"
-msgstr "—  < Без претварања >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Кодна страна улаза и приказа:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Маска:"
@@ -2089,12 +2104,13 @@ msgstr "&Убиј"
 msgid "Background jobs"
 msgstr "Позадински послови"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"Не могу да променим власништво циљног директоријума „%s“\n"
+"%s"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2183,17 +2199,27 @@ msgstr "О&чисти означене"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
+"Не могу да добијем податке о „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Не могу да отворим тар архиву\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Не могу да обрадим:"
 
 msgid "set &user ID on execution"
 msgstr "подеси ИБ &корисника при извршавању"
@@ -2295,13 +2321,21 @@ msgstr "Повежите „%s“ са:"
 msgid "Link"
 msgstr "Веза"
 
-#, c-format
-msgid "link: %s"
-msgstr "веза: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Не могу да направим циљну симболичку везу „%s“\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "симболичка веза: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Не могу да умножим цикличну симболичку везу\n"
+"„%s“"
 
 msgid "View file"
 msgstr "Прегледајте датотеку"
@@ -2323,6 +2357,12 @@ msgstr "Направите нови директоријум"
 
 msgid "Enter directory name:"
 msgstr "Унесите назив директоријума:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Не могу да направим директоријум „%s“"
 
 msgid "Extension file edit"
 msgstr "Уређивање датотеке проширења"
@@ -2372,12 +2412,16 @@ msgstr "Симболичка веза „%s“ упућује на:"
 msgid "Edit symlink"
 msgstr "Уреди симболичку везу"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "уређивање симболичке везе, не може да уклони „%s“: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "уреди симболичку везу: %s"
 
 msgid "FTP to machine"
@@ -2419,10 +2463,8 @@ msgstr "Не могу да извршим наредбе на не-месним 
 msgid "Parameter"
 msgstr "Параметар"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Не могу да направим привремену датотеку наредбе\n"
 "%s"
@@ -2433,7 +2475,7 @@ msgstr "Сојка није успела"
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2443,7 +2485,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2498,25 +2540,25 @@ msgstr "датотека/директоријума"
 msgid " with source mask:"
 msgstr " уз изворну маску:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"Не могу да добијем податке о изворној датотеци „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
+"Не могу да направим циљну симболичку везу „%s“\n"
+"%s"
 
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Не могу да прочитам изворну везу „%s“\n"
@@ -2528,9 +2570,9 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Не могу да направим циљну симболичку везу „%s“\n"
@@ -2560,21 +2602,31 @@ msgstr ""
 "„%s“\n"
 "су једна иста датотека"
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "Пробај &поново"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Директоријум „%s“ није празан.\n"
 "Да га обришем дубински?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Позадински процес:\n"
@@ -2584,17 +2636,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "&Ништа"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Не могу да уклоним датотеку „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Не могу да добијем податке о датотеци „%s“\n"
@@ -2604,102 +2656,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Не могу да препишем директоријум „%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Не могу да преместим датотеку „%s“ у „%s“\n"
+"Не могу да уклоним датотеку „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Не могу да уклоним директоријум „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Не могу да препишем директоријум „%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Не могу да препишем директоријум „%s“\n"
-"%s"
+msgstr "Не могу да препишем директоријум „%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Не могу да препишем датотеку „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Не могу да преместим директоријум „%s“ у „%s“\n"
+"Не могу да уклоним директоријум „%s“\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Не могу да радим над \"..\"!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Не могу да добијем податке о изворној датотеци „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Не могу да добијем податке о изворној датотеци „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Не могу да дознам податке о циљној датотеци „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Не могу да направим посебну датотеку „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Не могу да променим власништво циљне датотеке „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Не могу да променим режим циљне датотеке „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Не могу да отворим изворну везу „%s“\n"
@@ -2708,47 +2766,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Поновно добављање није успело, за време преписивања датотеке"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Не могу да дознам податке о изворној датотеци „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Не могу да направим циљну датотеку „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Не могу да дознам податке о циљној датотеци „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Не могу да прерасподелим простор за циљу датотеку „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
+"Не могу да прочитам изворну везу „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Не могу да запишем циљну датотеку „%s“\n"
@@ -2766,41 +2826,45 @@ msgstr "&Задржи"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Не могу да затворим изворну везу „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Не могу да затворим циљну датотеку „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Не могу да прерасподелим простор за циљу датотеку „%s“\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Не могу да добијем податке о изворном директоријуму „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Не могу да добијем податке о изворном директоријуму „%s“\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2818,25 +2882,27 @@ msgstr ""
 "Не могу да умножим цикличну симболичку везу\n"
 "„%s“"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Одредиште „%s“ мора бити директоријум\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Не могу да направим циљни директоријум „%s“\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Не могу да променим власништво циљног директоријума „%s“\n"
@@ -3165,11 +3231,9 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-msgid "The Midnight Commander"
-msgstr "Поноћни наредник"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Да ли стварно желите да изађете из Поноћног наредника?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Да ли стварно желите да извршите?"
 
 msgid "&Above"
 msgstr "И&знад"
@@ -3669,12 +3733,13 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
+"Нисам успео да прочитам податке из стандардног излаза порода:\n"
+"%s"
 
 msgid "Cannot run external panelize in a non-local directory"
 msgstr ""
@@ -3714,6 +3779,15 @@ msgid ""
 "%s"
 msgstr ""
 "Не могу да добавим податке о одредишту\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Одредиште „%s“ мора бити директоријум\n"
 "%s"
 
 #, c-format
@@ -3835,8 +3909,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Путања почетног директоријума није апсолутна"
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4519,8 +4594,9 @@ msgstr "Датотека је измењена. Да сачувам при из�
 msgid "&Cancel quit"
 msgstr "&Откажи излазак"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Поноћни наредник је угашен.\n"
@@ -4571,10 +4647,8 @@ msgstr "Разобликуј"
 msgid "ButtonBar|Format"
 msgstr "Обликуј"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Нисам успео да прочитам податке из стандардног излаза порода:\n"
 "%s"
@@ -4600,20 +4674,18 @@ msgstr ""
 msgid "View: "
 msgstr "Преглед: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Не могу да отворим „%s“\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Не могу да прикажем: није обична датотека"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Не могу да отворим „%s“ у режиму обраде\n"
@@ -4627,6 +4699,67 @@ msgstr "Да наставим са почетка?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Не могу да довучем месни примерак „/ftp://some.host/editme.txt“"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Поноћни наредник"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Да ли стварно желите да изађете из Поноћног наредника?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Не могу да отворим „%s“ за читање"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Не могу да добавим величину/овлашћења за „%s“"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Не могу да отворим спојку за писање: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Не могу да сачувам: одредиште није обична датотека"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не могу да отворим датотеку „%s“\n"
+#~ "%s"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "веза: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "симболичка веза: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не могу да преместим датотеку „%s“ у „%s“\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не могу да препишем директоријум „%s“\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не могу да преместим директоријум „%s“ у „%s“\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Другa, осмобитнa"

--- a/po/sv.po
+++ b/po/sv.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Swedish (http://app.transifex.com/mc/mc/language/sv/)\n"
@@ -59,6 +59,9 @@ msgstr "Kan inte skapa gruppen '%s' för händelser!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Kan inte skapa händelsen '%s'!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -770,10 +773,10 @@ msgstr "fil1 fil2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[denna_katalog] [andra_panelens_katalog]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -844,28 +847,23 @@ msgstr "Sök"
 msgid "Search is disabled"
 msgstr "Sök är inaktiverat"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Temporär diff-fil kunde inte skapas\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Backupfil kunde inte skapas\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Temporär sammanflätningsfil kunde inte skapas\n"
 "%s"
@@ -936,18 +934,19 @@ msgstr "ButtonBar|Inställ"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Avslut"
 
-msgid "Quit"
-msgstr "Avsluta"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Filer har ändrats. Spara vid nedstängning?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander är på väg att stängas ned.\n"
 "Spara ändrade filer?"
+
+msgid "Quit"
+msgstr "Avsluta"
 
 msgid "Diff:"
 msgstr "Diff:"
@@ -955,13 +954,15 @@ msgstr "Diff:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" är en katalog"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "'stat' misslyckades på \"%s\"\n"
@@ -980,9 +981,13 @@ msgstr "Laddar %3d%%"
 msgid "Loading..."
 msgstr "Laddar..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Kan inte öppna %s för läsning"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Öppning av \"%s\" misslyckades\n"
+"%s"
 
 msgid "Load file"
 msgstr "Ladda fil"
@@ -991,12 +996,10 @@ msgstr "Ladda fil"
 msgid "Error reading %s"
 msgstr "Fel vid läsning av %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Kan inte läsa storlek/behörigheter för %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" är inte en känd filtyp"
 
 #, c-format
@@ -1014,8 +1017,10 @@ msgstr "Varning"
 msgid "Error reading from pipe: %s"
 msgstr "Fel vid lädning från tunnel: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Tunnel kunde inte öppnas för läsning: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1028,12 +1033,11 @@ msgstr "Filen har modifierats av något annat under tiden. Spara ändå?"
 msgid "Error writing to pipe: %s"
 msgstr "Fel vid skrivning till tunnel: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Tunneln kunde inte öppnas för skrivning: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Filen kunde inte öppnas för skrivning: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1078,8 +1082,12 @@ msgstr "Kontrollera &POSIX-radslut"
 msgid "Edit Save Mode"
 msgstr "Editera sätt att spara"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Kan inte spara: målfilen är inte en vanlig fil"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Kan inte visas: inte en vanlig fil"
 
 msgid "A file already exists with this name"
 msgstr "En fil med detta namn finns redan"
@@ -1138,9 +1146,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Stäng fil"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander är på väg att stängas ned.\n"
@@ -1581,15 +1589,13 @@ msgstr "Bekräfta ersätt"
 msgid "%ld replacements made"
 msgstr "%ld ersättningar gjordes"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "En användarvänlig texteditor\n"
 "skriven för Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Om"
@@ -1717,16 +1723,14 @@ msgstr "< Auto >"
 msgid "< Reload Current Syntax >"
 msgstr "< Ladda om nuvarande >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Öppning av filen %s misslyckades"
+
 msgid "Load syntax file"
 msgstr "Ladda syntax-fil"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Filen %s kunde inte öppnas\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1757,7 +1761,8 @@ msgstr ""
 "Inte en xterm eller linux konsol;\n"
 "Subshell kan inte växlas."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Skriv 'exit' för att återvända till Midnight Commander"
 
 msgid "Set &all"
@@ -1788,26 +1793,33 @@ msgstr "Rättigheter (oktalt): 1%o"
 msgid "Chown advanced command"
 msgstr "Avancerat chown-kommando"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Chmod \"%s\" misslyckades\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Chown \"%s\" misslyckades\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Chmod \"%s\" misslyckades\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "I&gnorera"
-
-msgid "Ignore &all"
-msgstr "Ignorera a&lla"
-
-msgid "&Retry"
-msgstr "Försök &igen"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Chown \"%s\" misslyckades\n"
@@ -1824,6 +1836,20 @@ msgstr "Kör"
 
 msgid "Stopped"
 msgstr "Stannad"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Ingen översättning >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Teckenöversättning för inmatning/visning:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "Al&drig"
@@ -1902,17 +1928,6 @@ msgstr "A&utospara inställningar"
 
 msgid "Configure options"
 msgstr "Inställningar"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Ingen översättning >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Teckenöversättning för inmatning/visning:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Tema:"
@@ -2109,12 +2124,13 @@ msgstr "&Döda"
 msgid "Background jobs"
 msgstr "Bakgrundsjobb"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"Chown på målkatalogen \"%s\" misslyckades\n"
+"%s"
 
 msgid "Secure deletion"
 msgstr "säker radering"
@@ -2203,17 +2219,27 @@ msgstr "N&ollställ markerade"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
+"'stat' misslyckades på \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Kan inte öppna tarfilen\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Kunde inte tolka:"
 
 msgid "set &user ID on execution"
 msgstr "sätt användar-I&D vid exekvering"
@@ -2315,13 +2341,21 @@ msgstr "Länka %s till:"
 msgid "Link"
 msgstr "Länk"
 
-#, c-format
-msgid "link: %s"
-msgstr "länk: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Skapandet av mål-symlänken \"%s\" misslyckades\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "symlänk: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Cyklisk symboliskt länk kan inte kopieras\n"
+"\"%s\""
 
 msgid "View file"
 msgstr "Visa fil"
@@ -2343,6 +2377,12 @@ msgstr "Skapa en ny katalog"
 
 msgid "Enter directory name:"
 msgstr "Ange katalognamn:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Kan inte skapa katalogen %s"
 
 msgid "Extension file edit"
 msgstr "Redigera utökningsfilen"
@@ -2392,12 +2432,16 @@ msgstr "Symlänk '%s' pekar på:"
 msgid "Edit symlink"
 msgstr "Redigera symlänk"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "redigera symlänk: %s kunde inte tas bort: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "redigera symlänk: %s"
 
 msgid "FTP to machine"
@@ -2439,10 +2483,8 @@ msgstr "Kommandon kan inte exekveras på ickelokala filsystem"
 msgid "Parameter"
 msgstr "Parameter"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Skapandet av en temporär kommandofil misslyckades\n"
 "%s"
@@ -2453,7 +2495,7 @@ msgstr "Tunnel misslyckades"
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2463,7 +2505,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2518,29 +2560,23 @@ msgstr "filer/kataloger"
 msgid " with source mask:"
 msgstr " med källfilter:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Kan inte hämta information om källfil för hårdlänk ”%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Kan inte skapa mål för hårdlänk ”%s”\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Kan inte skapa mål för hårdlänk ”%s”"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Källänken \"%s\" kunde inte läsas\n"
@@ -2555,9 +2591,9 @@ msgstr ""
 "\n"
 "Inställningen 'stabila symlänkar' kommer att slås av"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Skapandet av mål-symlänken \"%s\" misslyckades\n"
@@ -2587,21 +2623,31 @@ msgstr ""
 "\"%s\"\n"
 "är samma fil"
 
+msgid "&Ignore"
+msgstr "I&gnorera"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "Försök &igen"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Katalogen \"%s\" är inte tom.\n"
 "Ta bort den rekursivt?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Bakgrundsprocess:\n"
@@ -2611,17 +2657,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "&Ingen"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Borttagning av filen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Stat misslyckades på filen \"%s\"\n"
@@ -2631,102 +2677,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Katalogen \"%s\" kan inte skrivas över"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Att flytta filen \"%s\" to \"%s\" misslyckades\n"
+"Borttagning av filen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Borttagning av katalogen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Katalogen \"%s\" kan inte skrivas över"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Katalogen \"%s\" kan inte skrivas över\n"
-"%s"
+msgstr "Katalogen \"%s\" kan inte skrivas över"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "Att skriva över filen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Att flytta katalogen \"%s\" till \"%s\" misslyckades\n"
+"Borttagning av katalogen \"%s\" misslyckades\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Kan inte använda \"..\"!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Stat på källfilen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Kan inte hämta information om källfil för hårdlänk ”%s”\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Fstat på målfilen \"%s\" misslyckades\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Skapandet av specialfilen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Chown på målfilen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Chmod på målfilen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Öppning av källfilen \"%s\" misslyckades\n"
@@ -2735,49 +2787,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Hämta om misslyckades. Skriver över filen."
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Fstat på källfilen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Att skapa målfilen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Fstat på målfilen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Förallokering av utrymme för målfilen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Läsning av källfilen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Skrivning av målfilen \"%s\" misslyckades\n"
@@ -2795,41 +2847,45 @@ msgstr "&Behåll"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Stängning av källfilen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Stängning av målfilen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Förallokering av utrymme för målfilen \"%s\" misslyckades\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Stat på källkatalogen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Stat på källkatalogen \"%s\" misslyckades\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2847,25 +2903,27 @@ msgstr ""
 "Cyklisk symboliskt länk kan inte kopieras\n"
 "\"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Målet \"%s\"  måste vara en katalog\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Skapandet av målkatalogen \"%s\" misslyckades\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Chown på målkatalogen \"%s\" misslyckades\n"
@@ -3193,11 +3251,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "Du har %zu öppnad skärm. Avsluta ändå?"
 msgstr[1] "Du har %zu öppnade skärmar. Avsluta ändå?"
 
-msgid "The Midnight Commander"
-msgstr "The Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Vill du verkligen avsluta Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Vill du verkligen exekvera?"
 
 msgid "&Above"
 msgstr "&Över"
@@ -3694,12 +3750,13 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
+"Läsning av data från barn-stdout misslyckades:\n"
+"%s"
 
 msgid "Cannot run external panelize in a non-local directory"
 msgstr "Extern panelisering kan inte köras på en icke-lokal katalog"
@@ -3738,6 +3795,15 @@ msgid ""
 "%s"
 msgstr ""
 "Stat på målet misslyckades\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Målet \"%s\"  måste vara en katalog\n"
 "%s"
 
 #, c-format
@@ -3859,8 +3925,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Hemkatalogsökvägen är inte absolut"
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4543,8 +4610,9 @@ msgstr "Filen har ändrats. Spara vid nedstängning?"
 msgid "&Cancel quit"
 msgstr "&Avbryt nedstängning"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander stängs ner.\n"
@@ -4595,10 +4663,8 @@ msgstr "ButtonBar|Oform"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Format"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Läsning av data från barn-stdout misslyckades:\n"
 "%s"
@@ -4624,20 +4690,18 @@ msgstr ""
 msgid "View: "
 msgstr "Visa:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Öppning av \"%s\" misslyckades\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Kan inte visas: inte en vanlig fil"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Öppna \"%s\" i tolkningsläge misslyckades\n"
@@ -4651,6 +4715,78 @@ msgstr "Fortsätt från början?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Kan inte hämta en lokal kopia av /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "The Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Vill du verkligen avsluta Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Kan inte öppna %s för läsning"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Kan inte läsa storlek/behörigheter för %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Tunneln kunde inte öppnas för skrivning: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Kan inte spara: målfilen är inte en vanlig fil"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Filen %s kunde inte öppnas\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ignorera a&lla"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "länk: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "symlänk: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kan inte skapa mål för hårdlänk ”%s”\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Att flytta filen \"%s\" to \"%s\" misslyckades\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Katalogen \"%s\" kan inte skrivas över\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Att flytta katalogen \"%s\" till \"%s\" misslyckades\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Annan 8-bitars"

--- a/po/szl.po
+++ b/po/szl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Silesian (http://app.transifex.com/mc/mc/language/szl/)\n"
@@ -47,6 +47,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -726,7 +729,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -792,23 +795,16 @@ msgstr ""
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -877,15 +873,16 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr ""
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Diff:"
@@ -895,12 +892,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -918,7 +917,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -929,11 +930,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -950,7 +949,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -964,11 +965,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1013,7 +1013,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1073,7 +1077,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1509,12 +1513,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1643,13 +1645,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1675,7 +1677,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1708,22 +1711,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1737,6 +1743,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1815,15 +1833,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2020,7 +2029,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2113,13 +2121,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2224,11 +2238,15 @@ msgid "Link"
 msgstr ""
 
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2250,6 +2268,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2299,11 +2323,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2343,10 +2371,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2355,7 +2380,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2365,7 +2390,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2422,23 +2447,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2450,7 +2471,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2470,19 +2491,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2491,13 +2522,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2507,37 +2538,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2546,43 +2581,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2591,37 +2626,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2639,31 +2674,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2681,19 +2716,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3019,10 +3056,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3519,11 +3553,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3559,6 +3591,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3661,8 +3700,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4312,8 +4352,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4362,10 +4403,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4386,16 +4424,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Slava Zanko <slavazanko@gmail.com>, 2011\n"
 "Language-Team: Tamil (http://app.transifex.com/mc/mc/language/ta/)\n"
@@ -47,6 +47,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -726,7 +729,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -792,23 +795,16 @@ msgstr "தேடு"
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -877,15 +873,16 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr ""
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Diff:"
@@ -895,12 +892,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -918,7 +917,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -929,11 +930,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -950,7 +949,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -964,11 +965,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1013,7 +1013,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1073,7 +1077,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1509,12 +1513,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1643,13 +1645,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1675,7 +1677,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1708,22 +1711,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1737,6 +1743,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1815,15 +1833,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2020,7 +2029,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2113,13 +2121,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2224,11 +2238,15 @@ msgid "Link"
 msgstr ""
 
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2250,6 +2268,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2299,11 +2323,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2343,10 +2371,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2355,7 +2380,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2365,7 +2390,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2422,23 +2447,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2450,7 +2471,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2470,19 +2491,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2491,13 +2522,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2507,37 +2538,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2546,43 +2581,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2591,37 +2626,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2639,31 +2674,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2681,19 +2716,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3018,10 +3055,7 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3515,11 +3549,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3555,6 +3587,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3657,8 +3696,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4308,8 +4348,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4358,10 +4399,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4382,16 +4420,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Telugu (http://app.transifex.com/mc/mc/language/te/)\n"
@@ -46,6 +46,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -725,7 +728,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -791,23 +794,16 @@ msgstr ""
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -876,15 +872,16 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr ""
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Diff:"
@@ -894,12 +891,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -917,7 +916,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -928,11 +929,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -949,7 +948,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -963,11 +964,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1012,7 +1012,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1072,7 +1076,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1508,12 +1512,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1642,13 +1644,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1674,7 +1676,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1707,22 +1710,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1736,6 +1742,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1814,15 +1832,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2019,7 +2028,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2112,13 +2120,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2223,11 +2237,15 @@ msgid "Link"
 msgstr ""
 
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2249,6 +2267,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2298,11 +2322,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2342,10 +2370,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2354,7 +2379,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2364,7 +2389,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2421,23 +2446,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2449,7 +2470,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2469,19 +2490,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2490,13 +2521,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2506,37 +2537,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2545,43 +2580,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2590,37 +2625,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2638,31 +2673,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2680,19 +2715,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3017,10 +3054,7 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3514,11 +3548,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3554,6 +3586,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3656,8 +3695,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4307,8 +4347,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4357,10 +4398,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4381,16 +4419,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Turkish (http://app.transifex.com/mc/mc/language/tr/)\n"
@@ -56,6 +56,9 @@ msgstr "Etkinlikler için  '% s' grubu oluşturulamadı!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "'% s' Olay oluşturulamadı!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -771,10 +774,10 @@ msgstr "dosya1 dosya2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[seçenekler] [bu_dizin] [diğer_panel_dizini]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -845,28 +848,23 @@ msgstr "Ara"
 msgid "Search is disabled"
 msgstr "Arama devre dışı"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Geçici fark dosyası oluşturulamadı\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Yedek dosyası oluşturulamadı\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Geçici birleştirme dosyası oluşturulamadı\n"
 "%s"
@@ -937,18 +935,19 @@ msgstr "Düğme Çubuğu|Secenekleri"
 msgid "ButtonBar|Quit"
 msgstr "Düğme Çubuğu|Çıkış"
 
-msgid "Quit"
-msgstr "Çık"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Değişiklikler çıkarken dosyaya kaydedilsin mi?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander kapatılıyor.\n"
 "Değiştirilmiş dosya(lar) kaydedilsin mi?"
+
+msgid "Quit"
+msgstr "Çık"
 
 msgid "Diff:"
 msgstr "Fark:"
@@ -956,13 +955,15 @@ msgstr "Fark:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" bir dizindir"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "\"%s\" durumlanamıyor\n"
@@ -981,9 +982,13 @@ msgstr "Yükleniyor: %3d%%"
 msgid "Loading..."
 msgstr "Yükleniyor..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "%s okumak için açılamıyor"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"\"%s\" açılamıyor\n"
+" %s"
 
 msgid "Load file"
 msgstr "Dosya yükle"
@@ -992,12 +997,10 @@ msgstr "Dosya yükle"
 msgid "Error reading %s"
 msgstr "%s okuma hatası"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "%s için boyut/izin bilgileri alınamadı"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s' normal bir dosya değil."
 
 #, c-format
@@ -1015,8 +1018,10 @@ msgstr "Uyarı"
 msgid "Error reading from pipe: %s"
 msgstr "Borudan okuma hatası: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Boru okumak için açılamıyor: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1029,12 +1034,11 @@ msgstr "Dosya değiştirilmiş. Yine de kaydedilsin mi?"
 msgid "Error writing to pipe: %s"
 msgstr "Boruya yazarken hata: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Boru yazmak için açılırken hata oluştu %s "
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "%s dosyası yazmak için açılamıyor:"
 
 msgid "The file you are saving does not end with a newline."
@@ -1081,8 +1085,12 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr "Kaydetme kipini düzenle"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Kaydedilemedi: hedef normal bir dosya değil"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Gösterilemiyor: normal bir dosya değil"
 
 msgid "A file already exists with this name"
 msgstr "Bu isimde bir dosya zaten var"
@@ -1141,9 +1149,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Dosyayı kapat"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander kapatılıyor.\n"
@@ -1586,15 +1594,13 @@ msgstr "Yer değişikliğini onaylat"
 msgid "%ld replacements made"
 msgstr "%ld yerleştirme yapıldı"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Kullanıcı dostu bir metin düzenleyici\n"
 "Midnight Commander için yazıldı"
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Hakkında"
@@ -1724,16 +1730,14 @@ msgstr "< Otomatik >"
 msgid "< Reload Current Syntax >"
 msgstr "< Mevcut Sözdizimini Yükle >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "%s dosyası açılamadı"
+
 msgid "Load syntax file"
 msgstr "Sözdizimi dosyasını yükle"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"%s dosyası açılamadı \n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1764,7 +1768,8 @@ msgstr ""
 "Bir xterm veya Linux konsolu değil;\n"
 "alt kabuk değiştirilemez."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Midnight Commander'a dönmek için 'exit' yazın"
 
 msgid "Set &all"
@@ -1795,26 +1800,33 @@ msgstr "İzinler (sekizlik):%o"
 msgid "Chown advanced command"
 msgstr "Dosya özellikleri"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"chmod \"%s\" yapılamadı \n"
+" %s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"chown \"%s\" yapılamadı \n"
+" %s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "chmod \"%s\" yapılamadı \n"
 " %s"
 
-msgid "&Ignore"
-msgstr "&Yoksay"
-
-msgid "Ignore &all"
-msgstr "Tümünü &yoksay"
-
-msgid "&Retry"
-msgstr "&Tekrar"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "chown \"%s\" yapılamadı \n"
@@ -1831,6 +1843,20 @@ msgstr "Çalışıyor"
 
 msgid "Stopped"
 msgstr "Durduruldu"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Çeviri yok >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Girdi / gösterme karakter kümesi:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "a&Sla"
@@ -1909,17 +1935,6 @@ msgstr "&Ayarları otomatik kaydet"
 
 msgid "Configure options"
 msgstr "Yapılandırma seçenekleri"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Çeviri yok >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Girdi / gösterme karakter kümesi:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Tema"
@@ -2117,12 +2132,13 @@ msgstr "&Öldür"
 msgid "Background jobs"
 msgstr "Artalan İşleri"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"Hedef \"%s\" dizininin sahibi değiştirilemiyor \n"
+" %s"
 
 msgid "Secure deletion"
 msgstr "Güvenli sil"
@@ -2211,17 +2227,27 @@ msgstr "İşa&retlenenleri Temizle"
 msgid "Chattr command"
 msgstr "Chattr komutu"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
+"\"%s\" durumlanamıyor\n"
+" %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"%s\n"
+"tar arşivini açılamadı"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Ayrıştırılamadı:"
 
 msgid "set &user ID on execution"
 msgstr "kullanıcı çalıştırabilir"
@@ -2323,13 +2349,21 @@ msgstr "%s bağı:"
 msgid "Link"
 msgstr "bağlantı"
 
-#, c-format
-msgid "link: %s"
-msgstr "bağ: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Hedef sembolik bağ \"%s\" oluşturulamıyor \n"
+" %s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "sembağ: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Devirli sembolik bağ kopyalanamaz \n"
+" `\"%s\""
 
 msgid "View file"
 msgstr "Dosyayı görüntüle"
@@ -2351,6 +2385,12 @@ msgstr "Yeni bir dizin Oluştur"
 
 msgid "Enter directory name:"
 msgstr "Dizin ismi Gir:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Dizin %s oluşturulamıyor"
 
 msgid "Extension file edit"
 msgstr "Uzantı dosyası düzenleme"
@@ -2400,12 +2440,16 @@ msgstr "Sembolik bağlantı '%s' şuna işaret ediyor:"
 msgid "Edit symlink"
 msgstr "Sembolik bağı düzenle"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "sembolik bağ düzenleme, %s silinemedi: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "Sembolik bağı düzenle: %s"
 
 msgid "FTP to machine"
@@ -2447,10 +2491,8 @@ msgstr "Yerel dosya sistemi dışında komut çalıştırılamaz"
 msgid "Parameter"
 msgstr "Parametre"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Geçici komut dosyası oluşturulamıyor:\n"
 " %s"
@@ -2461,7 +2503,7 @@ msgstr "Boru açılamadı"
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2471,7 +2513,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2526,25 +2568,25 @@ msgstr "dosya/dizin"
 msgid " with source mask:"
 msgstr " bu maskla:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"\"%s\" kaynak dosyası durumlanamıyor \n"
+" %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
+"Hedef sembolik bağ \"%s\" oluşturulamıyor \n"
+" %s"
 
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Kaynak bağı \"%s\" okunamadı \n"
@@ -2559,9 +2601,9 @@ msgstr ""
 "\n"
 " Sembolik Bağlarda Kararlılık seçeneği kapatılacak"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Hedef sembolik bağ \"%s\" oluşturulamıyor \n"
@@ -2591,21 +2633,31 @@ msgstr ""
 "\"%s\"\n"
 "aynı dosya"
 
+msgid "&Ignore"
+msgstr "&Yoksay"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "&Tekrar"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "\"%s\" dizini boş değil.\n"
 "Yinelemeli olarak silinsin mi?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Arkaplan işlemi:\n"
@@ -2615,17 +2667,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "&hiçbiri"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "\"%s\" dosyası silinemiyor \n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "\"%s\" dosyası durumlanamıyor \n"
@@ -2635,102 +2687,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "\"%s dizinin üstüne yazılamıyor "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"\"%s\" dosyası \"%s\" e taşınamıyor \n"
+"\"%s\" dosyası silinemiyor \n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "\"%s\" dizini silinemiyor \n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "\"%s dizinin üstüne yazılamıyor "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"\"%s\" dizininin üstüne yazılamıyor \n"
-"%s"
+msgstr "\"%s dizinin üstüne yazılamıyor "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "\"%s\" dosyasının üstüne yazılamadı\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"\"%s\" dizini \"%s\"e taşınamıyor \n"
+"\"%s\" dizini silinemiyor \n"
 " %s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "\"..\" üzerinde işlem yapılamıyor!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "\"%s\" kaynak dosyası durumlanamıyor \n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"\"%s\" kaynak dosyası durumlanamıyor \n"
+" %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"\"%s\" hedef dosyası fstat yapılamıyor \n"
+" %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "\"%s\" özel dosyası oluşturulamıyor \n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "\"%s\" hedef dosyasının sahibi değiştirilemiyor \n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "\"%s\" dosyasının kipi değiştirilemiyor \n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "\"%s\" kaynak dosyası açılamıyor \n"
@@ -2739,49 +2797,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "dosyanın üstüne yazılmasında, Reget başarısız"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "\"%s\" kaynak dosyasına fstat yapılamıyor\n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "\"%s\" hedef dosyası oluşturulamıyor \n"
 " %sw"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "\"%s\" hedef dosyası fstat yapılamıyor \n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "\"%s\"  hedef dosyası için alan önceden ayrılamadı\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "\"%s\" kaynak dosya okunamadı\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "\"%s\" hedef dosyasına yazılamıyor \n"
@@ -2799,41 +2857,45 @@ msgstr "&Koru"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "\"%s\" kaynak dosyası kapatılamıyor \n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "\"%s\" hedef dosyası kapatılamıyor \n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"\"%s\"  hedef dosyası için alan önceden ayrılamadı\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "\"%s\" kaynak dizini durumlanamıyor \n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"\"%s\" kaynak dizini durumlanamıyor \n"
+" %s"
 
 #, c-format
 msgid ""
@@ -2851,25 +2913,27 @@ msgstr ""
 "Devirli sembolik bağ kopyalanamaz \n"
 " `\"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Hedef \"%s\" bir dizin olmalı \n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Hedef dizin \"%s\" oluşturulamıyor \n"
 " %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Hedef \"%s\" dizininin sahibi değiştirilemiyor \n"
@@ -3197,11 +3261,9 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Midnight Commander'dan gerçekten çıkmak istiyor musunuz?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Gerçekten çalıştırmak istiyor musunuz?"
 
 msgid "&Above"
 msgstr "&Üst"
@@ -3698,12 +3760,13 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
+"Alt standar çıktıdan veri okuma başarısız:\n"
+"%s"
 
 msgid "Cannot run external panelize in a non-local directory"
 msgstr "Bir uzak dizine girilirken dış panalleme çalıştırılamaz"
@@ -3742,6 +3805,15 @@ msgid ""
 "%s"
 msgstr ""
 "Hedef durumlanamıyor\n"
+" %s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Hedef \"%s\" bir dizin olmalı \n"
 " %s"
 
 #, c-format
@@ -3864,8 +3936,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Ev dizini yolu mutlak değil"
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4549,8 +4622,9 @@ msgstr "Değişiklikler çıkarken dosyaya kaydedilsin mi?"
 msgid "&Cancel quit"
 msgstr "&Çıkışı durdur"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander kapatılıyor.\n"
@@ -4601,10 +4675,8 @@ msgstr "Düğme Çubuğu|Formsuz"
 msgid "ButtonBar|Format"
 msgstr "Düğme Çubuğu|Biçim"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Alt standar çıktıdan veri okuma başarısız:\n"
 "%s"
@@ -4630,20 +4702,18 @@ msgstr ""
 msgid "View: "
 msgstr "Görünüm:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"\"%s\" açılamıyor\n"
-" %s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Gösterilemiyor: normal bir dosya değil"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "\"%s\" ayrıştırma kipinde açılamadı\n"
@@ -4657,6 +4727,70 @@ msgstr "Başından devam edilsin mi?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr " /ftp://some.host/editme.txt 'in yerel kopyası alınamadı"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Midnight Commander'dan gerçekten çıkmak istiyor musunuz?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "%s okumak için açılamıyor"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "%s için boyut/izin bilgileri alınamadı"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Boru yazmak için açılırken hata oluştu %s "
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Kaydedilemedi: hedef normal bir dosya değil"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "%s dosyası açılamadı \n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Tümünü &yoksay"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "bağ: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "sembağ: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "\"%s\" dosyası \"%s\" e taşınamıyor \n"
+#~ " %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "\"%s\" dizininin üstüne yazılamıyor \n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "\"%s\" dizini \"%s\"e taşınamıyor \n"
+#~ " %s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Diğer 8 bit"

--- a/po/uk.po
+++ b/po/uk.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2016,2025\n"
 "Language-Team: Ukrainian (http://app.transifex.com/mc/mc/language/uk/)\n"
@@ -62,6 +62,9 @@ msgstr "Не вдалося створити для подій групу «%s»
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "Не вдалося створити подію '%s'!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -780,10 +783,10 @@ msgstr "file1 file2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[цей_каталог] [каталог_іншої_панелі]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -855,28 +858,23 @@ msgstr "Пошук"
 msgid "Search is disabled"
 msgstr "Пошук вимкнено"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "Не вдалося створити тимчасовий різницевий файл\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "Не вдалося створити файл резервної копії\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "Не вдалося створити тимчасовий файл об’єднання\n"
 "%s "
@@ -947,16 +945,17 @@ msgstr "ButtonBar|Параметри"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|Вихід"
 
-msgid "Quit"
-msgstr "Вийти"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "Файл(и) було змінено. Вийти зі збереженням?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr "Midnight Commander закривається. Зберегти змінені файли?"
+
+msgid "Quit"
+msgstr "Вийти"
 
 msgid "Diff:"
 msgstr "Різниця:"
@@ -964,13 +963,15 @@ msgstr "Різниця:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "«%s» є каталогом"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "Не вдалося отримати властивості «%s»\n"
@@ -989,9 +990,13 @@ msgstr "Завантаження: %3d%%"
 msgid "Loading..."
 msgstr "Завантаження..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "Не вдалося відкрити %s для читання"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"Не вдалося відкрити «%s»\n"
+"%s"
 
 msgid "Load file"
 msgstr "Завантажити файл"
@@ -1000,12 +1005,10 @@ msgstr "Завантажити файл"
 msgid "Error reading %s"
 msgstr "Сталася помилка зчитування %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "Не вдалося отримати розмір/права доступу для %s"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "«%s» не є звичайним файлом"
 
 #, c-format
@@ -1023,8 +1026,10 @@ msgstr "Попередження"
 msgid "Error reading from pipe: %s"
 msgstr "Сталася помилка читання з каналу: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "Не вдалося відкрити канал для читання: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1037,12 +1042,11 @@ msgstr "Файл змінено під час роботи. Все рівно з
 msgid "Error writing to pipe: %s"
 msgstr "Сталася помилка запису в канал: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "Не вдалося відкрити канал для запису: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "Не вдалося відкрити файл для запису: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1087,8 +1091,12 @@ msgstr "Перевіряти новий рядок &POSIX"
 msgid "Edit Save Mode"
 msgstr "Редагувати режим збереження "
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "Сталася помилка під час збереження: цільовий об’єкт не є файлом"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "Не вдалося показати: не звичайний файл"
 
 msgid "A file already exists with this name"
 msgstr "Файл із такою назвою вже існує"
@@ -1147,9 +1155,9 @@ msgstr ""
 msgid "Close file"
 msgstr "Закрити файл"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Виконується вихід із Midnight Commander.\n"
@@ -1591,15 +1599,13 @@ msgstr "Підтвердити заміну"
 msgid "%ld replacements made"
 msgstr "Виконано замін: %ld"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "Дружній до користувача редактор тексту\n"
 "написаний для Midnight Commander."
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "Про програму"
@@ -1727,16 +1733,14 @@ msgstr "< Авто >"
 msgid "< Reload Current Syntax >"
 msgstr "< Оновити поточний синтаксис >"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "Не вдалося відкрити файл %s "
+
 msgid "Load syntax file"
 msgstr "Завантажити файл синтаксису"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"Не вдалося відкрити файл %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1766,7 +1770,8 @@ msgstr ""
 "Це не xterm чи консоль Linux;\n"
 "підоболонку не можливо перемкнути."
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "Введіть 'exit', щоб повернутися до Midnight Commander"
 
 msgid "Set &all"
@@ -1797,26 +1802,33 @@ msgstr "Дозволи (шістнад.): %o"
 msgid "Chown advanced command"
 msgstr "Розширена зміна власника"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"Не вдалося змінити права на «%s» \n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"Не вдалося змінити власника «%s» \n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "Не вдалося змінити права на «%s» \n"
 "%s"
 
-msgid "&Ignore"
-msgstr "&Ігнорувати"
-
-msgid "Ignore &all"
-msgstr "Ігнорувати &все"
-
-msgid "&Retry"
-msgstr "По&вторити"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "Не вдалося змінити власника «%s» \n"
@@ -1833,6 +1845,20 @@ msgstr "Виконується"
 
 msgid "Stopped"
 msgstr "Зупинено"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Без перекодування >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Кодування вводу/показу:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Ніколи"
@@ -1911,17 +1937,6 @@ msgstr "&Автозбереження параметрів"
 
 msgid "Configure options"
 msgstr "Параметри конфігурації"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Без перекодування >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Кодування вводу/показу:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "Шкіра:"
@@ -2117,12 +2132,13 @@ msgstr "&Завершити"
 msgid "Background jobs"
 msgstr "Фонові завдання"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"Не вдалося змінити власника цільового каталогу «%s»\n"
+"%s"
 
 msgid "Secure deletion"
 msgstr "Безпечне видалення"
@@ -2211,19 +2227,29 @@ msgstr "&Вим. поміч."
 msgid "Chattr command"
 msgstr "Команда chattr"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 "Не вдалося змінити атрибути \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Не вдалося відкрити архів tar\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Не вдалося змінити атрибути \"%s\"\n"
+"%s"
 
 msgid "set &user ID on execution"
 msgstr "встановити ID &користувача на виконання"
@@ -2325,13 +2351,21 @@ msgstr "Створити посилання на %s:"
 msgid "Link"
 msgstr "Посилання"
 
-#, c-format
-msgid "link: %s"
-msgstr "посилання: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"Не вдалося створити цільове символьне посилання «%s»\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "символьне посилання: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"Не вдалося скопіювати циклічне символьне посилання\n"
+"«%s»"
 
 msgid "View file"
 msgstr "Перегляд файлу"
@@ -2353,6 +2387,12 @@ msgstr "Створити новий каталог"
 
 msgid "Enter directory name:"
 msgstr "Введіть назву каталогу:"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Не вдалося створити каталог %s"
 
 msgid "Extension file edit"
 msgstr "Редагування файла розширень"
@@ -2402,12 +2442,16 @@ msgstr "Символьне посилання «%s» вказує на:"
 msgid "Edit symlink"
 msgstr "Редагувати символьне посилання"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "редагування символьного посилання, не вдалося видалити %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "редагування символьного посилання: %s"
 
 msgid "FTP to machine"
@@ -2449,10 +2493,8 @@ msgstr "Не можна виконувати команди на нелокал�
 msgid "Parameter"
 msgstr "Параметр"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "Не вдалося створити тимчасовий командний файл\n"
 "%s"
@@ -2460,10 +2502,10 @@ msgstr ""
 msgid "Pipe failed"
 msgstr "Сталася помилка каналу"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 "У вас застарів файл %s.\n"
@@ -2476,7 +2518,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2531,29 +2573,23 @@ msgstr "файли/каталоги"
 msgid " with source mask:"
 msgstr " із шаблоном джерела:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 "Не вдалося отримати властивості вихідного файлу жорсткого посилання \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"Не вдалося створити цільове жорстке посилання \"%s\"\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "Не вдалося створити цільове жорстке посилання \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "Не вдалося прочитати джерельне посилання «%s»\n"
@@ -2569,9 +2605,9 @@ msgstr ""
 "\n"
 "Параметр «Стійкі символьні посилання» буде вимкнено"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "Не вдалося створити цільове символьне посилання «%s»\n"
@@ -2601,21 +2637,31 @@ msgstr ""
 "«%s»\n"
 "є одним і тим же файлом "
 
+msgid "&Ignore"
+msgstr "&Ігнорувати"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "По&вторити"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Каталог \"%s\" не порожній.\n"
 "Видалити його рекурсивно?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "Фоновий процес:\n"
@@ -2625,17 +2671,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "Ж&oдного"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "Не вдалося видалити файл «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "Не вдалося отримати властивості файлу «%s»\n"
@@ -2645,100 +2691,106 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "Не вдалося перезаписати каталог «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Не вдалося перенести файл «%s» у «%s»\n"
-"%s "
+"Не вдалося видалити файл «%s»\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "Не вдалося видалити каталог «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Не вдалося перезаписати каталог «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"Не вдалося перезаписати каталог «%s»\n"
-"%s"
+msgstr "Не вдалося перезаписати каталог «%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr "Не вдалося перезаписати файл «%s» %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"Не вдалося перенести каталог «%s» у «%s»\n"
+"Не вдалося видалити каталог «%s»\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "Не можна виконувати операції з «..»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "Не вдалося отримати властивості вихідного файлу «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Не вдалося отримати властивості вихідного файлу жорсткого посилання \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Не вдалося отримати властивості цільового файлу «%s»\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "Не вдалося створити спеціальний файл «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "Не вдалося змінити власника цільового файлу «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "Не вдалося змінити права доступу до цільового файлу «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "Не вдалося відкрити вихідний файл «%s»\n"
@@ -2747,49 +2799,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "Сталася помилка дозавантаження файлу, файл буде перезаписано "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "Не вдалося отримати властивості вихідного файлу «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "Не вдалося створити цільовий файл «%s»\n"
 "%s "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "Не вдалося отримати властивості цільового файлу «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "Не вдалося зарезервувати місце для цільового файлу «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "Не вдалося прочитати вихідний файл \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "Не вдалося записати цільовий файл «%s»\n"
@@ -2807,41 +2859,45 @@ msgstr "За&лишити"
 msgid "&Continue copy"
 msgstr "&Продовжити копіювання"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "Не вдалося закрити вихідний файл «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "Не вдалося закрити цільовий файл «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"Не вдалося зарезервувати місце для цільового файлу «%s»\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "Не вдавдалосяться отримати властивості вихідного каталогу «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"Не вдавдалосяться отримати властивості вихідного каталогу «%s»\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2859,25 +2915,27 @@ msgstr ""
 "Не вдалося скопіювати циклічне символьне посилання\n"
 "«%s»"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "Призначення «%s» повинно бути каталогом\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "Не вдалося створити цільовий каталог «%s»\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "Не вдалося змінити власника цільового каталогу «%s»\n"
@@ -3207,11 +3265,9 @@ msgstr[1] "Відкрито %zu екрани. Все одно вийти?"
 msgstr[2] "Відкрито %zu екранів. Все одно вийти?"
 msgstr[3] "Відкрито %zu екранів. Все одно вийти?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "Справді вийти з Midnight Commander?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "Справді виконати?"
 
 msgid "&Above"
 msgstr "Верхня"
@@ -3717,11 +3773,10 @@ msgstr ""
 "Зовнішнє панелізування:\n"
 "%s"
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 "Зовнішнє панелізування:\n"
 "не вдалося прочитати дані з підбуфера виводу:\n"
@@ -3764,6 +3819,15 @@ msgid ""
 "%s"
 msgstr ""
 "Не вдалося отримати властивості призначення\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"Призначення «%s» повинно бути каталогом\n"
 "%s"
 
 #, c-format
@@ -3885,8 +3949,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "Шлях до домашнього каталогу не абсолютний"
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4598,8 +4663,9 @@ msgstr "Файл змінено. Зберегти?"
 msgid "&Cancel quit"
 msgstr "&Не виходити"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Виконується вихід із Midnight Commander.\n"
@@ -4650,10 +4716,8 @@ msgstr "ButtonBar|НеФормат."
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|Формат."
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "Помилка читання даних зі stdout підпроцеса:\n"
 "%s"
@@ -4679,20 +4743,18 @@ msgstr ""
 msgid "View: "
 msgstr "Перегляд:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"Не вдалося відкрити «%s»\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "Не вдалося показати: не звичайний файл"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "Не вдалось відкрити \"%s\" в режимі парсингу\n"
@@ -4706,6 +4768,78 @@ msgstr "Почати спочатку?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Не вдалося отримати локальну копію /ftp://some.host/editme.txt"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "Справді вийти з Midnight Commander?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "Не вдалося відкрити %s для читання"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "Не вдалося отримати розмір/права доступу для %s"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "Не вдалося відкрити канал для запису: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "Сталася помилка під час збереження: цільовий об’єкт не є файлом"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не вдалося відкрити файл %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "Ігнорувати &все"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "посилання: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "символьне посилання: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не вдалося створити цільове жорстке посилання \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не вдалося перенести файл «%s» у «%s»\n"
+#~ "%s "
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не вдалося перезаписати каталог «%s»\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Не вдалося перенести каталог «%s» у «%s»\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "Інше 8-розрядне"

--- a/po/uz.po
+++ b/po/uz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Uzbek (http://app.transifex.com/mc/mc/language/uz/)\n"
@@ -46,6 +46,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -725,7 +728,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -791,23 +794,16 @@ msgstr ""
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
 #, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+msgid "Cannot create temporary merge file"
 msgstr ""
 
 msgid "&Fastest (Assume large files)"
@@ -876,15 +872,16 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr ""
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
+msgstr ""
+
+msgid "Quit"
 msgstr ""
 
 msgid "Diff:"
@@ -894,12 +891,14 @@ msgid "File name is empty!"
 msgstr ""
 
 #, c-format
-msgid "\"%s\" is a directory"
+msgid ""
+"%s\n"
+"is a directory"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -917,7 +916,9 @@ msgid "Loading..."
 msgstr ""
 
 #, c-format
-msgid "Cannot open %s for reading"
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
 
 msgid "Load file"
@@ -928,11 +929,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -949,7 +948,9 @@ msgid "Error reading from pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for reading: %s"
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
 
 msgid "File has hard-links. Detach before saving?"
@@ -963,11 +964,10 @@ msgid "Error writing to pipe: %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
 
 msgid "The file you are saving does not end with a newline."
@@ -1012,7 +1012,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1072,7 +1076,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1508,12 +1512,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1642,13 +1644,13 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
 #, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1674,7 +1676,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1707,22 +1710,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1736,6 +1742,18 @@ msgid "Running"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid "No translation"
+msgstr ""
+
+msgid "Detected display codepage"
+msgstr ""
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
 msgstr ""
 
 msgid "&Never"
@@ -1814,15 +1832,6 @@ msgid "A&uto save setup"
 msgstr ""
 
 msgid "Configure options"
-msgstr ""
-
-msgid "No translation"
-msgstr ""
-
-msgid "Detected display codepage"
-msgstr ""
-
-msgid "Selected source (file I/O) codepage"
 msgstr ""
 
 msgid "Skin:"
@@ -2019,7 +2028,6 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
 
@@ -2112,13 +2120,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
+"Cannot chattr\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot chattr\n"
 "%s"
 msgstr ""
 
@@ -2223,11 +2237,15 @@ msgid "Link"
 msgstr ""
 
 #, c-format
-msgid "link: %s"
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2249,6 +2267,12 @@ msgid "Create a new Directory"
 msgstr ""
 
 msgid "Enter directory name:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
 msgstr ""
 
 msgid "Extension file edit"
@@ -2298,11 +2322,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2342,10 +2370,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2354,7 +2379,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2364,7 +2389,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2421,23 +2446,19 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
 #, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 
@@ -2449,7 +2470,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 
@@ -2469,19 +2490,29 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
+msgstr ""
+
+msgid "&Retry"
 msgstr ""
 
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
@@ -2490,13 +2521,13 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 
@@ -2506,37 +2537,41 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
@@ -2545,43 +2580,43 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 
@@ -2590,37 +2625,37 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 
@@ -2638,31 +2673,31 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2680,19 +2715,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3016,10 +3053,7 @@ msgid "You have %zu opened screen. Quit anyway?"
 msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3510,11 +3544,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3550,6 +3582,13 @@ msgstr ""
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3652,8 +3691,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4303,8 +4343,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4353,10 +4394,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4377,16 +4415,16 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Slava Zanko <slavazanko@gmail.com>, 2011\n"
 "Language-Team: Vietnamese (http://app.transifex.com/mc/mc/language/vi/)\n"
@@ -47,6 +47,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -728,7 +731,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -794,24 +797,22 @@ msgstr "Tìm"
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
 msgid "&Fastest (Assume large files)"
 msgstr ""
@@ -879,16 +880,17 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr "Thoát"
 
-msgid "Quit"
-msgstr "Thoát"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
+
+msgid "Quit"
+msgstr "Thoát"
 
 msgid "Diff:"
 msgstr ""
@@ -896,15 +898,17 @@ msgstr ""
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"%s\n"
+"is a directory"
+msgstr "In ra tên thư mục dữ liệu"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat\n"
 "%s"
-msgstr ""
+msgstr "Không thể phân tích:"
 
 msgid "Diff viewer: invalid mode"
 msgstr ""
@@ -919,9 +923,13 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#, c-format
-msgid "Cannot open %s for reading"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
+"Không mở được tập tin nén tar\n"
+"%s"
 
 msgid "Load file"
 msgstr ""
@@ -931,11 +939,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -951,9 +957,13 @@ msgstr "Cảnh báo"
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
+"Không mở được tập tin %s để ghi nhớ:\n"
+"%s\n"
 
 msgid "File has hard-links. Detach before saving?"
 msgstr ""
@@ -965,13 +975,14 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
-msgstr ""
+"Không mở được tập tin %s để ghi nhớ:\n"
+"%s\n"
 
 msgid "The file you are saving does not end with a newline."
 msgstr ""
@@ -1015,7 +1026,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1075,7 +1090,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1511,12 +1526,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1645,13 +1658,15 @@ msgstr "< Tự động >"
 msgid "< Reload Current Syntax >"
 msgstr "< Nạp lại cú pháp hiện thời >"
 
-msgid "Load syntax file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+"Không mở được tập tin nén tar\n"
+"%s"
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1677,7 +1692,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1710,22 +1726,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
-msgstr "&Thử lại"
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1740,6 +1759,20 @@ msgstr ""
 
 msgid "Stopped"
 msgstr "Đã dừng"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < Không có dịch >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Bảng mã đầu vào / hiển thị:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Không bao giờ"
@@ -1818,17 +1851,6 @@ msgstr ""
 
 msgid "Configure options"
 msgstr "Tùy chọn cấu hình"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < Không có dịch >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Bảng mã đầu vào / hiển thị:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr ""
@@ -2021,12 +2043,11 @@ msgstr "&Diệt"
 msgid "Background jobs"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
-msgstr ""
+msgstr "Không đọc được nội dung thư mục"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2115,17 +2136,25 @@ msgstr "&Xóa đánh dấu"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
-msgstr ""
+"Cannot chattr\n"
+"%sn%s"
+msgstr "Không thể phân tích:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"Không mở được tập tin nén tar\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "Không thể phân tích:"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2227,12 +2256,18 @@ msgstr "Tạo liên kết tới %s:"
 msgid "Link"
 msgstr ""
 
-#, c-format
-msgid "link: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2255,6 +2290,12 @@ msgstr "Tạo thư mục mới"
 
 msgid "Enter directory name:"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Không đọc được nội dung thư mục"
 
 msgid "Extension file edit"
 msgstr "Soạn thảo phần mở rộng tập tin"
@@ -2303,11 +2344,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2347,11 +2392,9 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
-msgstr ""
+#, fuzzy
+msgid "Cannot create temporary command file"
+msgstr "Không đọc được nội dung thư mục"
 
 msgid "Pipe failed"
 msgstr ""
@@ -2359,7 +2402,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2369,7 +2412,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2424,27 +2467,27 @@ msgstr "tập tin/thư mục"
 msgid " with source mask:"
 msgstr " với nhãn ban đầu:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot read source link \"%s\"\n"
+"Không mở được tập tin nén tar\n"
 "%s"
-msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot read source link\n"
+"%s"
+msgstr "Không đọc được nội dung thư mục"
 
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
@@ -2452,11 +2495,13 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
 #, c-format
 msgid ""
@@ -2474,160 +2519,208 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
 msgstr ""
 
+msgid "&Retry"
+msgstr "&Thử lại"
+
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 msgid "Non&e"
 msgstr "&Không"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
-msgstr ""
+msgstr "Không đọc được nội dung thư mục"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "Không đọc được nội dung thư mục"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
+msgstr "Không đọc được nội dung thư mục"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
-msgstr ""
+msgstr "Không đọc được nội dung thư mục"
 
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
+"Không mở được tập tin nén tar\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
+"Không mở được tập tin nén tar\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
+"Không mở được tập tin nén cpio\n"
+"%s"
 
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
 
 msgid "(stalled)"
 msgstr "(bị nhốt)"
@@ -2641,33 +2734,39 @@ msgstr "&Giữ"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
+"Không mở được tập tin nén cpio\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot close target file\n"
+"%s"
+msgstr ""
+"Không mở được tập tin nén tar\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot set ext2 attributes for target file\n"
+"%s"
+msgstr ""
+"Không ghi nhớ được vào tập tin %s:\n"
+"%s\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat source directory\n"
+"%s"
+msgstr "Không đọc được nội dung thư mục"
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot stat source directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2685,21 +2784,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
-msgstr ""
+msgstr "Không đọc được nội dung thư mục"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
+"Không mở được tập tin nén tar\n"
+"%s"
 
 #, c-format
 msgid "Directories: %zu, total size: %s"
@@ -3021,10 +3124,7 @@ msgid "You have %zu opened screen. Quit anyway?"
 msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3516,11 +3616,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3558,6 +3656,13 @@ msgstr " Di chuyển thư mục \"%s\" vào:"
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3674,8 +3779,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4345,8 +4451,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr "&Dừng thoát"
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4395,10 +4502,7 @@ msgstr "Bỏ định dạng"
 msgid "ButtonBar|Format"
 msgstr "Định dạng"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4419,18 +4523,20 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
-msgid "Cannot view: not a regular file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
+"Không mở được tập tin nén tar\n"
+"%s"
 
 msgid "Search done"
 msgstr ""

--- a/po/wa.po
+++ b/po/wa.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Slava Zanko <slavazanko@gmail.com>, 2011\n"
 "Language-Team: Walloon (http://app.transifex.com/mc/mc/language/wa/)\n"
@@ -47,6 +47,9 @@ msgstr ""
 
 #, c-format
 msgid "Unable to create event '%s'!"
+msgstr ""
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
 msgstr ""
 
 #, c-format
@@ -726,7 +729,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -792,24 +795,22 @@ msgstr "Cweri"
 msgid "Search is disabled"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+msgid "Cannot create temporary diff file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
 msgid "&Fastest (Assume large files)"
 msgstr ""
@@ -877,16 +878,17 @@ msgstr ""
 msgid "ButtonBar|Quit"
 msgstr ""
 
-msgid "Quit"
-msgstr "Cwiter"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
+
+msgid "Quit"
+msgstr "Cwiter"
 
 msgid "Diff:"
 msgstr ""
@@ -894,13 +896,15 @@ msgstr ""
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
+msgstr "ridant"
 
 #, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 
@@ -917,9 +921,13 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#, c-format
-msgid "Cannot open %s for reading"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
 msgstr ""
+"Dji n' sai drovî li fitchî cpio\n"
+"%s"
 
 msgid "Load file"
 msgstr ""
@@ -929,11 +937,9 @@ msgid "Error reading %s"
 msgstr ""
 
 #, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr ""
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr ""
 
 #, c-format
@@ -949,9 +955,13 @@ msgstr "Advertixhmint"
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr ""
+"Dji n' sai drovî li fitchî %s po scrire divins:\n"
+"%s\n"
 
 msgid "File has hard-links. Detach before saving?"
 msgstr ""
@@ -963,13 +973,14 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
-msgstr ""
+"Dji n' sai drovî li fitchî %s po scrire divins:\n"
+"%s\n"
 
 msgid "The file you are saving does not end with a newline."
 msgstr ""
@@ -1013,7 +1024,11 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
+#, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
 msgstr ""
 
 msgid "A file already exists with this name"
@@ -1073,7 +1088,7 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 
@@ -1509,12 +1524,10 @@ msgstr ""
 msgid "%ld replacements made"
 msgstr ""
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1643,13 +1656,15 @@ msgstr ""
 msgid "< Reload Current Syntax >"
 msgstr ""
 
-msgid "Load syntax file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr ""
+"Dji n' sai drovî li fitchî cpio\n"
+"%s"
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1675,7 +1690,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1708,22 +1724,25 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
-"%s"
+"Cannot chmod\n"
+"%sn%s"
 msgstr ""
-
-msgid "&Ignore"
-msgstr ""
-
-msgid "Ignore &all"
-msgstr ""
-
-msgid "&Retry"
-msgstr "&Rissayî"
 
 #, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chmod\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot chown\n"
 "%s"
 msgstr ""
 
@@ -1738,6 +1757,19 @@ msgstr ""
 
 msgid "Stopped"
 msgstr "Djoké"
+
+msgid "No translation"
+msgstr ""
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "Ecôdaedje po ls intrêyes/rexhowes:"
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "&Måy"
@@ -1816,16 +1848,6 @@ msgstr ""
 
 msgid "Configure options"
 msgstr "Apontyî les tchûzes"
-
-msgid "No translation"
-msgstr ""
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "Ecôdaedje po ls intrêyes/rexhowes:"
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr ""
@@ -2018,12 +2040,11 @@ msgstr "&Touwer"
 msgid "Background jobs"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
-msgstr ""
+msgstr "Advertixhmint: dji n' sai candjî dins %s.\n"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2114,15 +2135,23 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
 
 #, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr ""
+"Dji n' sai drovî li fitchî cpio\n"
+"%s"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2224,12 +2253,18 @@ msgstr ""
 msgid "Link"
 msgstr ""
 
-#, c-format
-msgid "link: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
 #, c-format
-msgid "symlink: %s"
+msgid ""
+"Canot create symbolic link\n"
+"%s"
 msgstr ""
 
 msgid "View file"
@@ -2252,6 +2287,12 @@ msgstr "Fé on novea Ridant"
 
 msgid "Enter directory name:"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "Fé on novea Ridant"
 
 msgid "Extension file edit"
 msgstr "Aspougnî les cawetes di fitchîs"
@@ -2300,11 +2341,15 @@ msgid "Edit symlink"
 msgstr ""
 
 #, c-format
-msgid "edit symlink, unable to remove %s: %s"
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr ""
 
 #, c-format
-msgid "edit symlink: %s"
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr ""
 
 msgid "FTP to machine"
@@ -2344,10 +2389,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+msgid "Cannot create temporary command file"
 msgstr ""
 
 msgid "Pipe failed"
@@ -2356,7 +2398,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2366,7 +2408,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2421,27 +2463,27 @@ msgstr "fitchîs/ridants"
 msgid " with source mask:"
 msgstr " avou li masse soûrdant:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
 #, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
 
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
+"Dji n' sai drovî li fitchî cpio\n"
+"%s"
 
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
@@ -2449,11 +2491,13 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
 #, c-format
 msgid ""
@@ -2471,160 +2515,212 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr ""
+
 msgid "Ignore a&ll"
 msgstr ""
 
+msgid "&Retry"
+msgstr "&Rissayî"
+
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 msgid "Non&e"
 msgstr "&Nouk"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot remove directory\n"
+"%s"
+msgstr ""
+"Dji n' sai drovî li fitchî cpio\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot enter into directory\n"
+"%s"
+msgstr ""
+"Dji n' sai drovî li fitchî cpio\n"
+"%s"
 
 #, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
 #, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot overwrite file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
 
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
+"Dji n' sai drovî li fitchî cpio\n"
+"%s"
 
 msgid "Reget failed, about to overwrite file"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
 
 msgid "(stalled)"
 msgstr "(a djok)"
@@ -2638,33 +2734,39 @@ msgstr "&Wårder"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
+"Dji n' sai drovî li fitchî cpio\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot close target file\n"
+"%s"
+msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot set ext2 attributes for target file\n"
+"%s"
+msgstr ""
+"Dji n' sai scrire e fitchî %s :\n"
+"%s\n"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot stat source directory\n"
+"%s"
+msgstr "Fé on novea Ridant"
 
 #, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot stat source directory \"%s\"\n"
-"%s"
-msgstr ""
-
-#, c-format
-msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
 
@@ -2682,19 +2784,21 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
-msgstr ""
+msgstr "Fé on novea Ridant"
 
 #, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 
@@ -3019,10 +3123,7 @@ msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
+msgid "Do you really want to quit?"
 msgstr ""
 
 msgid "&Above"
@@ -3516,11 +3617,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3558,6 +3657,13 @@ msgstr "Bodjî li ridant «%s» dins:"
 msgid ""
 "Cannot stat the destination\n"
 "%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
 msgstr ""
 
 #, c-format
@@ -3675,8 +3781,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4331,8 +4438,9 @@ msgstr ""
 msgid "&Cancel quit"
 msgstr ""
 
+#, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 
@@ -4381,10 +4489,7 @@ msgstr ""
 msgid "ButtonBar|Format"
 msgstr ""
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4405,18 +4510,20 @@ msgstr ""
 
 #, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr ""
 
-msgid "Cannot view: not a regular file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
+"Dji n' sai drovî li fitchî cpio\n"
+"%s"
 
 msgid "Search done"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Yury V. Zaytsev <yury@shurup.com>, 2025\n"
 "Language-Team: Chinese (China) (http://app.transifex.com/mc/mc/language/"
@@ -60,6 +60,9 @@ msgstr "无法创建事件组“%s”!"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "无法创建事件“%s”!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -765,10 +768,10 @@ msgstr "文件1 文件2"
 msgid "[this_dir] [other_panel_dir]"
 msgstr "[this_dir] [other_panel_dir]"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 "\n"
@@ -839,28 +842,23 @@ msgstr "搜索"
 msgid "Search is disabled"
 msgstr "禁止搜索"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary diff file"
 msgstr ""
 "无法创建临时 diff 文件 \n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "无法创建备份文件\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
 "无法创建临时合并文件\n"
 "%s"
@@ -931,18 +929,19 @@ msgstr "ButtonBar|选项"
 msgid "ButtonBar|Quit"
 msgstr "ButtonBar|退出"
 
-msgid "Quit"
-msgstr "退出"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr "文件已被修改，保存并退出?"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "Midnight Commander 即将被关闭。\n"
 "要保存修改过的文件吗?"
+
+msgid "Quit"
+msgstr "退出"
 
 msgid "Diff:"
 msgstr "差异: "
@@ -950,13 +949,15 @@ msgstr "差异: "
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "“%s”是一个目录"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "无法查看“%s”的状态\n"
@@ -975,9 +976,13 @@ msgstr "正在载入: %3d%%"
 msgid "Loading..."
 msgstr "正在载入..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "无法打开 %s 读取内容"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"无法打开“%s”\n"
+"%s"
 
 msgid "Load file"
 msgstr "加载文件"
@@ -986,12 +991,10 @@ msgstr "加载文件"
 msgid "Error reading %s"
 msgstr "读取错误 %s"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "无法获取文件 %s 的大小和权限信息"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "“%s”不是一个常规文件"
 
 #, c-format
@@ -1009,8 +1012,10 @@ msgstr "警告"
 msgid "Error reading from pipe: %s"
 msgstr "读取管道时发生错误: %s"
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
 msgstr "无法打开管道读取: %s"
 
 msgid "File has hard-links. Detach before saving?"
@@ -1023,12 +1028,11 @@ msgstr "文件同时已经被修改。仍然保存吗?"
 msgid "Error writing to pipe: %s"
 msgstr "写入管道时发生错误: %s"
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr "试图打开管道写入时失败: %s"
-
-#, c-format
-msgid "Cannot open file for writing: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
 msgstr "无法打开文件进行写操作: %s"
 
 msgid "The file you are saving does not end with a newline."
@@ -1073,8 +1077,12 @@ msgstr "检查 &POSIX 换行"
 msgid "Edit Save Mode"
 msgstr "编辑保存模式"
 
-msgid "Cannot save: destination is not a regular file"
-msgstr "无法保存: 目标位置不是常规文件"
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "无法查看: 不是常规文件"
 
 msgid "A file already exists with this name"
 msgstr "同名文件已存在"
@@ -1133,9 +1141,9 @@ msgstr ""
 msgid "Close file"
 msgstr "关闭文件"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "Midnight Commander 即将被关闭。\n"
@@ -1576,15 +1584,13 @@ msgstr "确认替换"
 msgid "%ld replacements made"
 msgstr "替换了 %ld 处"
 
+#, fuzzy, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
+"written for the %s."
 msgstr ""
 "为 Midnight Commander 编写的\n"
 "一个界面友好的文本编辑器。"
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
-msgstr ""
 
 msgid "About"
 msgstr "关于"
@@ -1712,16 +1718,14 @@ msgstr "<自动>"
 msgid "< Reload Current Syntax >"
 msgstr "<重新加载当前语法>"
 
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s"
+msgstr "无法打开文件 %s"
+
 msgid "Load syntax file"
 msgstr "加载语法文件"
-
-#, c-format
-msgid ""
-"Cannot open file %s\n"
-"%s"
-msgstr ""
-"无法打开文件 %s\n"
-"%s"
 
 #, c-format
 msgid "Error in file %s on line %d"
@@ -1751,7 +1755,8 @@ msgstr ""
 "不是一个 xterm 或 Linux 控制台；\n"
 "无法切换subshell窗口。"
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, fuzzy, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr "输入 'exit' 返回 Midnight Commander"
 
 msgid "Set &all"
@@ -1782,26 +1787,33 @@ msgstr ""
 msgid "Chown advanced command"
 msgstr "Chown 高级命令"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"无法 chmod“%s”\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"无法 chown“%s”\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "无法 chmod“%s”\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "忽略(&I)"
-
-msgid "Ignore &all"
-msgstr "全部忽略(&A)"
-
-msgid "&Retry"
-msgstr "重试(&R)"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "无法 chown“%s”\n"
@@ -1818,6 +1830,20 @@ msgstr "正在运行"
 
 msgid "Stopped"
 msgstr "已停止"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < 没有翻译 >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "输入/显示代码页: "
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "从不(&N)"
@@ -1896,17 +1922,6 @@ msgstr "自动保存设置(&U)"
 
 msgid "Configure options"
 msgstr "配置选项"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < 没有翻译 >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "输入/显示代码页: "
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "皮肤:"
@@ -2102,12 +2117,13 @@ msgstr "杀死(&K)"
 msgid "Background jobs"
 msgstr "后台任务"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"无法 chown 目标目录“%s”\n"
+"%s"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2196,17 +2212,27 @@ msgstr "清除已标记的(&L)"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
+"无法查看“%s”的状态\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"无法打开 tar 档案文件\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "无法解析: "
 
 msgid "set &user ID on execution"
 msgstr "执行时设置用户 ID(&U)"
@@ -2308,13 +2334,21 @@ msgstr "链接 %s 到: "
 msgid "Link"
 msgstr "链接"
 
-#, c-format
-msgid "link: %s"
-msgstr "链接: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"无法创建目标符号链接“%s”\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "符号链接: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"无法复制循环的符号链接\n"
+"“%s”"
 
 msgid "View file"
 msgstr "查看文件"
@@ -2336,6 +2370,12 @@ msgstr "创建新目录"
 
 msgid "Enter directory name:"
 msgstr "输入目录名称: "
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "无法建立目录%s"
 
 msgid "Extension file edit"
 msgstr "扩展文件编辑"
@@ -2385,12 +2425,16 @@ msgstr "符号链接“%s”指向: "
 msgid "Edit symlink"
 msgstr "编辑符号链接"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "编辑符号链接，无法删除 %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "编辑符号链接: %s"
 
 msgid "FTP to machine"
@@ -2432,10 +2476,8 @@ msgstr "您无法在非本地文件系统上执行命令"
 msgid "Parameter"
 msgstr "参数"
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary command file"
 msgstr ""
 "无法创建临时命令文件\n"
 "%s"
@@ -2446,7 +2488,7 @@ msgstr "管道失败"
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2456,7 +2498,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2511,27 +2553,23 @@ msgstr "文件/目录"
 msgid " with source mask:"
 msgstr " 源掩码: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"无法 stat 源文件“%s”\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
-msgstr ""
-"无法创建目标硬链接 “%s”\n"
-"%s"
-
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
 msgstr "无法创建目标硬链接 “%s”"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
 "无法读取源链接“%s”\n"
@@ -2546,9 +2584,9 @@ msgstr ""
 "\n"
 "稳定符号链接选项将被禁用"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "无法创建目标符号链接“%s”\n"
@@ -2578,21 +2616,31 @@ msgstr ""
 "“%s”\n"
 "是同一个文件"
 
+msgid "&Ignore"
+msgstr "忽略(&I)"
+
 msgid "Ignore a&ll"
 msgstr ""
 
-#, c-format
+msgid "&Retry"
+msgstr "重试(&R)"
+
+#, fuzzy, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "目录“%s”不为空。\n"
 "递归删除其中内容?"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 "后台进程: \n"
@@ -2602,17 +2650,17 @@ msgstr ""
 msgid "Non&e"
 msgstr "无(&E)"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
 "无法删除文件“%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
 "无法 stat 文件“%s”\n"
@@ -2622,102 +2670,108 @@ msgstr ""
 msgid "Cannot overwrite directory \"%s\""
 msgstr "无法覆盖目录“%s”"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"无法移动文件“%s”到“%s”\n"
+"无法删除文件“%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "无法删除目录“%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "无法覆盖目录“%s”"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"无法覆盖目录“%s”\n"
-"%s"
+msgstr "无法覆盖目录“%s”"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "无法覆盖文件“%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"无法移动目录“%s”到“%s”\n"
+"无法删除目录“%s”\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr "无法操作\"..\"!"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
 "无法 stat 源文件“%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"无法 stat 源文件“%s”\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"无法 fstat 目标文件\"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
 "无法创建特殊文件“%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "无法 chown 目标文件“%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
 "无法 chmod 目标文件“%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot open source file\n"
 "%s"
 msgstr ""
 "无法打开源文件“%s”\n"
@@ -2726,49 +2780,49 @@ msgstr ""
 msgid "Reget failed, about to overwrite file"
 msgstr "重取失败，准备覆盖文件"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
 "无法 fstat 源文件“%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
 "无法创建目标文件“%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
 "无法 fstat 目标文件\"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
 "无法预分配空间给目标文件 “%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
 "无法读取源文件 “%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
 "无法写入目标文件“%s”\n"
@@ -2786,41 +2840,45 @@ msgstr "保留(&K)"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
 "无法关闭源文件“%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
 "无法关闭目标文件“%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"无法预分配空间给目标文件 “%s”\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
 msgstr ""
 "无法 stat 源目录“%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"无法 stat 源目录“%s”\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2838,25 +2896,27 @@ msgstr ""
 "无法复制循环的符号链接\n"
 "“%s”"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "目标“%s”必需是一个目录\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "无法创建目标目录“%s”\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
 "无法 chown 目标目录“%s”\n"
@@ -3183,11 +3243,9 @@ msgid "You have %zu opened screen. Quit anyway?"
 msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] "您打开了 %zu 个屏幕。确定要退出吗?"
 
-msgid "The Midnight Commander"
-msgstr "Midnight Commander"
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr "您真的要退出 Midnight Commander吗?"
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "您真的要执行吗?"
 
 msgid "&Above"
 msgstr "上(&A)"
@@ -3681,12 +3739,13 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
+#, fuzzy
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
+"无法从子进程的 stdout 读取数据:\n"
+"%s"
 
 msgid "Cannot run external panelize in a non-local directory"
 msgstr "在非本地目录无法执行外部面板"
@@ -3725,6 +3784,15 @@ msgid ""
 "%s"
 msgstr ""
 "无法查看目标信息 \n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"目标“%s”必需是一个目录\n"
 "%s"
 
 #, c-format
@@ -3846,8 +3914,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr "主目录路径不是绝对路径"
 
+#, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4530,8 +4599,9 @@ msgstr "文件已被修改。保存并退出?"
 msgid "&Cancel quit"
 msgstr "取消退出(&C)"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "Midnight Commander 即将被关闭。\n"
@@ -4582,10 +4652,8 @@ msgstr "ButtonBar|未格式化"
 msgid "ButtonBar|Format"
 msgstr "ButtonBar|格式化"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+#, fuzzy
+msgid "Failed to read data from child stdout"
 msgstr ""
 "无法从子进程的 stdout 读取数据:\n"
 "%s"
@@ -4611,20 +4679,18 @@ msgstr ""
 msgid "View: "
 msgstr "查看: "
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"无法打开“%s”\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "无法查看: 不是常规文件"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "无法打开“%s”，当前解析模式\n"
@@ -4638,6 +4704,78 @@ msgstr "从头继续搜索?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "无法获取 /ftp://some.host/editme.txt 的本地副本"
+
+#~ msgid "The Midnight Commander"
+#~ msgstr "Midnight Commander"
+
+#~ msgid "Do you really want to quit the Midnight Commander?"
+#~ msgstr "您真的要退出 Midnight Commander吗?"
+
+#, c-format
+#~ msgid "Cannot open %s for reading"
+#~ msgstr "无法打开 %s 读取内容"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "无法获取文件 %s 的大小和权限信息"
+
+#, c-format
+#~ msgid "Cannot open pipe for writing: %s"
+#~ msgstr "试图打开管道写入时失败: %s"
+
+#~ msgid "Cannot save: destination is not a regular file"
+#~ msgstr "无法保存: 目标位置不是常规文件"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot open file %s\n"
+#~ "%s"
+#~ msgstr ""
+#~ "无法打开文件 %s\n"
+#~ "%s"
+
+#~ msgid "Ignore &all"
+#~ msgstr "全部忽略(&A)"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "链接: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "符号链接: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot create target hardlink \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "无法创建目标硬链接 “%s”\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move file \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "无法移动文件“%s”到“%s”\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "无法覆盖目录“%s”\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "无法移动目录“%s”到“%s”\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "其它 8 位"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Midnight Commander\n"
 "Report-Msgid-Bugs-To: https://github.com/MidnightCommander/mc/issues\n"
-"POT-Creation-Date: 2025-05-09 12:01+0200\n"
+"POT-Creation-Date: 2025-05-25 12:21+0200\n"
 "PO-Revision-Date: 2010-12-29 10:19+0000\n"
 "Last-Translator: Meng Pang Wang, 2023\n"
 "Language-Team: Chinese (Taiwan) (http://app.transifex.com/mc/mc/language/"
@@ -51,6 +51,9 @@ msgstr "無法建立群組 '%s' !"
 #, c-format
 msgid "Unable to create event '%s'!"
 msgstr "無法建立事件 '%s'!"
+
+msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -746,7 +749,7 @@ msgstr ""
 #, c-format
 msgid ""
 "\n"
-"Please send any bug reports (including the output of 'mc -V')\n"
+"Please send any bug reports (including the output of '%s -V')\n"
 "as tickets at %s\n"
 msgstr ""
 
@@ -812,27 +815,24 @@ msgstr "搜尋"
 msgid "Search is disabled"
 msgstr "禁止被搜尋"
 
-#, c-format
-msgid ""
-"Cannot create temporary diff file\n"
-"%s"
-msgstr ""
+#, fuzzy
+msgid "Cannot create temporary diff file"
+msgstr "無法建立目錄 %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot create backup file\n"
-"%s%s\n"
-"%s"
+"%s~~~"
 msgstr ""
 "無法建立備份檔案\n"
 "%s%s\n"
 "%s"
 
-#, c-format
-msgid ""
-"Cannot create temporary merge file\n"
-"%s"
+#, fuzzy
+msgid "Cannot create temporary merge file"
 msgstr ""
+"無法建立目標目錄 \"%s\"\n"
+"%s"
 
 msgid "&Fastest (Assume large files)"
 msgstr ""
@@ -900,18 +900,19 @@ msgstr "按鈕列 | 選項"
 msgid "ButtonBar|Quit"
 msgstr "按鈕列 | 結束"
 
-msgid "Quit"
-msgstr "結束"
-
 msgid "File(s) was modified. Save with exit?"
 msgstr ""
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file(s)?"
 msgstr ""
 "正在結束 Midnight Commander。\n"
 "是否儲存已修改的檔案？"
+
+msgid "Quit"
+msgstr "結束"
 
 msgid "Diff:"
 msgstr "不同:"
@@ -919,13 +920,15 @@ msgstr "不同:"
 msgid "File name is empty!"
 msgstr ""
 
-#, c-format
-msgid "\"%s\" is a directory"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is a directory"
 msgstr "\"%s\" 是一個資料夾"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat \"%s\"\n"
+"Cannot stat\n"
 "%s"
 msgstr ""
 "無法統計 \"%s\"\n"
@@ -944,9 +947,13 @@ msgstr "讀取中: %3d%%"
 msgid "Loading..."
 msgstr "讀取中..."
 
-#, c-format
-msgid "Cannot open %s for reading"
-msgstr "無法開啟 %s 進行讀取"
+#, fuzzy, c-format
+msgid ""
+"Cannot open\n"
+"%s"
+msgstr ""
+"無法開啟 \"%s\"\n"
+"%s"
 
 msgid "Load file"
 msgstr "讀取檔案"
@@ -955,12 +962,10 @@ msgstr "讀取檔案"
 msgid "Error reading %s"
 msgstr "讀取 %s 時發生錯誤"
 
-#, c-format
-msgid "Cannot get size/permissions for %s"
-msgstr "無法取得 %s 的檔案大小或存取權限"
-
-#, c-format
-msgid "\"%s\" is not a regular file"
+#, fuzzy, c-format
+msgid ""
+"%s\n"
+"is not a regular file"
 msgstr "\"%s\" 不是一個普通的檔案"
 
 #, c-format
@@ -976,9 +981,11 @@ msgstr "警告"
 msgid "Error reading from pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for reading: %s"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot open pipe for reading\n"
+"%s"
+msgstr "無法開啟 %s 進行讀取"
 
 msgid "File has hard-links. Detach before saving?"
 msgstr ""
@@ -990,13 +997,12 @@ msgstr ""
 msgid "Error writing to pipe: %s"
 msgstr ""
 
-#, c-format
-msgid "Cannot open pipe for writing: %s"
-msgstr ""
-
-#, c-format
-msgid "Cannot open file for writing: %s"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot open file\n"
+"%s\n"
+"for writing"
+msgstr "無法開啟 %s 進行讀取"
 
 msgid "The file you are saving does not end with a newline."
 msgstr ""
@@ -1040,8 +1046,12 @@ msgstr ""
 msgid "Edit Save Mode"
 msgstr ""
 
-msgid "Cannot save: destination is not a regular file"
-msgstr ""
+#, fuzzy, c-format
+msgid ""
+"Cannot save\n"
+"%s:\n"
+"not a regular file"
+msgstr "無法檢視: 不是一般的檔案"
 
 msgid "A file already exists with this name"
 msgstr "相同的檔案名稱已經存在"
@@ -1098,9 +1108,9 @@ msgstr ""
 msgid "Close file"
 msgstr "關閉檔案"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file %s?"
 msgstr ""
 "正在結束 Midnight Commander。\n"
@@ -1538,12 +1548,10 @@ msgstr "確認取代"
 msgid "%ld replacements made"
 msgstr "已取代 %ld 個項目。"
 
+#, c-format
 msgid ""
 "A user friendly text editor\n"
-"written for the Midnight Commander."
-msgstr ""
-
-msgid "Copyright (C) 1996-2025 the Free Software Foundation"
+"written for the %s."
 msgstr ""
 
 msgid "About"
@@ -1672,13 +1680,13 @@ msgstr "< 自動 >"
 msgid "< Reload Current Syntax >"
 msgstr "< 重新讀取當前語法 >"
 
-msgid "Load syntax file"
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open file %s\n"
+"Cannot open file\n"
 "%s"
+msgstr "無法開啟檔案 %s"
+
+msgid "Load syntax file"
 msgstr ""
 
 #, c-format
@@ -1704,7 +1712,8 @@ msgid ""
 "the subshell cannot be toggled."
 msgstr ""
 
-msgid "Type 'exit' to return to the Midnight Commander"
+#, c-format
+msgid "Type 'exit' to return to the %s"
 msgstr ""
 
 msgid "Set &all"
@@ -1735,26 +1744,33 @@ msgstr ""
 msgid "Chown advanced command"
 msgstr "Chown 進階指令"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod \"%s\"\n"
+"Cannot chmod\n"
+"%sn%s"
+msgstr ""
+"無法對 \"%s\" 執行 chmod 指令\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chown\n"
+"%sn%s"
+msgstr ""
+"無法 chown \"%s\"\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chmod\n"
 "%s"
 msgstr ""
 "無法對 \"%s\" 執行 chmod 指令\n"
 "%s"
 
-msgid "&Ignore"
-msgstr "忽略"
-
-msgid "Ignore &all"
-msgstr "忽略全部"
-
-msgid "&Retry"
-msgstr "重試"
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown \"%s\"\n"
+"Cannot chown\n"
 "%s"
 msgstr ""
 "無法 chown \"%s\"\n"
@@ -1771,6 +1787,20 @@ msgstr "執行中"
 
 msgid "Stopped"
 msgstr "停止了"
+
+#, fuzzy
+msgid "No translation"
+msgstr "-  < 不轉換 >"
+
+#, fuzzy
+msgid "Detected display codepage"
+msgstr "輸入/顯示 頁碼："
+
+msgid "Selected source (file I/O) codepage"
+msgstr ""
+
+msgid "Classic terminal file manager inspired by Norton Commander."
+msgstr ""
 
 msgid "&Never"
 msgstr "從不"
@@ -1849,17 +1879,6 @@ msgstr ""
 
 msgid "Configure options"
 msgstr "設定選項"
-
-#, fuzzy
-msgid "No translation"
-msgstr "-  < 不轉換 >"
-
-#, fuzzy
-msgid "Detected display codepage"
-msgstr "輸入/顯示 頁碼："
-
-msgid "Selected source (file I/O) codepage"
-msgstr ""
 
 msgid "Skin:"
 msgstr "面板："
@@ -2052,12 +2071,13 @@ msgstr "關閉"
 msgid "Background jobs"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Cannot change directory to\n"
-"%s\n"
 "%s"
 msgstr ""
+"無法建立目標目錄 \"%s\"\n"
+"%s"
 
 msgid "Secure deletion"
 msgstr ""
@@ -2146,17 +2166,27 @@ msgstr "清除標示區"
 msgid "Chattr command"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chattr \"%s\"\n"
-"%s"
+"Cannot chattr\n"
+"%sn%s"
 msgstr ""
+"無法統計 \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of \"%s\"\n"
+"Cannot get ext2 attributes of\n"
 "%s"
 msgstr ""
+"無法開啟 tar 檔案集\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot chattr\n"
+"%s"
+msgstr "無法分析:"
 
 msgid "set &user ID on execution"
 msgstr ""
@@ -2258,13 +2288,21 @@ msgstr "連結 %s 到:"
 msgid "Link"
 msgstr "連結"
 
-#, c-format
-msgid "link: %s"
-msgstr "連結: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot create link\n"
+"%s"
+msgstr ""
+"無法建立目標連結 \"%s\"\n"
+"%s"
 
-#, c-format
-msgid "symlink: %s"
-msgstr "軟連結: %s"
+#, fuzzy, c-format
+msgid ""
+"Canot create symbolic link\n"
+"%s"
+msgstr ""
+"無法建立目標連結 \"%s\"\n"
+"%s"
 
 msgid "View file"
 msgstr "檢視檔案"
@@ -2286,6 +2324,12 @@ msgstr "建立新目錄"
 
 msgid "Enter directory name:"
 msgstr "輸入目錄名稱："
+
+#, fuzzy, c-format
+msgid ""
+"Cannot create directory\n"
+"%s"
+msgstr "無法建立目錄 %s"
 
 msgid "Extension file edit"
 msgstr "擴充檔案編輯"
@@ -2333,12 +2377,16 @@ msgstr "軟連結 '%s' 指向:"
 msgid "Edit symlink"
 msgstr "編輯符號連結"
 
-#, c-format
-msgid "edit symlink, unable to remove %s: %s"
+#, fuzzy, c-format
+msgid ""
+"Edit symlink, unable to remove\n"
+"%s"
 msgstr "編輯符號連結, 無法移除 %s: %s"
 
-#, c-format
-msgid "edit symlink: %s"
+#, fuzzy, c-format
+msgid ""
+"Cannot edit symlink\n"
+"%s"
 msgstr "編輯符號連結: %s"
 
 msgid "FTP to machine"
@@ -2378,11 +2426,9 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#, c-format
-msgid ""
-"Cannot create temporary command file\n"
-"%s"
-msgstr ""
+#, fuzzy
+msgid "Cannot create temporary command file"
+msgstr "無法執行簡短的指令"
 
 msgid "Pipe failed"
 msgstr ""
@@ -2390,7 +2436,7 @@ msgstr ""
 #, c-format
 msgid ""
 "You have an outdated %s file.\n"
-"Midnight Commander now uses %s file.\n"
+"%s now uses %s file.\n"
 "Please copy your modifications of the old file to the new one."
 msgstr ""
 
@@ -2400,7 +2446,7 @@ msgid ""
 "%s%s\n"
 "file has changed with version 4.0.\n"
 "It seems that the installation has failed.\n"
-"Please fetch a fresh copy from the Midnight Commander package."
+"Please fetch a fresh copy from the %s package."
 msgstr ""
 
 #, c-format
@@ -2455,27 +2501,29 @@ msgstr "檔案/目錄"
 msgid " with source mask:"
 msgstr " 以來源遮罩："
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat hardlink source file \"%s\"\n"
+"Cannot stat hardlink source file\n"
 "%s"
 msgstr ""
+"無法儲存檔案:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target hardlink \"%s\"\n"
+"Cannot create target hardlink\n"
 "%s"
 msgstr ""
+"無法建立目標連結 \"%s\"\n"
+"%s"
 
-#, c-format
-msgid "Cannot create target hardlink \"%s\""
-msgstr ""
-
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source link \"%s\"\n"
+"Cannot read source link\n"
 "%s"
 msgstr ""
+"無法建立目標連結 \"%s\"\n"
+"%s"
 
 msgid ""
 "Cannot make stable symlinks across non-local filesystems:\n"
@@ -2483,9 +2531,9 @@ msgid ""
 "Option Stable Symlinks will be disabled"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target symlink \"%s\"\n"
+"Cannot create target symlink\n"
 "%s"
 msgstr ""
 "無法建立目標連結 \"%s\"\n"
@@ -2507,170 +2555,211 @@ msgid ""
 "are the same file"
 msgstr ""
 
+msgid "&Ignore"
+msgstr "忽略"
+
 msgid "Ignore a&ll"
 msgstr ""
 
+msgid "&Retry"
+msgstr "重試"
+
 #, c-format
 msgid ""
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 #, c-format
 msgid ""
 "Background process:\n"
-"Directory \"%s\" not empty.\n"
+"Directory\n"
+"%s\n"
+"is not empty.\n"
 "Delete it recursively?"
 msgstr ""
 
 msgid "Non&e"
 msgstr "無"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove file \"%s\"\n"
+"Cannot remove file\n"
 "%s"
 msgstr ""
+"無法儲存檔案:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat file \"%s\"\n"
+"Cannot stat file\n"
 "%s"
 msgstr ""
+"無法儲存檔案:\n"
+"%s"
 
 #, c-format
 msgid "Cannot overwrite directory \"%s\""
 msgstr "無法覆寫目錄 \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move file \"%s\" to \"%s\"\n"
+"Cannot move file\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
+"無法儲存檔案 %s:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot remove directory \"%s\"\n"
+"Cannot remove directory\n"
 "%s"
 msgstr ""
 "無法刪除目錄 \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot enter into directory \"%s\"\n"
+"Cannot enter into directory\n"
 "%s"
-msgstr ""
+msgstr "無法覆寫目錄 \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite directory \"%s\"\n"
+"Cannot overwrite directory\n"
 "%s"
-msgstr ""
-"無法覆寫目錄 \"%s\"\n"
-"%s"
+msgstr "無法覆寫目錄 \"%s\""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot overwrite file \"%s\"\n"
+"Cannot overwrite file\n"
 "%s"
 msgstr ""
 "無法覆寫檔案 \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot move directory \"%s\" to \"%s\"\n"
+"Cannot move directory\n"
+"%s\n"
+"to\n"
 "%s"
 msgstr ""
-"無法將目錄 \"%s\" 移動到 \"%s\"\n"
+"無法刪除目錄 \"%s\"\n"
 "%s"
 
 msgid "Cannot operate on \"..\"!"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source file \"%s\"\n"
+"Cannot stat source file\n"
 "%s"
 msgstr ""
+"無法儲存檔案:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source file \"%s\"\n"
+"Cannot get ext2 attributes of source file\n"
 "%s"
 msgstr ""
+"無法寫入到檔案 %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes of target file \"%s\"\n"
+"Cannot set ext2 attributes of target file\n"
 "%s"
 msgstr ""
+"無法寫入到檔案 %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create special file \"%s\"\n"
+"Cannot create special file\n"
 "%s"
 msgstr ""
-
-#, c-format
-msgid ""
-"Cannot chown target file \"%s\"\n"
+"無法建立備份檔案\n"
+"%s%s\n"
 "%s"
-msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chmod target file \"%s\"\n"
+"Cannot chown target file\n"
 "%s"
 msgstr ""
 "無法對目標檔案 \"%s\" 執行 chmod 指令\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open source file \"%s\"\n"
+"Cannot chmod target file\n"
 "%s"
 msgstr ""
+"無法對目標檔案 \"%s\" 執行 chmod 指令\n"
+"%s"
+
+#, fuzzy, c-format
+msgid ""
+"Cannot open source file\n"
+"%s"
+msgstr "無法開啟檔案 %s"
 
 msgid "Reget failed, about to overwrite file"
 msgstr "複寫檔案找回失敗"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat source file \"%s\"\n"
+"Cannot fstat source file\n"
 "%s"
 msgstr ""
+"無法儲存檔案:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target file \"%s\"\n"
+"Cannot create target file\n"
 "%s"
 msgstr ""
+"無法建立目標目錄 \"%s\"\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot fstat target file \"%s\"\n"
+"Cannot fstat target file\n"
 "%s"
 msgstr ""
+"無法儲存檔案:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot preallocate space for target file \"%s\"\n"
+"Cannot preallocate space for target file\n"
 "%s"
 msgstr ""
+"無法對目標檔案 \"%s\" 執行 chmod 指令\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot read source file \"%s\"\n"
+"Cannot read source file\n"
 "%s"
 msgstr ""
+"無法儲存檔案:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot write target file \"%s\"\n"
+"Cannot write target file\n"
 "%s"
 msgstr ""
+"無法寫入到檔案 %s :\n"
+"%s\n"
 
 msgid "(stalled)"
 msgstr "(暫停了)"
@@ -2684,35 +2773,43 @@ msgstr "保留"
 msgid "&Continue copy"
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close source file \"%s\"\n"
+"Cannot close source file\n"
 "%s"
 msgstr ""
+"無法儲存檔案:\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot close target file \"%s\"\n"
+"Cannot close target file\n"
 "%s"
 msgstr ""
+"無法對目標檔案 \"%s\" 執行 chmod 指令\n"
+"%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot set ext2 attributes for target file \"%s\"\n"
+"Cannot set ext2 attributes for target file\n"
 "%s"
 msgstr ""
+"無法寫入到檔案 %s :\n"
+"%s\n"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot stat source directory \"%s\"\n"
+"Cannot stat source directory\n"
 "%s"
-msgstr ""
+msgstr "無法建立目錄 %s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot get ext2 attributes of source directory \"%s\"\n"
+"Cannot get ext2 attributes of source directory\n"
 "%s"
 msgstr ""
+"無法建立目標目錄 \"%s\"\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -2728,27 +2825,31 @@ msgid ""
 "\"%s\""
 msgstr ""
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Destination \"%s\" must be a directory\n"
+"Destination\n"
+"%s\n"
+"must be a directory\n"
 "%s"
 msgstr ""
 "目標 \"%s\" 必須是一個目錄\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot create target directory \"%s\"\n"
+"Cannot create target directory\n"
 "%s"
 msgstr ""
 "無法建立目標目錄 \"%s\"\n"
 "%s"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot chown target directory \"%s\"\n"
+"Cannot chown target directory\n"
 "%s"
 msgstr ""
+"無法建立目標目錄 \"%s\"\n"
+"%s"
 
 #, c-format
 msgid "Directories: %zu, total size: %s"
@@ -3071,11 +3172,9 @@ msgid "You have %zu opened screen. Quit anyway?"
 msgid_plural "You have %zu opened screens. Quit anyway?"
 msgstr[0] ""
 
-msgid "The Midnight Commander"
-msgstr ""
-
-msgid "Do you really want to quit the Midnight Commander?"
-msgstr ""
+#, fuzzy
+msgid "Do you really want to quit?"
+msgstr "您真的想要執行?"
 
 msgid "&Above"
 msgstr "上述"
@@ -3567,11 +3666,9 @@ msgid ""
 "%s"
 msgstr ""
 
-#, c-format
 msgid ""
 "External panelize:\n"
-"failed to read data from child stdout:\n"
-"%s"
+"failed to read data from child stdout:"
 msgstr ""
 
 msgid "Cannot run external panelize in a non-local directory"
@@ -3610,6 +3707,15 @@ msgid ""
 "Cannot stat the destination\n"
 "%s"
 msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"Destination\n"
+"%s\n"
+"must be a directory"
+msgstr ""
+"目標 \"%s\" 必須是一個目錄\n"
+"%s"
 
 #, c-format
 msgid "Delete %s?"
@@ -3725,8 +3831,9 @@ msgstr ""
 msgid "Home directory path is not absolute"
 msgstr ""
 
+#, fuzzy, c-format
 msgid ""
-"GNU Midnight Commander\n"
+"%s\n"
 "is already running on this terminal.\n"
 "Subshell support will be disabled."
 msgstr ""
@@ -4405,8 +4512,9 @@ msgstr "資料已被修改。儲存並離開?"
 msgid "&Cancel quit"
 msgstr "取消結束"
 
+#, fuzzy, c-format
 msgid ""
-"Midnight Commander is being shut down.\n"
+"%s is being shut down.\n"
 "Save modified file?"
 msgstr ""
 "正在結束 Midnight Commander。\n"
@@ -4457,10 +4565,7 @@ msgstr "按鈕列 | 取消格式"
 msgid "ButtonBar|Format"
 msgstr "按鈕列 | 格式"
 
-#, c-format
-msgid ""
-"Failed to read data from child stdout:\n"
-"%s"
+msgid "Failed to read data from child stdout"
 msgstr ""
 
 #, c-format
@@ -4484,20 +4589,18 @@ msgstr ""
 msgid "View: "
 msgstr "檢視:"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\"\n"
-"%s"
-msgstr ""
-"無法開啟 \"%s\"\n"
-"%s"
-
-msgid "Cannot view: not a regular file"
+"Cannot view\n"
+"%s\n"
+"Not a regular file"
 msgstr "無法檢視: 不是一般的檔案"
 
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Cannot open \"%s\" in parse mode\n"
+"Cannot open\n"
+"%s\n"
+"in parse mode\n"
 "%s"
 msgstr ""
 "無法在解析模式開啟 \"%s\"\n"
@@ -4511,6 +4614,37 @@ msgstr "從頭開始?"
 
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "無法取得本地的副本在 ftp://some.host/editme.txt"
+
+#, c-format
+#~ msgid "Cannot get size/permissions for %s"
+#~ msgstr "無法取得 %s 的檔案大小或存取權限"
+
+#~ msgid "Ignore &all"
+#~ msgstr "忽略全部"
+
+#, c-format
+#~ msgid "link: %s"
+#~ msgstr "連結: %s"
+
+#, c-format
+#~ msgid "symlink: %s"
+#~ msgstr "軟連結: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot overwrite directory \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "無法覆寫目錄 \"%s\"\n"
+#~ "%s"
+
+#, c-format
+#~ msgid ""
+#~ "Cannot move directory \"%s\" to \"%s\"\n"
+#~ "%s"
+#~ msgstr ""
+#~ "無法將目錄 \"%s\" 移動到 \"%s\"\n"
+#~ "%s"
 
 #~ msgid "Other 8 bit"
 #~ msgstr "其它八位元"

--- a/src/args.c
+++ b/src/args.c
@@ -459,10 +459,10 @@ mc_args_add_extended_info_to_help (void)
 {
     mc_args__loc__footer_string =
         g_strdup_printf (_ ("\n"
-                            "Please send any bug reports (including the output of 'mc -V')\n"
+                            "Please send any bug reports (including the output of '%s -V')\n"
                             "as tickets at %s\n"),
-                         PACKAGE_BUGREPORT);
-    mc_args__loc__header_string = g_strdup_printf (PACKAGE_NAME " %s\n", mc_global.mc_version);
+                         PACKAGE, PACKAGE_BUGREPORT);
+    mc_args__loc__header_string = g_strdup_printf ("%s %s\n", PACKAGE_NAME, mc_global.mc_version);
 
     g_option_context_set_description (context, mc_args__loc__footer_string);
     g_option_context_set_summary (context, mc_args__loc__header_string);

--- a/src/diffviewer/ydiff.c
+++ b/src/diffviewer/ydiff.c
@@ -2966,15 +2966,17 @@ dview_ok_to_exit (WDiff *dview)
 {
     gboolean res = TRUE;
     int act;
+    char *text;
 
     if (!dview->merged[DIFF_LEFT] && !dview->merged[DIFF_RIGHT])
         return res;
 
-    act = query_dialog (_ ("Quit"),
-                        !mc_global.midnight_shutdown
-                            ? _ ("File(s) was modified. Save with exit?")
-                            : _ ("Midnight Commander is being shut down.\nSave modified file(s)?"),
-                        D_NORMAL, 2, _ ("&Yes"), _ ("&No"));
+    text = g_strdup_printf (!mc_global.midnight_shutdown
+                                ? _ ("File(s) was modified. Save with exit?")
+                                : _ ("%s is being shut down.\nSave modified file(s)?"),
+                            PACKAGE_NAME);
+    act = query_dialog (_ ("Quit"), text, D_NORMAL, 2, _ ("&Yes"), _ ("&No"));
+    g_free (text);
 
     // Esc is No
     if (mc_global.midnight_shutdown || (act == -1))

--- a/src/editor/editcmd.c
+++ b/src/editor/editcmd.c
@@ -1474,7 +1474,7 @@ edit_ok_to_exit (WEdit *edit)
     }
     else
     {
-        msg = g_strdup_printf (_ ("Midnight Commander is being shut down.\nSave modified file %s?"),
+        msg = g_strdup_printf (_ ("%s is being shut down.\nSave modified file %s?"), PACKAGE_NAME,
                                fname);
         act = edit_query_dialog2 (_ ("Quit"), msg, _ ("&Yes"), _ ("&No"));
 

--- a/src/editor/editwidget.c
+++ b/src/editor/editwidget.c
@@ -137,19 +137,20 @@ edit_dlg_deinit (void)
 static void
 edit_about (void)
 {
-    char *ver;
+    char *ver, *desc;
 
     ver = g_strdup_printf ("MCEdit %s", mc_global.mc_version);
+    desc = g_strdup_printf (N_ ("A user friendly text editor\n"
+                                "written for the %s."),
+                            PACKAGE_NAME);
 
     {
         quick_widget_t quick_widgets[] = {
             QUICK_LABEL (ver, NULL),
             QUICK_SEPARATOR (TRUE),
-            QUICK_LABEL (N_ ("A user friendly text editor\n"
-                             "written for the Midnight Commander."),
-                         NULL),
+            QUICK_LABEL (desc, NULL),
             QUICK_SEPARATOR (FALSE),
-            QUICK_LABEL (N_ ("Copyright (C) 1996-2025 the Free Software Foundation"), NULL),
+            QUICK_LABEL (PACKAGE_COPYRIGHT, NULL),
             QUICK_START_BUTTONS (TRUE, TRUE),
             QUICK_BUTTON (N_ ("&OK"), B_ENTER, NULL, NULL),
             QUICK_END,
@@ -174,6 +175,7 @@ edit_about (void)
     }
 
     g_free (ver);
+    g_free (desc);
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/src/execute.c
+++ b/src/execute.c
@@ -505,7 +505,7 @@ toggle_subshell (void)
     {
         if (output_starts_shell)
         {
-            fputs (_ ("Type 'exit' to return to the Midnight Commander"), stderr);
+            fprintf (stderr, _ ("Type 'exit' to return to the %s"), PACKAGE_NAME);
             fputs ("\n\r\n\r", stderr);
 
             my_system (EXECUTE_INTERNAL, mc_global.shell->path, NULL);

--- a/src/filemanager/boxes.c
+++ b/src/filemanager/boxes.c
@@ -493,7 +493,7 @@ about_box (void)
     char *label_cp_display;
     char *label_cp_source;
 
-    char *version = g_strdup_printf ("Midnight Commander %s", mc_global.mc_version);
+    char *version = g_strdup_printf ("%s %s", PACKAGE_NAME, mc_global.mc_version);
 
     const char *name_cp_display =
         ((codepage_desc *) g_ptr_array_index (codepages, mc_global.display_codepage))->name;
@@ -512,7 +512,7 @@ about_box (void)
         QUICK_SEPARATOR (TRUE),
         QUICK_LABEL (N_ ("Classic terminal file manager inspired by Norton Commander."), NULL),
         QUICK_SEPARATOR (FALSE),
-        QUICK_LABEL (N_ ("Copyright (C) 1996-2025 the Free Software Foundation"), NULL),
+        QUICK_LABEL (PACKAGE_COPYRIGHT, NULL),
         QUICK_SEPARATOR (TRUE),
         QUICK_LABEL (label_cp_display, NULL),
         QUICK_LABEL (label_cp_source, NULL),

--- a/src/filemanager/boxes.c
+++ b/src/filemanager/boxes.c
@@ -488,6 +488,64 @@ task_cb (WButton *button, int action)
 /* --------------------------------------------------------------------------------------------- */
 
 void
+about_box (void)
+{
+    char *label_cp_display;
+    char *label_cp_source;
+
+    char *version = g_strdup_printf ("Midnight Commander %s", mc_global.mc_version);
+
+    const char *name_cp_display =
+        ((codepage_desc *) g_ptr_array_index (codepages, mc_global.display_codepage))->name;
+
+    const char *name_cp_source = mc_global.source_codepage >= 0
+        ? ((codepage_desc *) g_ptr_array_index (codepages, mc_global.source_codepage))->name
+        : N_ ("No translation");
+
+    label_cp_display =
+        g_strdup_printf ("%s: %s", N_ ("Detected display codepage"), name_cp_display);
+    label_cp_source =
+        g_strdup_printf ("%s: %s", N_ ("Selected source (file I/O) codepage"), name_cp_source);
+
+    quick_widget_t quick_widgets[] = {
+        QUICK_LABEL (version, NULL),
+        QUICK_SEPARATOR (TRUE),
+        QUICK_LABEL (N_ ("Classic terminal file manager inspired by Norton Commander."), NULL),
+        QUICK_SEPARATOR (FALSE),
+        QUICK_LABEL (N_ ("Copyright (C) 1996-2025 the Free Software Foundation"), NULL),
+        QUICK_SEPARATOR (TRUE),
+        QUICK_LABEL (label_cp_display, NULL),
+        QUICK_LABEL (label_cp_source, NULL),
+        QUICK_START_BUTTONS (TRUE, TRUE),
+        QUICK_BUTTON (N_ ("&OK"), B_ENTER, NULL, NULL),
+        QUICK_END,
+    };
+
+    WRect r = { -1, -1, 0, 40 };
+
+    quick_dialog_t qdlg = {
+        .rect = r,
+        .title = N_ ("About"),
+        .help = "[Overview]",
+        .widgets = quick_widgets,
+        .callback = NULL,
+        .mouse_callback = NULL,
+    };
+
+    quick_widgets[0].pos_flags = WPOS_KEEP_TOP | WPOS_CENTER_HORZ;
+    quick_widgets[2].pos_flags = WPOS_KEEP_TOP | WPOS_CENTER_HORZ;
+    quick_widgets[4].pos_flags = WPOS_KEEP_TOP | WPOS_CENTER_HORZ;
+
+    (void) quick_dialog (&qdlg);
+
+    g_free (version);
+    g_free (label_cp_display);
+    g_free (label_cp_source);
+}
+
+/* --------------------------------------------------------------------------------------------- */
+
+void
 configure_box (void)
 {
     const char *pause_options[] = {
@@ -590,23 +648,9 @@ void
 appearance_box (void)
 {
     const gboolean shadows = mc_global.tty.shadows;
-    char *label_cp_display;
-    char *label_cp_source;
 
     current_skin_name = g_strdup (mc_skin__default.name);
     skin_names = mc_skin_list ();
-
-    const char *name_cp_display =
-        ((codepage_desc *) g_ptr_array_index (codepages, mc_global.display_codepage))->name;
-
-    const char *name_cp_source = mc_global.source_codepage >= 0
-        ? ((codepage_desc *) g_ptr_array_index (codepages, mc_global.source_codepage))->name
-        : N_ ("No translation");
-
-    label_cp_display =
-        g_strdup_printf ("%s: %s", N_ ("Detected display codepage"), name_cp_display);
-    label_cp_source =
-        g_strdup_printf ("%s: %s", N_ ("Selected source (file I/O) codepage"), name_cp_source);
 
     {
         quick_widget_t quick_widgets[] = {
@@ -619,9 +663,6 @@ appearance_box (void)
             QUICK_STOP_COLUMNS,
             QUICK_SEPARATOR (TRUE),
             QUICK_CHECKBOX (N_ ("&Shadows"), &mc_global.tty.shadows, &shadows_id),
-            QUICK_SEPARATOR (TRUE),
-            QUICK_LABEL (label_cp_display, NULL),
-            QUICK_LABEL (label_cp_source, NULL),
             QUICK_BUTTONS_OK_CANCEL,
             QUICK_END,
             // clang-format on
@@ -648,8 +689,6 @@ appearance_box (void)
         }
     }
 
-    g_free (label_cp_display);
-    g_free (label_cp_source);
     g_free (current_skin_name);
     g_ptr_array_free (skin_names, TRUE);
 }

--- a/src/filemanager/boxes.h
+++ b/src/filemanager/boxes.h
@@ -18,6 +18,7 @@
 
 /*** declarations of public functions ************************************************************/
 
+void about_box (void);
 void configure_box (void);
 void appearance_box (void);
 void panel_options_box (void);

--- a/src/filemanager/ext.c
+++ b/src/filemanager/ext.c
@@ -772,9 +772,9 @@ check_old_extension_file (void)
     extension_old_file = mc_config_get_full_path (MC_EXT_OLD_FILE);
     if (exist_file (extension_old_file))
         message (D_ERROR, _ ("Warning"),
-                 _ ("You have an outdated %s file.\nMidnight Commander now uses %s file.\n"
+                 _ ("You have an outdated %s file.\n%s now uses %s file.\n"
                     "Please copy your modifications of the old file to the new one."),
-                 extension_old_file, MC_EXT_FILE);
+                 extension_old_file, PACKAGE_NAME, MC_EXT_FILE);
     g_free (extension_old_file);
 }
 
@@ -825,8 +825,8 @@ load_extension_file (void)
             message (D_ERROR, MSG_ERROR,
                      _ ("The format of the\n%s%s\nfile has changed with version 4.0.\n"
                         "It seems that the installation has failed.\nPlease fetch a fresh copy "
-                        "from the Midnight Commander package."),
-                     mc_global.sysconfig_dir, MC_EXT_FILE);
+                        "from the %s package."),
+                     mc_global.sysconfig_dir, MC_EXT_FILE, PACKAGE_NAME);
             return FALSE;
         }
 

--- a/src/filemanager/filemanager.c
+++ b/src/filemanager/filemanager.c
@@ -1029,16 +1029,14 @@ quit_cmd_internal (int quiet)
                               "You have %zu opened screens. Quit anyway?", n),
                     n);
 
-        if (query_dialog (_ ("The Midnight Commander"), msg, D_NORMAL, 2, _ ("&Yes"), _ ("&No"))
-            != 0)
+        if (query_dialog (PACKAGE_NAME, msg, D_NORMAL, 2, _ ("&Yes"), _ ("&No")) != 0)
             return FALSE;
         q = 1;
     }
     else if (quiet || !confirm_exit)
         q = 1;
-    else if (query_dialog (_ ("The Midnight Commander"),
-                           _ ("Do you really want to quit the Midnight Commander?"), D_NORMAL, 2,
-                           _ ("&Yes"), _ ("&No"))
+    else if (query_dialog (PACKAGE_NAME, _ ("Do you really want to quit?"), D_NORMAL, 2, _ ("&Yes"),
+                           _ ("&No"))
              == 0)
         q = 1;
 
@@ -1718,7 +1716,7 @@ load_hint (gboolean force)
     {
         char text[BUF_SMALL];
 
-        g_snprintf (text, sizeof (text), PACKAGE_NAME " %s\n", mc_global.mc_version);
+        g_snprintf (text, sizeof (text), "%s %s\n", PACKAGE_NAME, mc_global.mc_version);
         set_hintbar (text);
     }
 }

--- a/src/filemanager/filemanager.c
+++ b/src/filemanager/filemanager.c
@@ -329,6 +329,8 @@ create_options_menu (void)
 #endif
     entries = g_list_prepend (entries, menu_separator_new ());
     entries = g_list_prepend (entries, menu_entry_new (_ ("&Save setup"), CK_SaveSetup));
+    entries = g_list_prepend (entries, menu_separator_new ());
+    entries = g_list_prepend (entries, menu_entry_new (_ ("A&bout..."), CK_About));
 
     return g_list_reverse (entries);
 }
@@ -1107,6 +1109,9 @@ midnight_execute_cmd (Widget *sender, long command)
 
     switch (command)
     {
+    case CK_About:
+        about_box ();
+        break;
     case CK_ChangePanel:
         (void) change_panel ();
         break;

--- a/src/filemanager/info.c
+++ b/src/filemanager/info.c
@@ -122,7 +122,7 @@ info_show_info (WInfo *info)
 
     tty_setcolor (MARKED_COLOR);
     widget_gotoyx (w, 1, 3);
-    tty_printf (PACKAGE_NAME " %s", mc_global.mc_version);
+    tty_printf ("%s %s", PACKAGE_NAME, mc_global.mc_version);
 
     if (!info->ready)
         return;

--- a/src/filemanager/panel.c
+++ b/src/filemanager/panel.c
@@ -2894,8 +2894,8 @@ do_enter_on_file_entry (WPanel *panel, const file_entry_t *fe)
         return FALSE;
 
     if (confirm_execute
-        && query_dialog (_ ("The Midnight Commander"), _ ("Do you really want to execute?"),
-                         D_NORMAL, 2, _ ("&Yes"), _ ("&No"))
+        && query_dialog (PACKAGE_NAME, _ ("Do you really want to execute?"), D_NORMAL, 2,
+                         _ ("&Yes"), _ ("&No"))
             != 0)
         return TRUE;
 

--- a/src/main.c
+++ b/src/main.c
@@ -381,11 +381,13 @@ main (int argc, char *argv[])
     // inherit the file descriptors opened below, etc
     if (mc_global.tty.use_subshell && mc_global.run_from_parent_mc)
     {
-        const int quit_mc =
-            query_dialog (_ ("Warning"),
-                          _ ("GNU Midnight Commander\nis already running on this terminal.\n"
-                             "Subshell support will be disabled."),
-                          D_ERROR, 2, _ ("&OK"), _ ("&Quit"));
+        char *text;
+
+        text = g_strdup_printf (_ ("%s\nis already running on this terminal.\n"
+                                   "Subshell support will be disabled."),
+                                PACKAGE_NAME);
+        const int quit_mc = query_dialog (_ ("Warning"), text, D_ERROR, 2, _ ("&OK"), _ ("&Quit"));
+        g_free (text);
 
         if (quit_mc != 0)
         {

--- a/src/textconf.c
+++ b/src/textconf.c
@@ -138,7 +138,7 @@ show_version (void)
 {
     size_t i;
 
-    printf (PACKAGE_NAME " %s\n", mc_global.mc_version);
+    printf ("%s %s\n", PACKAGE_NAME, mc_global.mc_version);
 
     printf (_ ("Built with GLib %d.%d.%d (using GLib %u.%u.%u)\n"), GLIB_MAJOR_VERSION,
             GLIB_MINOR_VERSION, GLIB_MICRO_VERSION, glib_major_version, glib_minor_version,

--- a/src/viewer/actions_cmd.c
+++ b/src/viewer/actions_cmd.c
@@ -598,9 +598,12 @@ mcview_ok_to_quit (WView *view)
     }
     else
     {
-        r = query_dialog (_ ("Quit"),
-                          _ ("Midnight Commander is being shut down.\nSave modified file?"),
-                          D_NORMAL, 2, _ ("&Yes"), _ ("&No"));
+        char *text;
+
+        text = g_strdup_printf (_ ("%s is being shut down.\nSave modified file?"), PACKAGE_NAME);
+        r = query_dialog (_ ("Quit"), text, D_NORMAL, 2, _ ("&Yes"), _ ("&No"));
+        g_free (text);
+
         // Esc is No
         if (r == -1)
             r = 1;


### PR DESCRIPTION
## Proposed changes

As discussed in the related tickets, this adds an "About..." box to `mc`.

<img width="1002" alt="Screenshot 2025-05-18 at 10 56 07" src="https://github.com/user-attachments/assets/232d2272-c55b-4418-bc09-45713d971df8" />

The menu entry is positioned so that it does not interfere with established patterns, such as selecting the last item to save the setup.

<img width="1002" alt="Screenshot 2025-05-18 at 10 59 42" src="https://github.com/user-attachments/assets/c4f2134c-fac0-40a2-aac8-986d48f1612a" />

Relates to: #4702
Resolves: #4704
