### PR TITLE
Ticket #4801: invalid utf-8 in prompt

### DIFF
--- a/lib/terminal.c
+++ b/lib/terminal.c
@@ -238,7 +238,8 @@ strip_ctrl_codes (char *s)
         }
         else
         {
-            const char *n = str_cget_next_char (r);
+            // FIXME Improve the handling of invalid UTF-8, insert a replacement symbol (#4801)
+            const char *n = str_cget_next_char_safe (r);
 
             if (str_isprint (r))
             {

--- a/lib/terminal.c
+++ b/lib/terminal.c
@@ -237,17 +237,9 @@ strip_ctrl_codes (char *s)
                 r++;
         }
         else
-        {
-            // FIXME Improve the handling of invalid UTF-8, insert a replacement symbol (#4801)
-            const char *n = str_cget_next_char_safe (r);
-
-            if (str_isprint (r))
-            {
-                memmove (w, r, n - r);
-                w += n - r;
-            }
-            r = n;
-        }
+            // Copy byte by byte, thereby letting mc use its standard mechanism to denote invalid
+            // UTF-8 sequences. See #4801.
+            *(w++) = *(r++);
     }
 
     *w = '\0';

--- a/tests/lib/terminal.c
+++ b/tests/lib/terminal.c
@@ -82,7 +82,7 @@ START_TEST (test_strip_ctrl_codes)
 END_TEST
 
 // Test the handling of inner and final incomplete UTF-8, also make sure there's no overrun.
-// Ticket #4801. Ideally replacement symbols should be added, but we don't have that yet.
+// Ticket #4801. Invalid UTF-8 fragments are left in the string as-is.
 START_TEST (test_strip_ctrl_codes2)
 {
     // U+2764 heart in UTF-8, followed by " ábcdéfghíjklnmó\000pqrst" in Latin-1
@@ -94,9 +94,8 @@ START_TEST (test_strip_ctrl_codes2)
     memcpy (s, s_orig, sizeof (s_orig));
 
     char *actual = strip_ctrl_codes (s);
-    const char *expected = "\342\235\244 bcdfghjklm";
 
-    ck_assert_str_eq (actual, expected);
+    ck_assert_str_eq (actual, s_orig);
     g_free (s);
 }
 END_TEST


### PR DESCRIPTION
## Proposed changes

Don't assume that the prompt is valid UTF-8

* Resolves: #4801

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
