### PR TITLE
Ticket #4443: Set the terminal's pixel size for the subshell

### DIFF
--- a/lib/tty/tty.c
+++ b/lib/tty/tty.c
@@ -338,10 +338,10 @@ tty_resize (int fd)
 #if defined TIOCSWINSZ
     struct winsize tty_size;
 
-    tty_size.ws_row = LINES;
-    tty_size.ws_col = COLS;
-    tty_size.ws_xpixel = tty_size.ws_ypixel = 0;
-
+    /* Make sure to copy to the inner terminal all the fields, even the ones we don't care about,
+     * including ws_xpixel and ws_ypixel. */
+    if (ioctl (STDOUT_FILENO, TIOCGWINSZ, &tty_size) == -1)
+        return -1;
     return ioctl (fd, TIOCSWINSZ, &tty_size);
 #else
     return 0;


### PR DESCRIPTION
If the host terminal sets the pixel size values (ws_xpixel, ws_ypixel) then forward them to the inner terminal for the subshell and its apps.

## Proposed changes

Copy the entire structure, not just the two fields we use.

Resolves: #4443

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
