### PR TITLE
Ticket #4738: fix build with gcc 4.3.2 failing due to missing header

### DIFF
--- a/src/editor/editcmd.c
+++ b/src/editor/editcmd.c
@@ -43,6 +43,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <stdlib.h>
+#include <errno.h>
 
 #include "lib/global.h"
 #include "lib/tty/tty.h"


### PR DESCRIPTION
## Proposed changes

Add `errorno.h` include to fix the build with an ancient GCC.

Resolves: #4738
