### PR TITLE
Ticket #4071: Fix random freezes on directory change

### DIFF
--- a/src/subshell/common.c
+++ b/src/subshell/common.c
@@ -542,7 +542,11 @@ synchronize (void)
 
     // Wait until the subshell has stopped
     while (subshell_alive && !subshell_stopped)
-        sigsuspend (&old_mask);
+    {
+        // On macOS, sigsuspend() may fail to restore the original signal mask.
+        // https://openradar.appspot.com/FB18565075
+        pselect (0, NULL, NULL, NULL, NULL, &old_mask);
+    }
 
     if (subshell_state != ACTIVE)
     {


### PR DESCRIPTION
On macOS, sigsuspend() may fail to restore the original signal mask and leave SIGCHLD unblocked https://openradar.appspot.com/FB18565075

## Proposed changes

Switch to pselect as an alternative to sigsuspend

* Resolves: #4071

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)