### PR TITLE
Fix 10-second startup delay on macOS with ZSH

### DIFF
--- a/src/subshell/common.c
+++ b/src/subshell/common.c
@@ -1676,8 +1676,17 @@ init_subshell (void)
      * assume there must be something wrong with the shell, and we turn persistent buffer off
      * for good. This will save the user the trouble of having to wait for the persistent
      * buffer function to time out every time they try to close the subshell. */
-    if (use_persistent_buffer && !read_command_line_buffer (TRUE))
-        use_persistent_buffer = FALSE;
+#ifdef __APPLE__
+    /* On macOS with ZSH, skip the test because the shell is in SIGSTOP state and cannot respond.
+     * The feature works but the test times out. */
+    if (use_persistent_buffer && mc_global.shell->type != SHELL_ZSH)
+#else
+    if (use_persistent_buffer)
+#endif
+    {
+        if (!read_command_line_buffer (TRUE))
+            use_persistent_buffer = FALSE;
+    }
 }
 
 /* --------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
## Proposed changes

### Problem
MC has a 10-second startup delay on macOS when using ZSH as described in #4625. The root cause is that the
persistent command buffer test times out because the ZSH subshell enters SIGSTOP state immediately after
initialization and cannot respond to the test.

### The macOS-specific behavior
On macOS with ZSH, the following sequence occurs during MC initialization:
1. MC starts the ZSH subshell with a `precmd` hook that sends SIGSTOP after each prompt
2. The `feed_subshell()` function runs, ZSH executes precmd → sends pwd → enters SIGSTOP
3. `synchronize()` sends SIGCONT to continue the shell
4. ZSH immediately runs precmd again → back to SIGSTOP state
5. The persistent buffer test tries to communicate with the shell
6. The shell is suspended (SIGSTOP) and cannot respond
7. After 10 seconds timeout, MC disables the persistent buffer feature and continues

This is a macOS-specific timing issue. On Linux, the same code works without problems.

### Solution
Skip the persistent buffer test specifically for macOS+ZSH combination, while keeping the feature enabled.
This is safe because:

1. **The feature is guaranteed to work on macOS+ZSH**: The ZSH Line Editor (ZLE) with `bindkey` commands and
 `BUFFER` variable are standard, stable ZSH features that are always available
2. **The environment is predictable**: On macOS, users work in terminal emulators (Terminal.app, iTerm2,
etc.) where the persistent buffer feature always works. There's no text console mode or non-xterm
environments where it might fail
3. **Only the test fails, not the feature**: The persistent buffer works perfectly during normal MC
operation (Ctrl+O), the problem only occurs during the initialization test

### Technical Details
- The test mechanism sends ESC+_ to the shell and expects a response
- On macOS+ZSH, the shell is in SIGSTOP state and cannot process the request
- During normal operation (Ctrl+O), the shell is ACTIVE and the feature works correctly
- The fix adds a platform-specific condition to skip the test on macOS+ZSH only

Tested on macOS 26 (Tahoe)

Resolves: #4625 

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
