### PR TITLE
Add 10 modern color scheme skins for MC

### DIFF
--- a/misc/skins/Makefile.am
+++ b/misc/skins/Makefile.am
@@ -1,18 +1,24 @@
 skindir = $(pkgdatadir)/skins
 
 SKINS = \
+	catppuccin256.ini \
+	catppuccin-latte256.ini \
 	dark.ini \
 	darkfar.ini \
 	default.ini \
 	double-lines.ini \
+	everforest256.ini \
 	featured-plus.ini \
 	featured.ini \
 	gotar.ini \
 	gray-green-purple256.ini \
 	gray-orange-blue256.ini \
+	gruvbox256.ini \
 	julia256.ini \
 	julia256root.ini \
+	kanagawa256.ini \
 	mashdark256.ini \
+	matte-black256.ini \
 	mc46.ini \
 	modarcon16-defbg.ini \
 	modarcon16-defbg-thin.ini \
@@ -31,11 +37,16 @@ SKINS = \
 	modarin256root-thin.ini \
 	modarin256root.ini \
 	nicedark.ini \
+	nord256.ini \
+	osaka-jade256.ini \
+	ristretto256.ini \
+	rose-pine256.ini \
 	sand256.ini \
 	seasons-autumn16M.ini \
 	seasons-spring16M.ini \
 	seasons-summer16M.ini \
 	seasons-winter16M.ini \
+	tokyo-night256.ini \
 	xoria256-thin.ini \
 	xoria256.ini \
 	xoria256root-thin.ini \

--- a/misc/skins/Makefile.am
+++ b/misc/skins/Makefile.am
@@ -1,18 +1,24 @@
 skindir = $(pkgdatadir)/skins
 
 SKINS = \
+	catppuccin256.ini \
+	catppuccin-latte256.ini \
 	dark.ini \
 	darkfar.ini \
 	default.ini \
 	double-lines.ini \
+	everforest256.ini \
 	featured-plus.ini \
 	featured.ini \
 	gotar.ini \
 	gray-green-purple256.ini \
 	gray-orange-blue256.ini \
+	gruvbox256.ini \
 	julia256.ini \
 	julia256root.ini \
+	kanagawa256.ini \
 	mashdark256.ini \
+	matte-black256.ini \
 	mc46.ini \
 	modarcon16-defbg.ini \
 	modarcon16-defbg-thin.ini \
@@ -31,6 +37,10 @@ SKINS = \
 	modarin256root-thin.ini \
 	modarin256root.ini \
 	nicedark.ini \
+	nord256.ini \
+	osaka-jade256.ini \
+	ristretto256.ini \
+	rose-pine256.ini \
 	sand256.ini \
 	seasons-autumn16M.ini \
 	seasons-spring16M.ini \

--- a/misc/skins/catppuccin-latte256.ini
+++ b/misc/skins/catppuccin-latte256.ini
@@ -1,0 +1,169 @@
+# Catppuccin Latte (Light) theme for Midnight Commander
+# Based on the Catppuccin color scheme: https://github.com/catppuccin/catppuccin
+# Light version of the soothing pastel theme
+
+[skin]
+    description = Catppuccin Latte - Light soothing pastel theme
+    256colors = true
+
+[lines]
+    horiz = ─
+    vert = │
+    lefttop = ┌
+    righttop = ┐
+    leftbottom = └
+    rightbottom = ┘
+    topmiddle = ┬
+    bottommiddle = ┴
+    leftmiddle = ├
+    rightmiddle = ┤
+    cross = ┼
+    dhoriz = ─
+    dvert = │
+    dlefttop = ┌
+    drighttop = ┐
+    dleftbottom = └
+    drightbottom = ┘
+    dtopmiddle = ┬
+    dbottommiddle = ┴
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[core]
+    _default_ = color238;color255
+    selected = color255;color69
+    marked = color172;color255
+    markselect = color172;color69
+    gauge = color238;color250
+    input = color255;color69
+    inputunchanged = color245;color69
+    inputmark = color69;color255
+    disabled = color245;color248
+    reverse = color255;color238
+    hintbar = default;default
+    shellprompt = default;default
+    commandline = default;default
+    commandlinemark = color255;color238
+    header = color172;color255
+    inputhistory =
+    commandhistory =
+    shadow = color245;color252
+    frame = color238;color255
+
+[dialog]
+    _default_ = color255;color248
+    dfocus = color255;color69
+    dhotnormal = color69;color248
+    dhotfocus = color255;color69
+    dselnormal = color255;color69
+    dselfocus = color255;color69
+    dtitle = color69;color248
+    dframe = color255;color248
+
+[error]
+    _default_ = color238;color210
+    errdfocus = color255;color248
+    errdhotnormal = color172;color210
+    errdhotfocus = color172;color248
+    errdtitle = color172;color210
+    errdframe = color238;color210
+
+[filehighlight]
+    _default_ =
+    directory = color238;
+    executable = color151;
+    symlink = color245;
+    hardlink =
+    stalelink = color210;
+    device = color219;
+    special = color69;
+    core = color210;
+    temp = color245;
+    archive = color219;
+    doc = color180;
+    source = color123;
+    media = color151;
+    graph = color123;
+    database = color210;
+
+[menu]
+    _default_ = color238;color252
+    menusel = color255;color69
+    menuhot = color172;color252
+    menuhotsel = color172;color69
+    menuinactive = color245;color252
+    menuframe = color238;color252
+
+[popupmenu]
+    _default_ = color238;color252
+    menusel = color255;color69
+    menutitle = color172;color252
+    menuframe = color238;color252
+
+[buttonbar]
+    hotkey = color238;color255
+    button = color255;color69
+
+[statusbar]
+    _default_ = color255;color69
+
+[help]
+    _default_ = color255;color248
+    helpitalic = color210;color248
+    helpbold = color69;color248
+    helplink = color255;color69
+    helpslink = color172;color69
+    helptitle = color69;color248
+    helpframe = color255;color248
+
+[editor]
+    _default_ = color238;color255
+    editbold = color172;color151
+    editmarked = color255;color69
+    editwhitespace = color69;color255
+    editnonprintable = ;color255
+    editlinestate = color238;color69
+    bookmark = color238;color210
+    bookmarkfound = color255;color151
+    editrightmargin = color69;color255
+    editframeactive = color238;
+    editframedrag = color151;
+
+[viewer]
+    _default_ = color238;color255
+    viewbold = color172;color255
+    viewunderline = color210;color255
+    viewboldunderline = color172;color255
+    viewselected = color172;color69
+    viewframe = color238;color255
+
+[diffviewer]
+    added = color238;color151
+    changedline = color238;color69
+    changednew = color210;color69
+    changed = color238;color69
+    removed = color238;color210
+    error = color210;color248
+
+[widget-panel]
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
+
+[widget-scrollbar]
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/catppuccin256.ini
+++ b/misc/skins/catppuccin256.ini
@@ -1,0 +1,169 @@
+# Catppuccin Mocha theme for Midnight Commander
+# Based on the Catppuccin color scheme: https://github.com/catppuccin/catppuccin
+# Soothing pastel theme for the high-spirited!
+
+[skin]
+    description = Catppuccin Mocha - Soothing pastel theme
+    256colors = true
+
+[lines]
+    horiz = ─
+    vert = │
+    lefttop = ┌
+    righttop = ┐
+    leftbottom = └
+    rightbottom = ┘
+    topmiddle = ┬
+    bottommiddle = ┴
+    leftmiddle = ├
+    rightmiddle = ┤
+    cross = ┼
+    dhoriz = ─
+    dvert = │
+    dlefttop = ┌
+    drighttop = ┐
+    dleftbottom = └
+    drightbottom = ┘
+    dtopmiddle = ┬
+    dbottommiddle = ┴
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[core]
+    _default_ = color189;color234
+    selected = color30;color69
+    marked = color228;color234
+    markselect = color228;color69
+    gauge = color189;color240
+    input = color30;color189
+    inputunchanged = color244;color189
+    inputmark = color189;color30
+    disabled = color244;color250
+    reverse = color30;color189
+    hintbar = default;default
+    shellprompt = default;default
+    commandline = default;default
+    commandlinemark = color30;color189
+    header = color228;color234
+    inputhistory =
+    commandhistory =
+    shadow = color244;color16
+    frame = color189;color234
+
+[dialog]
+    _default_ = color30;color250
+    dfocus = color30;color189
+    dhotnormal = color69;color250
+    dhotfocus = color69;color189
+    dselnormal = color30;color189
+    dselfocus = color69;color189
+    dtitle = color69;color250
+    dframe = color30;color250
+
+[error]
+    _default_ = color189;color210
+    errdfocus = color30;color250
+    errdhotnormal = color228;color210
+    errdhotfocus = color228;color250
+    errdtitle = color228;color210
+    errdframe = color189;color210
+
+[filehighlight]
+    _default_ =
+    directory = color189;
+    executable = color151;
+    symlink = color244;
+    hardlink =
+    stalelink = color210;
+    device = color219;
+    special = color30;
+    core = color210;
+    temp = color244;
+    archive = color219;
+    doc = color180;
+    source = color123;
+    media = color151;
+    graph = color123;
+    database = color210;
+
+[menu]
+    _default_ = color189;color69
+    menusel = color189;color30
+    menuhot = color228;color69
+    menuhotsel = color228;color30
+    menuinactive = color30;color69
+    menuframe = color189;color69
+
+[popupmenu]
+    _default_ = color189;color69
+    menusel = color228;color30
+    menutitle = color228;color69
+    menuframe = color189;color69
+
+[buttonbar]
+    hotkey = color189;color30
+    button = color30;color189
+
+[statusbar]
+    _default_ = color30;color189
+
+[help]
+    _default_ = color30;color250
+    helpitalic = color210;color250
+    helpbold = color69;color250
+    helplink = color30;color189
+    helpslink = color228;color69
+    helptitle = color69;color250
+    helpframe = color30;color250
+
+[editor]
+    _default_ = color189;color234
+    editbold = color228;color151
+    editmarked = color30;color189
+    editwhitespace = color69;color234
+    editnonprintable = ;color30
+    editlinestate = color189;color69
+    bookmark = color189;color210
+    bookmarkfound = color30;color151
+    editrightmargin = color69;color30
+    editframeactive = color189;
+    editframedrag = color151;
+
+[viewer]
+    _default_ = color189;color234
+    viewbold = color228;color234
+    viewunderline = color210;color234
+    viewboldunderline = color228;color234
+    viewselected = color228;color189
+    viewframe = color189;color234
+
+[diffviewer]
+    changedline = color117;color232
+    changednew = color210;color232
+    changed = color117;color232
+    added = color120;color232
+    removed = color210;color232
+    error = color231;color52
+
+[widget-panel]
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
+
+[widget-scrollbar]
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/everforest256.ini
+++ b/misc/skins/everforest256.ini
@@ -1,0 +1,169 @@
+# Everforest theme for Midnight Commander
+# Based on the Everforest color scheme: https://github.com/sainnhe/everforest
+# A green based color scheme designed to be warm and soft
+
+[skin]
+    description = Everforest - Green based warm and soft color scheme
+    256colors = true
+
+[lines]
+    horiz = ─
+    vert = │
+    lefttop = ┌
+    righttop = ┐
+    leftbottom = └
+    rightbottom = ┘
+    topmiddle = ┬
+    bottommiddle = ┴
+    leftmiddle = ├
+    rightmiddle = ┤
+    cross = ┼
+    dhoriz = ─
+    dvert = │
+    dlefttop = ┌
+    drighttop = ┐
+    dleftbottom = └
+    drightbottom = ┘
+    dtopmiddle = ┬
+    dbottommiddle = ┴
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[core]
+    _default_ = color188;color235
+    selected = color235;color108
+    marked = color179;color235
+    markselect = color179;color108
+    gauge = color188;color237
+    input = color235;color108
+    inputunchanged = color245;color108
+    inputmark = color108;color235
+    disabled = color245;color248
+    reverse = color235;color188
+    hintbar = default;default
+    shellprompt = default;default
+    commandline = default;default
+    commandlinemark = color235;color188
+    header = color179;color235
+    inputhistory =
+    commandhistory =
+    shadow = color245;color16
+    frame = color188;color235
+
+[dialog]
+    _default_ = color235;color248
+    dfocus = color235;color108
+    dhotnormal = color167;color248
+    dhotfocus = color167;color108
+    dselnormal = color235;color108
+    dselfocus = color167;color108
+    dtitle = color167;color248
+    dframe = color235;color248
+
+[error]
+    _default_ = color188;color167
+    errdfocus = color235;color248
+    errdhotnormal = color179;color167
+    errdhotfocus = color179;color248
+    errdtitle = color179;color167
+    errdframe = color188;color167
+
+[filehighlight]
+    _default_ =
+    directory = color188;
+    executable = color175;
+    symlink = color245;
+    hardlink =
+    stalelink = color167;
+    device = color175;
+    special = color108;
+    core = color167;
+    temp = color245;
+    archive = color142;
+    doc = color179;
+    source = color116;
+    media = color142;
+    graph = color116;
+    database = color167;
+
+[menu]
+    _default_ = color188;color28
+    menusel = color188;color235
+    menuhot = color179;color28
+    menuhotsel = color179;color235
+    menuinactive = color235;color28
+    menuframe = color188;color28
+
+[popupmenu]
+    _default_ = color188;color28
+    menusel = color179;color235
+    menutitle = color179;color28
+    menuframe = color188;color28
+
+[buttonbar]
+    hotkey = color188;color235
+    button = color235;color108
+
+[statusbar]
+    _default_ = color235;color108
+
+[help]
+    _default_ = color235;color248
+    helpitalic = color167;color248
+    helpbold = color28;color248
+    helplink = color235;color108
+    helpslink = color179;color28
+    helptitle = color28;color248
+    helpframe = color235;color248
+
+[editor]
+    _default_ = color188;color235
+    editbold = color179;color142
+    editmarked = color235;color108
+    editwhitespace = color28;color235
+    editnonprintable = ;color235
+    editlinestate = color188;color108
+    bookmark = color188;color167
+    bookmarkfound = color235;color142
+    editrightmargin = color28;color235
+    editframeactive = color188;
+    editframedrag = color142;
+
+[viewer]
+    _default_ = color188;color235
+    viewbold = color179;color235
+    viewunderline = color167;color235
+    viewboldunderline = color179;color235
+    viewselected = color179;color108
+    viewframe = color188;color235
+
+[diffviewer]
+    added = color188;color142
+    changedline = color28;color108
+    changednew = color167;color108
+    changed = color188;color108
+    removed = color188;color167
+    error = color167;color248
+
+[widget-panel]
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
+
+[widget-scrollbar]
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/gruvbox256.ini
+++ b/misc/skins/gruvbox256.ini
@@ -1,0 +1,169 @@
+# Gruvbox Dark theme for Midnight Commander
+# Based on the Gruvbox color scheme: https://github.com/morhetz/gruvbox
+# Retro groove color scheme with warm colors
+
+[skin]
+    description = Gruvbox Dark - Retro groove color scheme
+    256colors = true
+
+[lines]
+    horiz = ─
+    vert = │
+    lefttop = ┌
+    righttop = ┐
+    leftbottom = └
+    rightbottom = ┘
+    topmiddle = ┬
+    bottommiddle = ┴
+    leftmiddle = ├
+    rightmiddle = ┤
+    cross = ┼
+    dhoriz = ─
+    dvert = │
+    dlefttop = ┌
+    drighttop = ┐
+    dleftbottom = └
+    drightbottom = ┘
+    dtopmiddle = ┬
+    dbottommiddle = ┴
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[core]
+    _default_ = color223;color235
+    selected = color235;color108
+    marked = color214;color235
+    markselect = color214;color108
+    gauge = color223;color237
+    input = color235;color108
+    inputunchanged = color245;color108
+    inputmark = color108;color235
+    disabled = color245;color248
+    reverse = color235;color223
+    hintbar = default;default
+    shellprompt = default;default
+    commandline = default;default
+    commandlinemark = color235;color223
+    header = color214;color235
+    inputhistory =
+    commandhistory =
+    shadow = color245;color16
+    frame = color223;color235
+
+[dialog]
+    _default_ = color235;color248
+    dfocus = color235;color108
+    dhotnormal = color167;color248
+    dhotfocus = color167;color108
+    dselnormal = color235;color108
+    dselfocus = color167;color108
+    dtitle = color167;color248
+    dframe = color235;color248
+
+[error]
+    _default_ = color223;color167
+    errdfocus = color235;color248
+    errdhotnormal = color214;color167
+    errdhotfocus = color214;color248
+    errdtitle = color214;color167
+    errdframe = color223;color167
+
+[filehighlight]
+    _default_ =
+    directory = color223;
+    executable = color175;
+    symlink = color245;
+    hardlink =
+    stalelink = color167;
+    device = color175;
+    special = color108;
+    core = color167;
+    temp = color245;
+    archive = color142;
+    doc = color172;
+    source = color108;
+    media = color142;
+    graph = color108;
+    database = color167;
+
+[menu]
+    _default_ = color223;color24
+    menusel = color223;color235
+    menuhot = color214;color24
+    menuhotsel = color214;color235
+    menuinactive = color235;color24
+    menuframe = color223;color24
+
+[popupmenu]
+    _default_ = color223;color24
+    menusel = color214;color235
+    menutitle = color214;color24
+    menuframe = color223;color24
+
+[buttonbar]
+    hotkey = color223;color235
+    button = color235;color108
+
+[statusbar]
+    _default_ = color235;color108
+
+[help]
+    _default_ = color235;color248
+    helpitalic = color167;color248
+    helpbold = color24;color248
+    helplink = color235;color108
+    helpslink = color214;color24
+    helptitle = color24;color248
+    helpframe = color235;color248
+
+[editor]
+    _default_ = color223;color235
+    editbold = color214;color142
+    editmarked = color235;color108
+    editwhitespace = color24;color235
+    editnonprintable = ;color235
+    editlinestate = color223;color108
+    bookmark = color223;color167
+    bookmarkfound = color235;color142
+    editrightmargin = color24;color235
+    editframeactive = color223;
+    editframedrag = color142;
+
+[viewer]
+    _default_ = color223;color235
+    viewbold = color214;color235
+    viewunderline = color167;color235
+    viewboldunderline = color214;color235
+    viewselected = color214;color108
+    viewframe = color223;color235
+
+[diffviewer]
+    added = color223;color142
+    changedline = color24;color108
+    changednew = color167;color108
+    changed = color223;color108
+    removed = color223;color167
+    error = color167;color248
+
+[widget-panel]
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
+
+[widget-scrollbar]
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/kanagawa256.ini
+++ b/misc/skins/kanagawa256.ini
@@ -1,0 +1,169 @@
+# Kanagawa theme for Midnight Commander
+# Based on the Kanagawa color scheme: https://github.com/rebelot/kanagawa.nvim
+# A color scheme inspired by the famous painting "The Great Wave off Kanagawa"
+
+[skin]
+    description = Kanagawa - Inspired by "The Great Wave off Kanagawa"
+    256colors = true
+
+[lines]
+    horiz = ─
+    vert = │
+    lefttop = ┌
+    righttop = ┐
+    leftbottom = └
+    rightbottom = ┘
+    topmiddle = ┬
+    bottommiddle = ┴
+    leftmiddle = ├
+    rightmiddle = ┤
+    cross = ┼
+    dhoriz = ─
+    dvert = │
+    dlefttop = ┌
+    drighttop = ┐
+    dleftbottom = └
+    drightbottom = ┘
+    dtopmiddle = ┬
+    dbottommiddle = ┴
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[core]
+    _default_ = color188;color235
+    selected = black;color66
+    marked = color222;color235
+    markselect = color222;color66
+    gauge = color188;color237
+    input = black;color66
+    inputunchanged = color245;color66
+    inputmark = color66;black
+    disabled = color245;color248
+    reverse = black;color188
+    hintbar = default;default
+    shellprompt = default;default
+    commandline = default;default
+    commandlinemark = black;color188
+    header = color222;color235
+    inputhistory =
+    commandhistory =
+    shadow = color245;black
+    frame = color188;color235
+
+[dialog]
+    _default_ = black;color248
+    dfocus = black;color66
+    dhotnormal = color167;color248
+    dhotfocus = color167;color66
+    dselnormal = black;color66
+    dselfocus = color167;color66
+    dtitle = color167;color248
+    dframe = black;color248
+
+[error]
+    _default_ = color188;color167
+    errdfocus = color235;color248
+    errdhotnormal = color222;color167
+    errdhotfocus = color222;color248
+    errdtitle = color222;color167
+    errdframe = color188;color167
+
+[filehighlight]
+    _default_ =
+    directory = color188;
+    executable = color175;
+    symlink = color245;
+    hardlink =
+    stalelink = color167;
+    device = color175;
+    special = color66;
+    core = color167;
+    temp = color245;
+    archive = color108;
+    doc = color180;
+    source = color116;
+    media = color108;
+    graph = color116;
+    database = color167;
+
+[menu]
+    _default_ = color188;color24
+    menusel = color188;color235
+    menuhot = color222;color24
+    menuhotsel = color222;color235
+    menuinactive = color235;color24
+    menuframe = color188;color24
+
+[popupmenu]
+    _default_ = color188;color24
+    menusel = color222;color235
+    menutitle = color222;color24
+    menuframe = color188;color24
+
+[buttonbar]
+    hotkey = color188;color235
+    button = color235;color66
+
+[statusbar]
+    _default_ = color235;color66
+
+[help]
+    _default_ = color235;color248
+    helpitalic = color167;color248
+    helpbold = color24;color248
+    helplink = color235;color66
+    helpslink = color222;color24
+    helptitle = color24;color248
+    helpframe = color235;color248
+
+[editor]
+    _default_ = color188;color235
+    editbold = color222;color108
+    editmarked = color235;color66
+    editwhitespace = color24;color235
+    editnonprintable = ;color235
+    editlinestate = color188;color66
+    bookmark = color188;color167
+    bookmarkfound = color235;color108
+    editrightmargin = color24;color235
+    editframeactive = color188;
+    editframedrag = color108;
+
+[viewer]
+    _default_ = color188;color235
+    viewbold = color222;color235
+    viewunderline = color167;color235
+    viewboldunderline = color222;color235
+    viewselected = color222;color66
+    viewframe = color188;color235
+
+[diffviewer]
+    added = color188;color108
+    changedline = color24;color66
+    changednew = color167;color66
+    changed = color188;color66
+    removed = color188;color167
+    error = color167;color248
+
+[widget-panel]
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
+
+[widget-scrollbar]
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/matte-black256.ini
+++ b/misc/skins/matte-black256.ini
@@ -1,0 +1,168 @@
+# Matte Black theme for Midnight Commander
+# A sleek, minimalist black theme with subtle accents
+
+[skin]
+    description = Matte Black - Sleek minimalist black theme
+    256colors = true
+
+[lines]
+    horiz = ─
+    vert = │
+    lefttop = ┌
+    righttop = ┐
+    leftbottom = └
+    rightbottom = ┘
+    topmiddle = ┬
+    bottommiddle = ┴
+    leftmiddle = ├
+    rightmiddle = ┤
+    cross = ┼
+    dhoriz = ─
+    dvert = │
+    dlefttop = ┌
+    drighttop = ┐
+    dleftbottom = └
+    drightbottom = ┘
+    dtopmiddle = ┬
+    dbottommiddle = ┴
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[core]
+    _default_ = color250;color232
+    selected = color232;color240
+    marked = color255;color232
+    markselect = color255;color240
+    gauge = color250;color235
+    input = color232;color240
+    inputunchanged = color244;color240
+    inputmark = color240;color232
+    disabled = color244;color248
+    reverse = color232;color250
+    hintbar = default;default
+    shellprompt = default;default
+    commandline = default;default
+    commandlinemark = color232;color250
+    header = color255;color232
+    inputhistory =
+    commandhistory =
+    shadow = color244;color16
+    frame = color250;color232
+
+[dialog]
+    _default_ = color232;color248
+    dfocus = color232;color240
+    dhotnormal = color255;color248
+    dhotfocus = color255;color240
+    dselnormal = color232;color240
+    dselfocus = color255;color240
+    dtitle = color255;color248
+    dframe = color232;color248
+
+[error]
+    _default_ = color250;color196
+    errdfocus = color232;color248
+    errdhotnormal = color255;color196
+    errdhotfocus = color255;color248
+    errdtitle = color255;color196
+    errdframe = color250;color196
+
+[filehighlight]
+    _default_ =
+    directory = color250;
+    executable = color82;
+    symlink = color244;
+    hardlink =
+    stalelink = color196;
+    device = color201;
+    special = color240;
+    core = color196;
+    temp = color244;
+    archive = color201;
+    doc = color226;
+    source = color81;
+    media = color82;
+    graph = color81;
+    database = color196;
+
+[menu]
+    _default_ = color250;color235
+    menusel = color250;color232
+    menuhot = color255;color235
+    menuhotsel = color255;color232
+    menuinactive = color232;color235
+    menuframe = color250;color235
+
+[popupmenu]
+    _default_ = color250;color235
+    menusel = color255;color232
+    menutitle = color255;color235
+    menuframe = color250;color235
+
+[buttonbar]
+    hotkey = color250;color232
+    button = color232;color240
+
+[statusbar]
+    _default_ = color232;color240
+
+[help]
+    _default_ = color232;color248
+    helpitalic = color196;color248
+    helpbold = color255;color248
+    helplink = color232;color240
+    helpslink = color255;color235
+    helptitle = color255;color248
+    helpframe = color232;color248
+
+[editor]
+    _default_ = color250;color232
+    editbold = color255;color82
+    editmarked = color232;color240
+    editwhitespace = color235;color232
+    editnonprintable = ;color232
+    editlinestate = color250;color240
+    bookmark = color250;color196
+    bookmarkfound = color232;color82
+    editrightmargin = color235;color232
+    editframeactive = color250;
+    editframedrag = color82;
+
+[viewer]
+    _default_ = color250;color232
+    viewbold = color255;color232
+    viewunderline = color196;color232
+    viewboldunderline = color255;color232
+    viewselected = color255;color240
+    viewframe = color250;color232
+
+[diffviewer]
+    added = color255;color22
+    changedline = color255;color232
+    changednew = color196;color232
+    changed = color255;color17
+    removed = color255;color52
+    error = color196;color232
+
+[widget-panel]
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
+
+[widget-scrollbar]
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/nord256.ini
+++ b/misc/skins/nord256.ini
@@ -1,0 +1,169 @@
+# Nord theme for Midnight Commander
+# Based on the Nord color scheme: https://www.nordtheme.com/
+# An arctic, north-bluish color palette
+
+[skin]
+    description = Nord - Arctic, north-bluish color palette
+    256colors = true
+
+[lines]
+    horiz = ─
+    vert = │
+    lefttop = ┌
+    righttop = ┐
+    leftbottom = └
+    rightbottom = ┘
+    topmiddle = ┬
+    bottommiddle = ┴
+    leftmiddle = ├
+    rightmiddle = ┤
+    cross = ┼
+    dhoriz = ─
+    dvert = │
+    dlefttop = ┌
+    drighttop = ┐
+    dleftbottom = └
+    drightbottom = ┘
+    dtopmiddle = ┬
+    dbottommiddle = ┴
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[core]
+    _default_ = color188;color236
+    selected = color236;color109
+    marked = color222;color236
+    markselect = color222;color109
+    gauge = color188;color240
+    input = color236;color109
+    inputunchanged = color245;color109
+    inputmark = color109;color236
+    disabled = color245;color252
+    reverse = color236;color188
+    hintbar = default;default
+    shellprompt = default;default
+    commandline = default;default
+    commandlinemark = color236;color188
+    header = color222;color236
+    inputhistory =
+    commandhistory =
+    shadow = color245;color16
+    frame = color188;color236
+
+[dialog]
+    _default_ = color236;color252
+    dfocus = color236;color109
+    dhotnormal = color167;color252
+    dhotfocus = color167;color109
+    dselnormal = color236;color109
+    dselfocus = color167;color109
+    dtitle = color167;color252
+    dframe = color236;color252
+
+[error]
+    _default_ = color188;color167
+    errdfocus = color236;color252
+    errdhotnormal = color222;color167
+    errdhotfocus = color222;color252
+    errdtitle = color222;color167
+    errdframe = color188;color167
+
+[filehighlight]
+    _default_ =
+    directory = color188;
+    executable = color139;
+    symlink = color245;
+    hardlink =
+    stalelink = color167;
+    device = color139;
+    special = color109;
+    core = color167;
+    temp = color245;
+    archive = color139;
+    doc = color180;
+    source = color109;
+    media = color108;
+    graph = color116;
+    database = color167;
+
+[menu]
+    _default_ = color188;color24
+    menusel = color188;color236
+    menuhot = color222;color24
+    menuhotsel = color222;color236
+    menuinactive = color236;color24
+    menuframe = color188;color24
+
+[popupmenu]
+    _default_ = color188;color24
+    menusel = color222;color236
+    menutitle = color222;color24
+    menuframe = color188;color24
+
+[buttonbar]
+    hotkey = color188;color236
+    button = color236;color109
+
+[statusbar]
+    _default_ = color236;color109
+
+[help]
+    _default_ = color236;color252
+    helpitalic = color167;color252
+    helpbold = color24;color252
+    helplink = color236;color109
+    helpslink = color222;color24
+    helptitle = color24;color252
+    helpframe = color236;color252
+
+[editor]
+    _default_ = color188;color236
+    editbold = color222;color108
+    editmarked = color236;color109
+    editwhitespace = color24;color236
+    editnonprintable = ;color236
+    editlinestate = color188;color109
+    bookmark = color188;color167
+    bookmarkfound = color236;color108
+    editrightmargin = color24;color236
+    editframeactive = color188;
+    editframedrag = color108;
+
+[viewer]
+    _default_ = color188;color236
+    viewbold = color222;color236
+    viewunderline = color167;color236
+    viewboldunderline = color222;color236
+    viewselected = color222;color109
+    viewframe = color188;color236
+
+[diffviewer]
+    added = color188;color108
+    changedline = color24;color109
+    changednew = color167;color109
+    changed = color188;color109
+    removed = color188;color167
+    error = color167;color252
+
+[widget-panel]
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
+
+[widget-scrollbar]
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/osaka-jade256.ini
+++ b/misc/skins/osaka-jade256.ini
@@ -1,0 +1,168 @@
+# Osaka Jade theme for Midnight Commander
+# A dark theme with jade green accents inspired by Japanese aesthetics
+
+[skin]
+    description = Osaka Jade - Dark theme with jade green accents
+    256colors = true
+
+[lines]
+    horiz = ─
+    vert = │
+    lefttop = ┌
+    righttop = ┐
+    leftbottom = └
+    rightbottom = ┘
+    topmiddle = ┬
+    bottommiddle = ┴
+    leftmiddle = ├
+    rightmiddle = ┤
+    cross = ┼
+    dhoriz = ─
+    dvert = │
+    dlefttop = ┌
+    drighttop = ┐
+    dleftbottom = └
+    drightbottom = ┘
+    dtopmiddle = ┬
+    dbottommiddle = ┴
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[core]
+    _default_ = color188;color235
+    selected = color235;color66
+    marked = color120;color235
+    markselect = color120;color66
+    gauge = color188;color237
+    input = color235;color66
+    inputunchanged = color245;color66
+    inputmark = color66;color235
+    disabled = color245;color248
+    reverse = color235;color188
+    hintbar = default;default
+    shellprompt = default;default
+    commandline = default;default
+    commandlinemark = color235;color188
+    header = color120;color235
+    inputhistory =
+    commandhistory =
+    shadow = color245;color16
+    frame = color188;color235
+
+[dialog]
+    _default_ = color235;color248
+    dfocus = color235;color66
+    dhotnormal = color167;color248
+    dhotfocus = color167;color66
+    dselnormal = color235;color66
+    dselfocus = color167;color66
+    dtitle = color167;color248
+    dframe = color235;color248
+
+[error]
+    _default_ = color188;color167
+    errdfocus = color235;color248
+    errdhotnormal = color120;color167
+    errdhotfocus = color120;color248
+    errdtitle = color120;color167
+    errdframe = color188;color167
+
+[filehighlight]
+    _default_ =
+    directory = color188;
+    executable = color119;
+    symlink = color245;
+    hardlink =
+    stalelink = color167;
+    device = color175;
+    special = color66;
+    core = color167;
+    temp = color245;
+    archive = color120;
+    doc = color180;
+    source = color116;
+    media = color119;
+    graph = color116;
+    database = color167;
+
+[menu]
+    _default_ = color188;color22
+    menusel = color188;color235
+    menuhot = color120;color22
+    menuhotsel = color120;color235
+    menuinactive = color235;color22
+    menuframe = color188;color22
+
+[popupmenu]
+    _default_ = color188;color22
+    menusel = color120;color235
+    menutitle = color120;color22
+    menuframe = color188;color22
+
+[buttonbar]
+    hotkey = color188;color235
+    button = color235;color66
+
+[statusbar]
+    _default_ = color235;color66
+
+[help]
+    _default_ = color235;color248
+    helpitalic = color167;color248
+    helpbold = color22;color248
+    helplink = color235;color66
+    helpslink = color120;color22
+    helptitle = color22;color248
+    helpframe = color235;color248
+
+[editor]
+    _default_ = color188;color235
+    editbold = color120;color119
+    editmarked = color235;color66
+    editwhitespace = color22;color235
+    editnonprintable = ;color235
+    editlinestate = color188;color66
+    bookmark = color188;color167
+    bookmarkfound = color235;color119
+    editrightmargin = color22;color235
+    editframeactive = color188;
+    editframedrag = color119;
+
+[viewer]
+    _default_ = color188;color235
+    viewbold = color120;color235
+    viewunderline = color167;color235
+    viewboldunderline = color120;color235
+    viewselected = color120;color66
+    viewframe = color188;color235
+
+[diffviewer]
+    added = color255;color22
+    changedline = color255;color232
+    changednew = color167;color232
+    changed = color255;color17
+    removed = color255;color52
+    error = color167;color232
+
+[widget-panel]
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
+
+[widget-scrollbar]
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/ristretto256.ini
+++ b/misc/skins/ristretto256.ini
@@ -1,0 +1,168 @@
+# Ristretto theme for Midnight Commander
+# A warm, coffee-inspired dark theme with rich brown and cream tones
+
+[skin]
+    description = Ristretto - Warm coffee-inspired dark theme
+    256colors = true
+
+[lines]
+    horiz = ─
+    vert = │
+    lefttop = ┌
+    righttop = ┐
+    leftbottom = └
+    rightbottom = ┘
+    topmiddle = ┬
+    bottommiddle = ┴
+    leftmiddle = ├
+    rightmiddle = ┤
+    cross = ┼
+    dhoriz = ─
+    dvert = │
+    dlefttop = ┌
+    drighttop = ┐
+    dleftbottom = └
+    drightbottom = ┘
+    dtopmiddle = ┬
+    dbottommiddle = ┴
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[core]
+    _default_ = color187;color52
+    selected = color52;color94
+    marked = color222;color52
+    markselect = color222;color94
+    gauge = color187;color58
+    input = color52;color94
+    inputunchanged = color245;color94
+    inputmark = color94;color52
+    disabled = color245;color248
+    reverse = color52;color187
+    hintbar = default;default
+    shellprompt = default;default
+    commandline = default;default
+    commandlinemark = color52;color187
+    header = color222;color52
+    inputhistory =
+    commandhistory =
+    shadow = color245;color16
+    frame = color187;color52
+
+[dialog]
+    _default_ = color52;color248
+    dfocus = color52;color94
+    dhotnormal = color203;color248
+    dhotfocus = color203;color94
+    dselnormal = color52;color94
+    dselfocus = color203;color94
+    dtitle = color203;color248
+    dframe = color52;color248
+
+[error]
+    _default_ = color187;color203
+    errdfocus = color52;color248
+    errdhotnormal = color222;color203
+    errdhotfocus = color222;color248
+    errdtitle = color222;color203
+    errdframe = color187;color203
+
+[filehighlight]
+    _default_ =
+    directory = color187;
+    executable = color119;
+    symlink = color245;
+    hardlink =
+    stalelink = color203;
+    device = color219;
+    special = color94;
+    core = color203;
+    temp = color245;
+    archive = color180;
+    doc = color222;
+    source = color116;
+    media = color119;
+    graph = color116;
+    database = color203;
+
+[menu]
+    _default_ = color187;color58
+    menusel = color187;color52
+    menuhot = color222;color58
+    menuhotsel = color222;color52
+    menuinactive = color52;color58
+    menuframe = color187;color58
+
+[popupmenu]
+    _default_ = color187;color58
+    menusel = color222;color52
+    menutitle = color222;color58
+    menuframe = color187;color58
+
+[buttonbar]
+    hotkey = color187;color52
+    button = color52;color94
+
+[statusbar]
+    _default_ = color52;color94
+
+[help]
+    _default_ = color52;color248
+    helpitalic = color203;color248
+    helpbold = color58;color248
+    helplink = color52;color94
+    helpslink = color222;color58
+    helptitle = color58;color248
+    helpframe = color52;color248
+
+[editor]
+    _default_ = color187;color52
+    editbold = color222;color119
+    editmarked = color52;color94
+    editwhitespace = color58;color52
+    editnonprintable = ;color52
+    editlinestate = color187;color94
+    bookmark = color187;color203
+    bookmarkfound = color52;color119
+    editrightmargin = color58;color52
+    editframeactive = color187;
+    editframedrag = color119;
+
+[viewer]
+    _default_ = color187;color52
+    viewbold = color222;color52
+    viewunderline = color203;color52
+    viewboldunderline = color222;color52
+    viewselected = color222;color94
+    viewframe = color187;color52
+
+[diffviewer]
+    added = color255;color22
+    changedline = color255;color232
+    changednew = color203;color232
+    changed = color255;color17
+    removed = color255;color52
+    error = color203;color232
+
+[widget-panel]
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
+
+[widget-scrollbar]
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/rose-pine256.ini
+++ b/misc/skins/rose-pine256.ini
@@ -1,0 +1,169 @@
+# Rose Pine theme for Midnight Commander
+# Based on the Rose Pine color scheme: https://rosepinetheme.com/
+# A soho vibes color scheme with warm colors
+
+[skin]
+    description = Rose Pine - Soho vibes with warm colors
+    256colors = true
+
+[lines]
+    horiz = ─
+    vert = │
+    lefttop = ┌
+    righttop = ┐
+    leftbottom = └
+    rightbottom = ┘
+    topmiddle = ┬
+    bottommiddle = ┴
+    leftmiddle = ├
+    rightmiddle = ┤
+    cross = ┼
+    dhoriz = ─
+    dvert = │
+    dlefttop = ┌
+    drighttop = ┐
+    dleftbottom = └
+    drightbottom = ┘
+    dtopmiddle = ┬
+    dbottommiddle = ┴
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[core]
+    _default_ = color188;color235
+    selected = black;color139
+    marked = color222;color235
+    markselect = color222;color139
+    gauge = color188;color237
+    input = black;color139
+    inputunchanged = color245;color139
+    inputmark = color139;black
+    disabled = color245;color248
+    reverse = black;color188
+    hintbar = default;default
+    shellprompt = default;default
+    commandline = default;default
+    commandlinemark = black;color188
+    header = color222;color235
+    inputhistory =
+    commandhistory =
+    shadow = color245;black
+    frame = color188;color235
+
+[dialog]
+    _default_ = black;color248
+    dfocus = black;color139
+    dhotnormal = color203;color248
+    dhotfocus = color203;color139
+    dselnormal = black;color139
+    dselfocus = color203;color139
+    dtitle = color203;color248
+    dframe = black;color248
+
+[error]
+    _default_ = color188;color203
+    errdfocus = color235;color248
+    errdhotnormal = color222;color203
+    errdhotfocus = color222;color248
+    errdtitle = color222;color203
+    errdframe = color188;color203
+
+[filehighlight]
+    _default_ =
+    directory = color188;
+    executable = color183;
+    symlink = color245;
+    hardlink =
+    stalelink = color203;
+    device = color219;
+    special = color139;
+    core = color203;
+    temp = color245;
+    archive = color180;
+    doc = color222;
+    source = color117;
+    media = color183;
+    graph = color117;
+    database = color203;
+
+[menu]
+    _default_ = color188;color96
+    menusel = color188;color235
+    menuhot = color222;color96
+    menuhotsel = color222;color235
+    menuinactive = color235;color96
+    menuframe = color188;color96
+
+[popupmenu]
+    _default_ = color188;color96
+    menusel = color222;color235
+    menutitle = color222;color96
+    menuframe = color188;color96
+
+[buttonbar]
+    hotkey = color188;color235
+    button = color235;color139
+
+[statusbar]
+    _default_ = color235;color139
+
+[help]
+    _default_ = color235;color248
+    helpitalic = color203;color248
+    helpbold = color96;color248
+    helplink = color235;color139
+    helpslink = color222;color96
+    helptitle = color96;color248
+    helpframe = color235;color248
+
+[editor]
+    _default_ = color188;color235
+    editbold = color222;color183
+    editmarked = color235;color139
+    editwhitespace = color96;color235
+    editnonprintable = ;color235
+    editlinestate = color188;color139
+    bookmark = color188;color203
+    bookmarkfound = color235;color183
+    editrightmargin = color96;color235
+    editframeactive = color188;
+    editframedrag = color183;
+
+[viewer]
+    _default_ = color188;color235
+    viewbold = color222;color235
+    viewunderline = color203;color235
+    viewboldunderline = color222;color235
+    viewselected = color222;color139
+    viewframe = color188;color235
+
+[diffviewer]
+    added = color255;color22
+    changedline = color255;color232
+    changednew = color203;color232
+    changed = color255;color17
+    removed = color255;color52
+    error = color203;color232
+
+[widget-panel]
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
+
+[widget-scrollbar]
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕

--- a/misc/skins/tokyo-night256.ini
+++ b/misc/skins/tokyo-night256.ini
@@ -1,0 +1,169 @@
+# Tokyo Night theme for Midnight Commander
+# Based on the Tokyo Night color scheme: https://github.com/folke/tokyonight.nvim
+# A clean, dark theme inspired by Tokyo's neon lights
+
+[skin]
+    description = Tokyo Night - Clean dark theme inspired by Tokyo's neon lights
+    256colors = true
+
+[lines]
+    horiz = ─
+    vert = │
+    lefttop = ┌
+    righttop = ┐
+    leftbottom = └
+    rightbottom = ┘
+    topmiddle = ┬
+    bottommiddle = ┴
+    leftmiddle = ├
+    rightmiddle = ┤
+    cross = ┼
+    dhoriz = ─
+    dvert = │
+    dlefttop = ┌
+    drighttop = ┐
+    dleftbottom = └
+    drightbottom = ┘
+    dtopmiddle = ┬
+    dbottommiddle = ┴
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[core]
+    _default_ = color147;color234
+    selected = black;color69
+    marked = color221;color234
+    markselect = color221;color69
+    gauge = color147;color237
+    input = black;color69
+    inputunchanged = color244;color69
+    inputmark = color69;black
+    disabled = color244;color252
+    reverse = black;color147
+    hintbar = default;default
+    shellprompt = default;default
+    commandline = default;default
+    commandlinemark = black;color147
+    header = color221;color234
+    inputhistory =
+    commandhistory =
+    shadow = color244;black
+    frame = color147;color234
+
+[dialog]
+    _default_ = black;color252
+    dfocus = black;color69
+    dhotnormal = color203;color252
+    dhotfocus = color203;color69
+    dselnormal = black;color69
+    dselfocus = color203;color69
+    dtitle = color203;color252
+    dframe = black;color252
+
+[error]
+    _default_ = color147;color203
+    errdfocus = color234;color252
+    errdhotnormal = color221;color203
+    errdhotfocus = color221;color252
+    errdtitle = color221;color203
+    errdframe = color147;color203
+
+[filehighlight]
+    _default_ =
+    directory = color147;
+    executable = color183;
+    symlink = color244;
+    hardlink =
+    stalelink = color203;
+    device = color183;
+    special = color69;
+    core = color203;
+    temp = color244;
+    archive = color148;
+    doc = color179;
+    source = color117;
+    media = color148;
+    graph = color117;
+    database = color203;
+
+[menu]
+    _default_ = color147;color69
+    menusel = color147;color234
+    menuhot = color221;color69
+    menuhotsel = color221;color234
+    menuinactive = color234;color69
+    menuframe = color147;color69
+
+[popupmenu]
+    _default_ = color147;color69
+    menusel = color221;color234
+    menutitle = color221;color69
+    menuframe = color147;color69
+
+[buttonbar]
+    hotkey = color147;color234
+    button = color234;color69
+
+[statusbar]
+    _default_ = color234;color69
+
+[help]
+    _default_ = color234;color252
+    helpitalic = color203;color252
+    helpbold = color69;color252
+    helplink = color234;color69
+    helpslink = color221;color69
+    helptitle = color69;color252
+    helpframe = color234;color252
+
+[editor]
+    _default_ = color147;color234
+    editbold = color221;color148
+    editmarked = color234;color69
+    editwhitespace = color69;color234
+    editnonprintable = ;color234
+    editlinestate = color147;color69
+    bookmark = color147;color203
+    bookmarkfound = color234;color148
+    editrightmargin = color69;color234
+    editframeactive = color147;
+    editframedrag = color148;
+
+[viewer]
+    _default_ = color147;color234
+    viewbold = color221;color234
+    viewunderline = color203;color234
+    viewboldunderline = color221;color234
+    viewselected = color221;color69
+    viewframe = color147;color234
+
+[diffviewer]
+    added = color255;color22
+    changedline = color255;color232
+    changednew = color203;color232
+    changed = color255;color17
+    removed = color255;color52
+    error = color203;color232
+
+[widget-panel]
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ↓
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
+
+[widget-scrollbar]
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕


### PR DESCRIPTION
## Summary
- Add 11 contemporary color scheme skins including popular themes like Catppuccin, Gruvbox, Nord, Tokyo Night, and others
- Update Makefile.am to include new skin files in distribution
- Provide modern color options for MC users who prefer contemporary terminal themes

## Test plan
- [ ] Verify all skins load correctly with `mc -S <skin-name>`
- [ ] Test color rendering in different terminal environments
- [ ] Confirm Makefile.am includes all new skin files for proper distribution
- [ ] Validate skin syntax and color definitions

## New skins added
- catppuccin.ini (mocha variant)
- catppuccin-latte.ini (light variant)
- everforest.ini
- gruvbox.ini
- kanagawa.ini
- matte-black.ini
- nord.ini
- osaka-jade.ini
- ristretto.ini
- rose-pine.ini
- tokyo-night.ini