### PR TITLE
Ticket #4144: fix build with ncurses-5.9

### DIFF
--- a/lib/tty/tty-ncurses.h
+++ b/lib/tty/tty-ncurses.h
@@ -27,7 +27,7 @@
 #endif
 
 /* do not draw shadows if NCurses is built with --disable-widec */
-#if defined(NCURSES_WIDECHAR) && NCURSES_WIDECHAR
+#if defined(NCURSES_WIDECHAR) && (NCURSES_WIDECHAR - 0 < 1)
 #define ENABLE_SHADOWS 1
 #endif
 


### PR DESCRIPTION
In some versions, `NCURSES_WIDECHAR` can be defined but empty, so treat it as undefined in this case. This seems to be supported by the latest ncurses source code, which uses the following condition in tests:

```
defined(NCURSES_WIDECHAR) && (NCURSES_WIDECHAR - 0 < 1)
```

Resolves: #4144
