### PR TITLE
Fix %pkglibexecdir% leaking into man pages in some cases

### DIFF
--- a/doc/man/date-of-man-include.am
+++ b/doc/man/date-of-man-include.am
@@ -1,10 +1,10 @@
 SED_PARAMETERS = \
 	-e "s/%DATE_OF_MAN_PAGE%/$${MAN_DATE}/g" \
-	-e "s/%MAN_VERSION%/@MAN_VERSION@/g" \
-	-e "s{%sysconfdir%{@sysconfdir@{g" \
-	-e "s{%libexecdir%{@libexecdir@{g" \
-	-e "s{%pkglibexecdir%{@pkglibexecdir@{g" \
-	-e "s{%pkgdatadir%{$(datadir)/@PACKAGE@{g"
+	-e "s/%MAN_VERSION%/$(MAN_VERSION)/g" \
+	-e "s{%sysconfdir%{$(sysconfdir){g" \
+	-e "s{%libexecdir%{$(libexecdir){g" \
+	-e "s{%pkglibexecdir%{$(pkglibexecdir){g" \
+	-e "s{%pkgdatadir%{$(pkgdatadir){g"
 
 MAN_DATE_CMD = \
 	LC_ALL=$(DATE_LANG) @PERL_FOR_BUILD@ -CS -MPOSIX -e '\


### PR DESCRIPTION
The generated "doc/man/es/Makefile" contains

	pkglibexecdir = $(libexecdir)/mc
	libexecdir = ${exec_prefix}/libexec
	SED_PARAMETERS = \
		... \
		-e "s{%libexecdir%{${exec_prefix}/libexec{g" \
		-e "s{%pkglibexecdir%{@pkglibexecdir@{g" \

I think "@pkglibexecdir@" is an Automake macro that should have been expanded
when generating this Makefile.

When I install from source, this leads to

	$ man mc | grep bash
	shell to the last directory Midnight Commander was in. Source the file @pkglibexecdir@/mc.sh (bash and zsh

Fix that by expanding earlier. We should also be able to use the Make variable
("$(pkglibexecdir)", which is defined in the Makefile) but I couldn't get
that to work.

Ref: https://github.com/MidnightCommander/mc/pull/4726/commits/7376bc6699c7372fce6186ad6691a9a777777292#r2186982049
Signed-off-by: Johannes Altmanninger <aclopte@gmail.com>
