### PR TITLE
Ticket #4096: use `set_escdelay` interface instead of `ESCDELAY` var

### DIFF
--- a/lib/tty/tty-ncurses.c
+++ b/lib/tty/tty-ncurses.c
@@ -230,17 +230,17 @@ tty_init (gboolean mouse_enable, gboolean is_xterm)
 
     initscr ();
 
-#ifdef HAVE_ESCDELAY
+#ifdef HAVE_SET_ESCDELAY
     /*
-     * If ncurses exports the ESCDELAY variable, it should be set to
-     * a low value, or you'll experience a delay in processing escape
-     * sequences that are recognized by mc (e.g. Esc-Esc).  On the other
-     * hand, making ESCDELAY too small can result in some sequences
-     * (e.g. cursor arrows) being reported as separate keys under heavy
-     * processor load, and this can be a problem if mc hasn't learned
-     * them in the "Learn Keys" dialog.  The value is in milliseconds.
+     * ESCDELAY variable should be set to a low value, or you'll experience a
+     * delay in processing escape sequences recognized by mc (e.g. Esc-Esc).
+     * Making ESCDELAY too small can result in some sequences (like cursor
+     * arrows) being reported as separate keys under heavy processor load,
+     * and this can be a problem if mc hasn't learned them in the "Learn Keys"
+     * dialog. The value is in milliseconds (AIX defaults to 0.1s, ncurses 1s).
      */
-    ESCDELAY = 200;
+    if (g_getenv ("ESCDELAY") == NULL)
+        set_escdelay (100);
 #endif
 
     tcgetattr (STDIN_FILENO, &mode);

--- a/m4.include/mc-with-screen-ncurses.m4
+++ b/m4.include/mc-with-screen-ncurses.m4
@@ -107,18 +107,7 @@ AC_DEFUN([mc_WITH_NCURSES], [
     AS_IF([test x"$ncurses_term_h_found" != xyes],
         [AC_MSG_ERROR([NCurses(w) term.h header file not found])])
 
-    dnl If ncurses exports the ESCDELAY variable it should be set to 0
-    dnl or you'll have to press Esc three times to dismiss a dialog box.
-    AC_CACHE_CHECK([for ESCDELAY variable], [mc_cv_ncurses_escdelay],
-        [AC_LINK_IFELSE(
-            [AC_LANG_PROGRAM([[extern int ESCDELAY;]],[[ESCDELAY = 0;]])],
-            [mc_cv_ncurses_escdelay=yes], [mc_cv_ncurses_escdelay=no])
-        ])
-
-    AS_IF([test x"$mc_cv_ncurses_escdelay" = xyes],
-        [AC_DEFINE([HAVE_ESCDELAY], [1], [Define if NCurses(w) has ESCDELAY variable])])
-
-    AC_CHECK_FUNCS(resizeterm)
+    AC_CHECK_FUNCS([resizeterm set_escdelay])
 
     AC_DEFINE([HAVE_NCURSES], [1], [Define to use NCurses for screen management])
     AC_DEFINE_UNQUOTED([NCURSES_LIB_DISPLAYNAME], ["$screen_msg"], [Define NCurses library display name])


### PR DESCRIPTION
## Proposed changes

Refs: #4096

This doesn't solve the ESC / Meta confounding on `ncurses`, but it switches to a new interface and aligns the default with AIX (100 ms or 0.1 s).