### PR TITLE
Ticket #4711: support browsing Android packages (APK) in mc.ext

### DIFF
--- a/misc/filehighlight.ini
+++ b/misc/filehighlight.ini
@@ -25,7 +25,7 @@
     regexp=(^#.*|.*~$)
 
 [archive]
-    extensions=7z;Z;ace;apk;arc;arj;ark;bz2;cab;cpio;deb;gz;lha;lz;lz4;lzh;lzma;lzo;rar;rpm;tar;tbz;tbz2;tgz;tlz;txz;tzo;tzst;vsix;xz;zip;zoo;zst
+    extensions=7z;Z;aab;aar;ace;apk;arc;arj;ark;bz2;cab;cpio;deb;gz;lha;lz;lz4;lzh;lzma;lzo;rar;rpm;tar;tbz;tbz2;tgz;tlz;txz;tzo;tzst;vsix;xapk;xz;zip;zoo;zst
 
 [doc]
     extensions=chm;css;ctl;diz;doc;docm;docx;dtd;fodg;fodp;fods;fodt;htm;html;json;letter;lsm;mail;man;markdown;md;me;mkd;msg;nroff;odg;odp;ods;odt;pdf;po;ppt;pptm;pptx;ps;rtf;sgml;shtml;tex;text;txt;xls;xlsm;xlsx;xml;xsd;xslt

--- a/misc/mc.ext.ini.in
+++ b/misc/mc.ext.ini.in
@@ -1138,6 +1138,12 @@ TypeIgnoreCase=true
 Open=%cd %p/uzip://
 View=%view{ascii} @EXTHELPERSDIR@/archive.sh view zip
 
+[apk]
+Type=Android package \\(APK\\)
+TypeIgnoreCase=true
+Open=%cd %p/uzip://
+View=%view{ascii} @EXTHELPERSDIR@/archive.sh view zip
+
 [lha]
 Type=^LHa .*archive
 Open=%cd %p/ulha://


### PR DESCRIPTION
## Proposed changes

XAPK, AAB and AAR files should be captured by `zip-by-type` rule:

```
% file Google\ Chrome_136.0.7103.125_APKPure.xapk 
Google Chrome_136.0.7103.125_APKPure.xapk: Zip archive data, at least v2.0 to extract, compression method=store
```

Resolves: #4711
