### PR TITLE
Ticket #4803: replace `LIBS` with `LDADD` to fix tests deps and linkage

### DIFF
--- a/tests/lib/Makefile.am
+++ b/tests/lib/Makefile.am
@@ -4,19 +4,16 @@ SUBDIRS = . mcconfig search strutil vfs widget
 
 AM_CPPFLAGS = $(GLIB_CFLAGS) -I$(top_srcdir) @CHECK_CFLAGS@
 
-LIBS = @CHECK_LIBS@ \
-	$(top_builddir)/lib/libmc.la
-
-if ENABLE_MCLIB
-LIBS += $(GLIB_LIBS) \
-	@E2P_LIBS@
-endif
+LDADD = \
+	$(top_builddir)/lib/libmc.la \
+	@CHECK_LIBS@
 
 EXTRA_DIST = utilunix__my_system-common.c
 
 TESTS = \
 	library_independ \
 	mc_build_filename \
+	mc_realpath \
 	name_quote \
 	serialize \
 	terminal \
@@ -26,8 +23,6 @@ TESTS = \
 	utilunix__my_system_fork_child_shell \
 	utilunix__my_system_fork_child \
 	x_basename
-
-TESTS += mc_realpath
 
 check_PROGRAMS = $(TESTS)
 

--- a/tests/lib/mcconfig/Makefile.am
+++ b/tests/lib/mcconfig/Makefile.am
@@ -6,13 +6,9 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	@CHECK_CFLAGS@
 
-LIBS = @CHECK_LIBS@ \
-	$(top_builddir)/lib/libmc.la
-
-if ENABLE_MCLIB
-LIBS += $(GLIB_LIBS) \
-	@E2P_LIBS@
-endif
+LDADD = \
+	$(top_builddir)/lib/libmc.la \
+	@CHECK_LIBS@
 
 TESTS = \
 	config_string \

--- a/tests/lib/search/Makefile.am
+++ b/tests/lib/search/Makefile.am
@@ -6,12 +6,9 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/lib/search \
 	@CHECK_CFLAGS@
 
-LIBS = @CHECK_LIBS@ \
-	$(top_builddir)/lib/libmc.la
-
-if ENABLE_MCLIB
-LIBS += $(GLIB_LIBS)
-endif
+LDADD = \
+	$(top_builddir)/lib/libmc.la \
+	@CHECK_LIBS@
 
 TESTS = \
 	glob_prepare_replace_str \

--- a/tests/lib/strutil/Makefile.am
+++ b/tests/lib/strutil/Makefile.am
@@ -5,12 +5,9 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	@CHECK_CFLAGS@
 
-LIBS = @CHECK_LIBS@ \
-	$(top_builddir)/lib/libmc.la
-
-if ENABLE_MCLIB
-LIBS += $(GLIB_LIBS)
-endif
+LDADD = \
+	$(top_builddir)/lib/libmc.la \
+	@CHECK_LIBS@
 
 TESTS = \
 	parse_integer \

--- a/tests/lib/vfs/Makefile.am
+++ b/tests/lib/vfs/Makefile.am
@@ -11,13 +11,9 @@ EXTRA_DIST = mc.charsets.in
 
 CLEANFILES = mc.charsets
 
-LIBS = @CHECK_LIBS@ \
-	$(top_builddir)/lib/libmc.la
-
-if ENABLE_MCLIB
-LIBS += $(GLIB_LIBS) \
-	@E2P_LIBS@
-endif
+LDADD = \
+	$(top_builddir)/lib/libmc.la \
+	@CHECK_LIBS@
 
 TESTS = \
 	canonicalize_pathname \

--- a/tests/lib/widget/Makefile.am
+++ b/tests/lib/widget/Makefile.am
@@ -6,12 +6,9 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/lib/vfs \
 	@CHECK_CFLAGS@
 
-LIBS = @CHECK_LIBS@ \
-	$(top_builddir)/lib/libmc.la
-
-if ENABLE_MCLIB
-LIBS += $(GLIB_LIBS)
-endif
+LDADD = \
+	$(top_builddir)/lib/libmc.la \
+	@CHECK_LIBS@
 
 TESTS = \
 	complete_engine \

--- a/tests/src/Makefile.am
+++ b/tests/src/Makefile.am
@@ -13,13 +13,10 @@ AM_CPPFLAGS = \
 	-DTEST_SHARE_DIR=\"$(abs_srcdir)/fixtures\" \
 	@CHECK_CFLAGS@
 
-LIBS = @CHECK_LIBS@ \
+LDADD = \
 	$(top_builddir)/src/libinternal.la \
-	$(top_builddir)/lib/libmc.la
-
-if ENABLE_MCLIB
-LIBS += $(GLIB_LIBS)
-endif
+	$(top_builddir)/lib/libmc.la \
+	@CHECK_LIBS@
 
 EXTRA_DIST = \
 	fixtures/mc.charsets \

--- a/tests/src/editor/Makefile.am
+++ b/tests/src/editor/Makefile.am
@@ -6,13 +6,10 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	@CHECK_CFLAGS@
 
-LIBS = @CHECK_LIBS@ \
+LDADD = \
 	$(top_builddir)/src/libinternal.la \
-	$(top_builddir)/lib/libmc.la
-
-if ENABLE_MCLIB
-LIBS += $(GLIB_LIBS)
-endif
+	$(top_builddir)/lib/libmc.la \
+	@CHECK_LIBS@
 
 EXTRA_DIST = edit_complete_word_cmd_test_data.txt.in
 

--- a/tests/src/filemanager/Makefile.am
+++ b/tests/src/filemanager/Makefile.am
@@ -7,13 +7,10 @@ AM_CPPFLAGS = \
 	-DTEST_SHARE_DIR=\"$(abs_srcdir)/../fixtures\" \
 	@CHECK_CFLAGS@
 
-LIBS = @CHECK_LIBS@ \
+LDADD = \
 	$(top_builddir)/src/libinternal.la \
-	$(top_builddir)/lib/libmc.la
-
-if ENABLE_MCLIB
-LIBS += $(GLIB_LIBS)
-endif
+	$(top_builddir)/lib/libmc.la \
+	@CHECK_LIBS@
 
 TESTS = \
 	cd_to \

--- a/tests/src/vfs/extfs/helpers-list/Makefile.am
+++ b/tests/src/vfs/extfs/helpers-list/Makefile.am
@@ -4,11 +4,8 @@ SUBDIRS = misc
 
 AM_CPPFLAGS = $(GLIB_CFLAGS) -I$(top_srcdir)
 
-LIBS = $(top_builddir)/lib/libmc.la
-
-if ENABLE_MCLIB
-LIBS += $(GLIB_LIBS)
-endif
+LDADD = \
+	$(top_builddir)/lib/libmc.la
 
 # Programs/scripts to build on 'make check'.
 check_PROGRAMS = mc_parse_ls_l

--- a/tests/src/vfs/ftpfs/Makefile.am
+++ b/tests/src/vfs/ftpfs/Makefile.am
@@ -7,13 +7,10 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/lib/vfs \
 	@CHECK_CFLAGS@
 
-LIBS = @CHECK_LIBS@ \
+LDADD = \
 	$(top_builddir)/src/libinternal.la \
-	$(top_builddir)/lib/libmc.la
-
-if ENABLE_MCLIB
-LIBS += $(GLIB_LIBS)
-endif
+	$(top_builddir)/lib/libmc.la \
+	@CHECK_LIBS@
 
 EXTRA_DIST = \
 	data/aix_list.input \


### PR DESCRIPTION
## Proposed changes

The low-level LIBS variable of autotools does not provide dependency tracking for sources and also does not resolve interdependencies between libraries.

Replace it with high-level LDADD to make sure that tests get re-linked when underlying source files change, and also automatically consider dependent libraries.

Resolves: #4803