### PR TITLE
syntax: basic conf-file coloring and support for Dockerfile

### DIFF
--- a/misc/syntax/Makefile.am
+++ b/misc/syntax/Makefile.am
@@ -15,6 +15,7 @@ SYNTAXFILES =			\
 	changelog.syntax	\
 	cmake.syntax		\
 	cobol.syntax		\
+	conf.syntax		\
 	cs.syntax		\
 	css.syntax		\
 	cuda.syntax		\

--- a/misc/syntax/Makefile.am
+++ b/misc/syntax/Makefile.am
@@ -28,6 +28,7 @@ SYNTAXFILES =			\
 	debian-sources-list.syntax	\
 	diff.syntax		\
 	dlink.syntax		\
+	dockerfile.syntax	\
 	dos.syntax		\
 	dot.syntax		\
 	ebuild.syntax		\

--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -357,5 +357,8 @@ include toml.syntax
 file .\*\\.(mch|ref|imp)$ B\sFile
 include b.syntax
 
+file ..\*\\.(?i:cfg|cnf|conf)$ Config\sfile
+include conf.syntax
+
 file .\* unknown
 include unknown.syntax

--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -360,5 +360,8 @@ include b.syntax
 file ..\*\\.(?i:cfg|cnf|conf)$ Config\sfile
 include conf.syntax
 
+file Dockerfile.\*$ Dockerfile
+include dockerfile.syntax
+
 file .\* unknown
 include unknown.syntax

--- a/misc/syntax/conf.syntax
+++ b/misc/syntax/conf.syntax
@@ -1,0 +1,36 @@
+#
+# Simple syntax coloring for most config files (.cfg .conf)
+#
+# The objective is to highlight #-comments, parens and numbers/strings to make files easier to read
+#
+
+context default
+    keyword ; brightcyan
+    keyword ( brightcyan
+    keyword ) brightcyan
+    keyword { brightcyan
+    keyword } brightcyan
+    keyword [ brightcyan
+    keyword ] brightcyan
+    keyword = white
+
+    keyword whole \{0123456789\}\[0123456789\] brightgreen
+
+wholechars abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._
+
+# String values
+context ' ' green
+context " " green
+
+# Comments
+context # \n brown
+    keyword whole BUG brightred
+    keyword whole FixMe brightred
+    keyword whole FIXME brightred
+    keyword whole Note brightred
+    keyword whole NOTE brightred
+    keyword whole ToDo brightred
+    keyword whole TODO brightred
+    keyword !!\[!\] brightred
+    keyword ??\[?\] brightred
+    spellcheck

--- a/misc/syntax/dockerfile.syntax
+++ b/misc/syntax/dockerfile.syntax
@@ -1,0 +1,76 @@
+# Syntax coloring for Dockerfile
+# https://docs.docker.com/reference/dockerfile
+
+context default
+    keyword ADD yellow
+    keyword ARG yellow
+    keyword CMD yellow
+    keyword COPY yellow
+    keyword ENTRYPOINT yellow
+    keyword ENV yellow
+    keyword EXPOSE yellow
+    keyword FROM yellow
+    keyword HEALTHCHECK yellow
+    keyword LABEL yellow
+    keyword ONBUILD yellow
+    keyword RUN yellow
+    keyword SHELL yellow
+    keyword STOPSIGNAL yellow
+    keyword USER yellow
+    keyword VOLUME yellow
+    keyword WORKDIR yellow
+    # deprecated things
+    keyword MAINTAINER brightred
+
+    # Options for RUN
+    keyword --mount brightmagenta
+    keyword --device brightmagenta
+    keyword --network brightmagenta
+    keyword --security brightmagenta
+
+    # Options for ADD
+    keyword --keep-git-dir brightmagenta
+    keyword --checksum brightmagenta
+    keyword --chown brightmagenta
+    keyword --chmod brightmagenta
+    keyword --link brightmagenta
+    keyword --exclude brightmagenta
+
+    # Options for COPY (some already in ADD)
+    keyword --from brightmagenta
+    keyword --parents brightmagenta
+
+    keyword ; brightcyan
+    keyword ( brightcyan
+    keyword ) brightcyan
+    keyword { brightcyan
+    keyword } brightcyan
+    keyword [ brightcyan
+    keyword ] brightcyan
+    keyword = white
+    keyword && white
+    keyword || white
+    keyword \\$ white
+    keyword ${*} brightgreen
+
+    keyword whole \{0123456789\}\[0123456789\] brightgreen
+    keyword wholeright $+ brightgreen
+
+wholechars abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._
+
+# String values
+context ' ' green
+context " " green
+
+# Comments
+context # \n brown
+    keyword whole BUG brightred
+    keyword whole FixMe brightred
+    keyword whole FIXME brightred
+    keyword whole Note brightred
+    keyword whole NOTE brightred
+    keyword whole ToDo brightred
+    keyword whole TODO brightred
+    keyword !!\[!\] brightred
+    keyword ??\[?\] brightred
+    spellcheck


### PR DESCRIPTION
## Proposed changes

Add basic syntax coloring support for most config files (*.cfg/*.conf)