### PR TITLE
Ticket #3158: fix ncurses double lines

### DIFF
--- a/lib/mcconfig.h
+++ b/lib/mcconfig.h
@@ -50,6 +50,8 @@ gchar **mc_config_get_keys (const mc_config_t *mc_config, const gchar *group, gs
 
 gchar *mc_config_get_string (mc_config_t *mc_config, const gchar *group, const gchar *param,
                              const gchar *def);
+gchar *mc_config_get_string_strict (mc_config_t *mc_config, const gchar *group, const gchar *param,
+                                    const gchar *def);
 MC_MOCKABLE gchar *mc_config_get_string_raw (mc_config_t *mc_config, const gchar *group,
                                              const gchar *param, const gchar *def);
 gboolean mc_config_get_bool (mc_config_t *mc_config, const gchar *group, const gchar *param,

--- a/lib/skin/common.c
+++ b/lib/skin/common.c
@@ -204,7 +204,7 @@ mc_skin_get (const gchar *group, const gchar *key, const gchar *default_value)
     if (mc_global.tty.ugly_line_drawing)
         return g_strdup (default_value);
 
-    return mc_config_get_string (mc_skin__default.config, group, key, default_value);
+    return mc_config_get_string_strict (mc_skin__default.config, group, key, default_value);
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/skin/lines.c
+++ b/lib/skin/lines.c
@@ -29,6 +29,7 @@
 
 #include "internal.h"
 #include "lib/tty/tty.h"
+#include "lib/strutil.h"
 
 /*** global variables ****************************************************************************/
 
@@ -44,17 +45,104 @@
 /*** file scope functions ************************************************************************/
 /* --------------------------------------------------------------------------------------------- */
 
-static int
-mc_skin_lines_load_frm (mc_skin_t *mc_skin, const char *name)
+static mc_tty_char_t
+unicode_to_mc_acs (gunichar c)
 {
-    int ret;
-    char *frm_val;
+    switch (c)
+    {
+    case 0x2500:  // ─
+        return MC_ACS_HLINE;
+    case 0x2502:  // │
+        return MC_ACS_VLINE;
+    case 0x250C:  // ┌
+        return MC_ACS_ULCORNER;
+    case 0x2510:  // ┐
+        return MC_ACS_URCORNER;
+    case 0x2514:  // └
+        return MC_ACS_LLCORNER;
+    case 0x2518:  // ┘
+        return MC_ACS_LRCORNER;
+    case 0x251C:  // ├
+        return MC_ACS_LTEE;
+    case 0x2524:  // ┤
+        return MC_ACS_RTEE;
+    case 0x252C:  // ┬
+        return MC_ACS_TTEE;
+    case 0x2534:  // ┴
+        return MC_ACS_BTEE;
+    case 0x253C:  // ┼
+        return MC_ACS_PLUS;
 
-    frm_val = mc_config_get_string_raw (mc_skin->config, "Lines", name, " ");
-    ret = mc_tty_normalize_lines_char (frm_val);
-    g_free (frm_val);
+    default:
+        return 0;
+    }
+}
 
-    return ret;
+/* --------------------------------------------------------------------------------------------- */
+
+// "def" is the default in case the skin doesn't define anything. It's not the fallback in case the
+// character cannot be converted to the locale, the fallback is handled by the caller.
+static gboolean
+skin_get_char (mc_skin_t *mc_skin, const char *name, gunichar def, mc_tty_char_t *result)
+{
+    gunichar c;
+    GIConv conv;
+    GString *buffer;
+    estr_t conv_res;
+    char *value_utf8;
+
+    value_utf8 = mc_config_get_string_raw (mc_skin->config, "Lines", name, NULL);
+    if (value_utf8 != NULL)
+    {
+        c = g_utf8_get_char_validated (value_utf8, -1);
+        if (c == (gunichar) (-1) || c == (gunichar) (-2))
+        {
+            g_free (value_utf8);
+            return FALSE;
+        }
+    }
+    else
+    {
+        // the default to be used if not defined in the skin file
+        value_utf8 = g_malloc (7);
+        const int len = g_unichar_to_utf8 (def, value_utf8);
+        value_utf8[len] = '\0';
+        c = def;
+    }
+
+    // in UTF-8 nothing left to do, no ACS business, just return the codepoint
+    if (mc_global.utf8_display)
+    {
+        g_free (value_utf8);
+        *result = c;
+        return TRUE;
+    }
+
+    // use MC_ACS_* values for single line drawing chars
+    const mc_tty_char_t mc_acs = unicode_to_mc_acs (c);
+    if (mc_acs != 0)
+    {
+        g_free (value_utf8);
+        *result = mc_acs;
+        return TRUE;
+    }
+
+    // convert to 8-bit charset, e.g. KOI8-R has all the double line chars
+    conv = str_crt_conv_from ("UTF-8");
+    if (conv == INVALID_CONV)
+    {
+        g_free (value_utf8);
+        return FALSE;
+    }
+
+    buffer = g_string_new ("");
+    conv_res = str_convert (conv, value_utf8, buffer);
+    if (conv_res == ESTR_SUCCESS)
+        *result = (unsigned char) buffer->str[0];
+    str_close_conv (conv);
+    g_string_free (buffer, TRUE);
+    g_free (value_utf8);
+    return conv_res == ESTR_SUCCESS;
 }
 
 /* --------------------------------------------------------------------------------------------- */
@@ -64,35 +152,70 @@ mc_skin_lines_load_frm (mc_skin_t *mc_skin, const char *name)
 void
 mc_skin_lines_parse_ini_file (mc_skin_t *mc_skin)
 {
+    gboolean success;
+
     if (mc_global.tty.slow_terminal)
         mc_skin_hardcoded_space_lines (mc_skin);
     else if (mc_global.tty.ugly_line_drawing)
         mc_skin_hardcoded_ugly_lines (mc_skin);
 
     // single lines
-    mc_tty_frm[MC_TTY_FRM_VERT] = mc_skin_lines_load_frm (mc_skin, "vert");
-    mc_tty_frm[MC_TTY_FRM_HORIZ] = mc_skin_lines_load_frm (mc_skin, "horiz");
-    mc_tty_frm[MC_TTY_FRM_LEFTTOP] = mc_skin_lines_load_frm (mc_skin, "lefttop");
-    mc_tty_frm[MC_TTY_FRM_RIGHTTOP] = mc_skin_lines_load_frm (mc_skin, "righttop");
-    mc_tty_frm[MC_TTY_FRM_LEFTBOTTOM] = mc_skin_lines_load_frm (mc_skin, "leftbottom");
-    mc_tty_frm[MC_TTY_FRM_RIGHTBOTTOM] = mc_skin_lines_load_frm (mc_skin, "rightbottom");
-    mc_tty_frm[MC_TTY_FRM_TOPMIDDLE] = mc_skin_lines_load_frm (mc_skin, "topmiddle");
-    mc_tty_frm[MC_TTY_FRM_BOTTOMMIDDLE] = mc_skin_lines_load_frm (mc_skin, "bottommiddle");
-    mc_tty_frm[MC_TTY_FRM_LEFTMIDDLE] = mc_skin_lines_load_frm (mc_skin, "leftmiddle");
-    mc_tty_frm[MC_TTY_FRM_RIGHTMIDDLE] = mc_skin_lines_load_frm (mc_skin, "rightmiddle");
-    mc_tty_frm[MC_TTY_FRM_CROSS] = mc_skin_lines_load_frm (mc_skin, "cross");
+    success = TRUE /* just for nicer indentation */
+        && skin_get_char (mc_skin, "horiz", 0x2500, &mc_tty_frm[MC_TTY_FRM_HORIZ])
+        && skin_get_char (mc_skin, "vert", 0x2502, &mc_tty_frm[MC_TTY_FRM_VERT])
+        && skin_get_char (mc_skin, "lefttop", 0x250C, &mc_tty_frm[MC_TTY_FRM_LEFTTOP])
+        && skin_get_char (mc_skin, "righttop", 0x2510, &mc_tty_frm[MC_TTY_FRM_RIGHTTOP])
+        && skin_get_char (mc_skin, "leftbottom", 0x2514, &mc_tty_frm[MC_TTY_FRM_LEFTBOTTOM])
+        && skin_get_char (mc_skin, "rightbottom", 0x2518, &mc_tty_frm[MC_TTY_FRM_RIGHTBOTTOM])
+        && skin_get_char (mc_skin, "topmiddle", 0x252C, &mc_tty_frm[MC_TTY_FRM_TOPMIDDLE])
+        && skin_get_char (mc_skin, "bottommiddle", 0x2534, &mc_tty_frm[MC_TTY_FRM_BOTTOMMIDDLE])
+        && skin_get_char (mc_skin, "leftmiddle", 0x251C, &mc_tty_frm[MC_TTY_FRM_LEFTMIDDLE])
+        && skin_get_char (mc_skin, "rightmiddle", 0x2524, &mc_tty_frm[MC_TTY_FRM_RIGHTMIDDLE])
+        && skin_get_char (mc_skin, "cross", 0x253C, &mc_tty_frm[MC_TTY_FRM_CROSS]);
+
+    // if any of them are unavailable, revert all of them to regular single lines
+    if (!success)
+    {
+        mc_tty_frm[MC_TTY_FRM_HORIZ] = MC_ACS_HLINE;
+        mc_tty_frm[MC_TTY_FRM_VERT] = MC_ACS_VLINE;
+        mc_tty_frm[MC_TTY_FRM_LEFTTOP] = MC_ACS_ULCORNER;
+        mc_tty_frm[MC_TTY_FRM_RIGHTTOP] = MC_ACS_URCORNER;
+        mc_tty_frm[MC_TTY_FRM_LEFTBOTTOM] = MC_ACS_LLCORNER;
+        mc_tty_frm[MC_TTY_FRM_RIGHTBOTTOM] = MC_ACS_LRCORNER;
+        mc_tty_frm[MC_TTY_FRM_TOPMIDDLE] = MC_ACS_TTEE;
+        mc_tty_frm[MC_TTY_FRM_BOTTOMMIDDLE] = MC_ACS_BTEE;
+        mc_tty_frm[MC_TTY_FRM_LEFTMIDDLE] = MC_ACS_LTEE;
+        mc_tty_frm[MC_TTY_FRM_RIGHTMIDDLE] = MC_ACS_RTEE;
+        mc_tty_frm[MC_TTY_FRM_CROSS] = MC_ACS_PLUS;
+    }
 
     // double lines
-    mc_tty_frm[MC_TTY_FRM_DVERT] = mc_skin_lines_load_frm (mc_skin, "dvert");
-    mc_tty_frm[MC_TTY_FRM_DHORIZ] = mc_skin_lines_load_frm (mc_skin, "dhoriz");
-    mc_tty_frm[MC_TTY_FRM_DLEFTTOP] = mc_skin_lines_load_frm (mc_skin, "dlefttop");
-    mc_tty_frm[MC_TTY_FRM_DRIGHTTOP] = mc_skin_lines_load_frm (mc_skin, "drighttop");
-    mc_tty_frm[MC_TTY_FRM_DLEFTBOTTOM] = mc_skin_lines_load_frm (mc_skin, "dleftbottom");
-    mc_tty_frm[MC_TTY_FRM_DRIGHTBOTTOM] = mc_skin_lines_load_frm (mc_skin, "drightbottom");
-    mc_tty_frm[MC_TTY_FRM_DTOPMIDDLE] = mc_skin_lines_load_frm (mc_skin, "dtopmiddle");
-    mc_tty_frm[MC_TTY_FRM_DBOTTOMMIDDLE] = mc_skin_lines_load_frm (mc_skin, "dbottommiddle");
-    mc_tty_frm[MC_TTY_FRM_DLEFTMIDDLE] = mc_skin_lines_load_frm (mc_skin, "dleftmiddle");
-    mc_tty_frm[MC_TTY_FRM_DRIGHTMIDDLE] = mc_skin_lines_load_frm (mc_skin, "drightmiddle");
+    success = TRUE /* just for nicer indentation */
+        && skin_get_char (mc_skin, "dhoriz", 0x2550, &mc_tty_frm[MC_TTY_FRM_DHORIZ])
+        && skin_get_char (mc_skin, "dvert", 0x2551, &mc_tty_frm[MC_TTY_FRM_DVERT])
+        && skin_get_char (mc_skin, "dlefttop", 0x2554, &mc_tty_frm[MC_TTY_FRM_DLEFTTOP])
+        && skin_get_char (mc_skin, "drighttop", 0x2557, &mc_tty_frm[MC_TTY_FRM_DRIGHTTOP])
+        && skin_get_char (mc_skin, "dleftbottom", 0x255A, &mc_tty_frm[MC_TTY_FRM_DLEFTBOTTOM])
+        && skin_get_char (mc_skin, "drightbottom", 0x255D, &mc_tty_frm[MC_TTY_FRM_DRIGHTBOTTOM])
+        && skin_get_char (mc_skin, "dtopmiddle", 0x2564, &mc_tty_frm[MC_TTY_FRM_DTOPMIDDLE])
+        && skin_get_char (mc_skin, "dbottommiddle", 0x2567, &mc_tty_frm[MC_TTY_FRM_DBOTTOMMIDDLE])
+        && skin_get_char (mc_skin, "dleftmiddle", 0x255F, &mc_tty_frm[MC_TTY_FRM_DLEFTMIDDLE])
+        && skin_get_char (mc_skin, "drightmiddle", 0x2562, &mc_tty_frm[MC_TTY_FRM_DRIGHTMIDDLE]);
+
+    // if any of them are unavailable, revert all of them to their single counterpart
+    if (!success)
+    {
+        mc_tty_frm[MC_TTY_FRM_DHORIZ] = mc_tty_frm[MC_TTY_FRM_HORIZ];
+        mc_tty_frm[MC_TTY_FRM_DVERT] = mc_tty_frm[MC_TTY_FRM_VERT];
+        mc_tty_frm[MC_TTY_FRM_DLEFTTOP] = mc_tty_frm[MC_TTY_FRM_LEFTTOP];
+        mc_tty_frm[MC_TTY_FRM_DRIGHTTOP] = mc_tty_frm[MC_TTY_FRM_RIGHTTOP];
+        mc_tty_frm[MC_TTY_FRM_DLEFTBOTTOM] = mc_tty_frm[MC_TTY_FRM_LEFTBOTTOM];
+        mc_tty_frm[MC_TTY_FRM_DRIGHTBOTTOM] = mc_tty_frm[MC_TTY_FRM_RIGHTBOTTOM];
+        mc_tty_frm[MC_TTY_FRM_DTOPMIDDLE] = mc_tty_frm[MC_TTY_FRM_TOPMIDDLE];
+        mc_tty_frm[MC_TTY_FRM_DBOTTOMMIDDLE] = mc_tty_frm[MC_TTY_FRM_BOTTOMMIDDLE];
+        mc_tty_frm[MC_TTY_FRM_DLEFTMIDDLE] = mc_tty_frm[MC_TTY_FRM_LEFTMIDDLE];
+        mc_tty_frm[MC_TTY_FRM_DRIGHTMIDDLE] = mc_tty_frm[MC_TTY_FRM_RIGHTMIDDLE];
+    }
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/skin/lines.c
+++ b/lib/skin/lines.c
@@ -128,6 +128,18 @@ skin_get_char (mc_skin_t *mc_skin, const char *name, gunichar def, mc_tty_char_t
     }
 
     // convert to 8-bit charset, e.g. KOI8-R has all the double line chars
+
+#ifdef HAVE_NCURSES
+    // ncurses versions before 6.5-20251115 are buggy in KOI8-R locale, see mc #4799.
+    // Claim failure so that the caller will fall back to ACS single lines.
+    // ASCII chars (e.g. with `--stickchars`) need to fall through.
+    if (ncurses_koi8r_double_line_bug && c >= 128)
+    {
+        g_free (value_utf8);
+        return FALSE;
+    }
+#endif
+
     conv = str_crt_conv_from ("UTF-8");
     if (conv == INVALID_CONV)
     {

--- a/lib/tty/tty-ncurses.c
+++ b/lib/tty/tty-ncurses.c
@@ -190,16 +190,16 @@ mc_tty_normalize_lines_char (const char *str)
         { "\342\224\202", ACS_VLINE },     // │
         { "\342\224\274", ACS_PLUS },      // ┼
 
-        { "\342\225\235", ACS_LRCORNER | A_BOLD },  // ╔
-        { "\342\225\232", ACS_LLCORNER | A_BOLD },  // ╚
-        { "\342\225\227", ACS_URCORNER | A_BOLD },  // ╗
-        { "\342\225\224", ACS_ULCORNER | A_BOLD },  // ╝
-        { "\342\225\237", ACS_LTEE | A_BOLD },      // ╟
-        { "\342\225\242", ACS_RTEE | A_BOLD },      // ╢
-        { "\342\225\244", ACS_TTEE | A_BOLD },      // ╤
-        { "\342\225\247", ACS_BTEE | A_BOLD },      // ╧
-        { "\342\225\220", ACS_HLINE | A_BOLD },     // ═
-        { "\342\225\221", ACS_VLINE | A_BOLD },     // ║
+        { "\342\225\235", ACS_LRCORNER },  // ╔
+        { "\342\225\232", ACS_LLCORNER },  // ╚
+        { "\342\225\227", ACS_URCORNER },  // ╗
+        { "\342\225\224", ACS_ULCORNER },  // ╝
+        { "\342\225\237", ACS_LTEE },      // ╟
+        { "\342\225\242", ACS_RTEE },      // ╢
+        { "\342\225\244", ACS_TTEE },      // ╤
+        { "\342\225\247", ACS_BTEE },      // ╧
+        { "\342\225\220", ACS_HLINE },     // ═
+        { "\342\225\221", ACS_VLINE },     // ║
 
         { NULL, 0 },
     };

--- a/lib/tty/tty-ncurses.c
+++ b/lib/tty/tty-ncurses.c
@@ -63,6 +63,8 @@
 
 /*** global variables ****************************************************************************/
 
+gboolean ncurses_koi8r_double_line_bug;
+
 /*** file scope macro definitions ****************************************************************/
 
 #if !defined(CTRL)
@@ -263,6 +265,12 @@ void
 tty_init (gboolean mouse_enable, gboolean is_xterm)
 {
     struct termios mode;
+
+    // ncurses versions before 6.5-20251115 are buggy in KOI8-R locale, see mc #4799.
+    // Note: This check will fail at ncurses version 10. We can surely remove this workaround then.
+    const char *ncurses_ver = curses_version ();
+    ncurses_koi8r_double_line_bug =
+        (strncmp (ncurses_ver, "ncurses ", 8) == 0 && strcmp (ncurses_ver + 8, "6.5.20251115") < 0);
 
     initscr ();
 

--- a/lib/tty/tty-ncurses.h
+++ b/lib/tty/tty-ncurses.h
@@ -39,6 +39,8 @@
 
 /*** global variables defined in .c file *********************************************************/
 
+extern gboolean ncurses_koi8r_double_line_bug;
+
 /*** declarations of public functions ************************************************************/
 
 /*** inline functions ****************************************************************************/

--- a/lib/tty/tty-slang.h
+++ b/lib/tty/tty-slang.h
@@ -8,18 +8,6 @@
 
 #define KEY_F(x)       (1000 + x)
 
-#define ACS_VLINE      SLSMG_VLINE_CHAR
-#define ACS_HLINE      SLSMG_HLINE_CHAR
-#define ACS_LTEE       SLSMG_LTEE_CHAR
-#define ACS_RTEE       SLSMG_RTEE_CHAR
-#define ACS_TTEE       SLSMG_UTEE_CHAR
-#define ACS_BTEE       SLSMG_DTEE_CHAR
-#define ACS_ULCORNER   SLSMG_ULCORN_CHAR
-#define ACS_LLCORNER   SLSMG_LLCORN_CHAR
-#define ACS_URCORNER   SLSMG_URCORN_CHAR
-#define ACS_LRCORNER   SLSMG_LRCORN_CHAR
-#define ACS_PLUS       SLSMG_PLUS_CHAR
-
 #define COLS           SLtt_Screen_Cols
 #define LINES          SLtt_Screen_Rows
 

--- a/lib/tty/tty.c
+++ b/lib/tty/tty.c
@@ -63,7 +63,7 @@
 
 /*** global variables ****************************************************************************/
 
-int mc_tty_frm[MC_TTY_FRM_MAX];
+mc_tty_char_t mc_tty_frm[MC_TTY_FRM_MAX];
 
 /*** file scope macro definitions ****************************************************************/
 
@@ -248,7 +248,7 @@ tty_flush_winch (void)
 void
 tty_print_one_hline (gboolean single)
 {
-    tty_print_alt_char (ACS_HLINE, single);
+    tty_print_char (mc_tty_frm[single ? MC_TTY_FRM_HORIZ : MC_TTY_FRM_DHORIZ]);
 }
 
 /* --------------------------------------------------------------------------------------------- */
@@ -256,7 +256,7 @@ tty_print_one_hline (gboolean single)
 void
 tty_print_one_vline (gboolean single)
 {
-    tty_print_alt_char (ACS_VLINE, single);
+    tty_print_char (mc_tty_frm[single ? MC_TTY_FRM_VERT : MC_TTY_FRM_DVERT]);
 }
 
 /* --------------------------------------------------------------------------------------------- */
@@ -280,13 +280,13 @@ tty_draw_box (int y, int x, int ys, int xs, gboolean single)
     tty_draw_hline (y, x, mc_tty_frm[single ? MC_TTY_FRM_HORIZ : MC_TTY_FRM_DHORIZ], xs);
     tty_draw_hline (y2, x, mc_tty_frm[single ? MC_TTY_FRM_HORIZ : MC_TTY_FRM_DHORIZ], xs);
     tty_gotoyx (y, x);
-    tty_print_alt_char (ACS_ULCORNER, single);
+    tty_print_char (mc_tty_frm[single ? MC_TTY_FRM_LEFTTOP : MC_TTY_FRM_DLEFTTOP]);
     tty_gotoyx (y2, x);
-    tty_print_alt_char (ACS_LLCORNER, single);
+    tty_print_char (mc_tty_frm[single ? MC_TTY_FRM_LEFTBOTTOM : MC_TTY_FRM_DLEFTBOTTOM]);
     tty_gotoyx (y, x2);
-    tty_print_alt_char (ACS_URCORNER, single);
+    tty_print_char (mc_tty_frm[single ? MC_TTY_FRM_RIGHTTOP : MC_TTY_FRM_DRIGHTTOP]);
     tty_gotoyx (y2, x2);
-    tty_print_alt_char (ACS_LRCORNER, single);
+    tty_print_char (mc_tty_frm[single ? MC_TTY_FRM_RIGHTBOTTOM : MC_TTY_FRM_DRIGHTBOTTOM]);
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/tty/tty.h
+++ b/lib/tty/tty.h
@@ -25,13 +25,40 @@
 #define KEY_KP_SUBTRACT 4002
 #define KEY_KP_MULTIPLY 4003
 
+// In UTF-8 locales it's always the gunichar.
+// In 8-bit locales it's either one of the MC_ACS_* special values for single frame characters,
+// or the 8-bit character code.
+typedef unsigned int mc_tty_char_t;
+
 /*** enums ***************************************************************************************/
 
+// These values always represent the given line drawing characters, in a common way regardless of
+// the underlying screen library. Only used in 8-bit mode, in UTF-8 the actual codepoint is used.
+// These values really have the type 'mc_tty_char_t', but enum cannot denote it.
+enum
+{
+    // Even though these are only used in 8-bit mode, let's start the numbers above the highest
+    // Unicode value to avoid any chance of confusion.
+    MC_ACS_HLINE = 0x110000,  // ─
+    MC_ACS_VLINE,             // │
+    MC_ACS_ULCORNER,          // ┌
+    MC_ACS_URCORNER,          // ┐
+    MC_ACS_LLCORNER,          // └
+    MC_ACS_LRCORNER,          // ┘
+    MC_ACS_TTEE,              // ┬
+    MC_ACS_BTEE,              // ┴
+    MC_ACS_LTEE,              // ├
+    MC_ACS_RTEE,              // ┤
+    MC_ACS_PLUS,              // ┼
+};
+
+// These refer to the roles, the given positions of more prominent and less prominent boxes.
+// The actual characters, taken from the skin, may or may not match the role name.
 typedef enum
 {
     // single lines
-    MC_TTY_FRM_VERT,
     MC_TTY_FRM_HORIZ,
+    MC_TTY_FRM_VERT,
     MC_TTY_FRM_LEFTTOP,
     MC_TTY_FRM_RIGHTTOP,
     MC_TTY_FRM_LEFTBOTTOM,
@@ -43,8 +70,8 @@ typedef enum
     MC_TTY_FRM_CROSS,
 
     // double lines
-    MC_TTY_FRM_DVERT,
     MC_TTY_FRM_DHORIZ,
+    MC_TTY_FRM_DVERT,
     MC_TTY_FRM_DLEFTTOP,
     MC_TTY_FRM_DRIGHTTOP,
     MC_TTY_FRM_DLEFTBOTTOM,
@@ -61,7 +88,9 @@ typedef enum
 
 /*** global variables defined in .c file *********************************************************/
 
-extern int mc_tty_frm[];
+// The actual characters used for frame drawing, as taken from the skin. Indexed by MC_TTY_FRM_*,
+// the values are either one of MCS_ACS_* or a character in the current locale.
+extern mc_tty_char_t mc_tty_frm[];
 
 extern int tty_tigetflag (const char *terminfo_cap, const char *termcap_cap);
 extern int tty_tigetnum (const char *terminfo_cap, const char *termcap_cap);
@@ -112,19 +141,16 @@ extern void tty_touch_screen (void);
 extern void tty_gotoyx (int y, int x);
 extern void tty_getyx (int *py, int *px);
 
-extern void tty_set_alt_charset (gboolean alt_charset);
-
 extern void tty_display_8bit (gboolean what);
-extern void tty_print_char (int c);
-extern void tty_print_alt_char (int c, gboolean single);
-extern void tty_print_anychar (int c);
+extern void tty_print_char (mc_tty_char_t c);
+extern void tty_print_anychar (mc_tty_char_t c);
 extern void tty_print_string (const char *s);
 extern void tty_printf (const char *s, ...) G_GNUC_PRINTF (1, 2);
 
 extern void tty_print_one_vline (gboolean single);
 extern void tty_print_one_hline (gboolean single);
-extern void tty_draw_hline (int y, int x, int ch, int len);
-extern void tty_draw_vline (int y, int x, int ch, int len);
+extern void tty_draw_hline (int y, int x, mc_tty_char_t ch, int len);
+extern void tty_draw_vline (int y, int x, mc_tty_char_t ch, int len);
 extern void tty_draw_box (int y, int x, int rows, int cols, gboolean single);
 extern void tty_draw_box_shadow (int y, int x, int rows, int cols, int shadow_color);
 extern void tty_fill_region (int y, int x, int rows, int cols, unsigned char ch);
@@ -135,8 +161,6 @@ extern void tty_change_screen_size (void);
 
 /* Clear screen */
 extern void tty_clear_screen (void);
-
-extern int mc_tty_normalize_lines_char (const char *str);
 
 extern void tty_enter_ca_mode (void);
 extern void tty_exit_ca_mode (void);

--- a/lib/widget/hline.c
+++ b/lib/widget/hline.c
@@ -110,14 +110,14 @@ hline_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void *dat
             tty_setcolor (colors[DLG_COLOR_NORMAL]);
         }
 
-        tty_draw_hline (w->rect.y, w->rect.x + 1, ACS_HLINE, w->rect.cols - 2);
+        tty_draw_hline (w->rect.y, w->rect.x + 1, mc_tty_frm[MC_TTY_FRM_HORIZ], w->rect.cols - 2);
 
         if (l->auto_adjust_cols)
         {
             widget_gotoyx (w, 0, 0);
-            tty_print_alt_char (ACS_LTEE, FALSE);
+            tty_print_char (mc_tty_frm[MC_TTY_FRM_DLEFTMIDDLE]);
             widget_gotoyx (w, 0, w->rect.cols - 1);
-            tty_print_alt_char (ACS_RTEE, FALSE);
+            tty_print_char (mc_tty_frm[MC_TTY_FRM_DRIGHTMIDDLE]);
         }
 
         if (l->text != NULL)

--- a/lib/widget/menu.c
+++ b/lib/widget/menu.c
@@ -138,10 +138,10 @@ menubar_paint_idx (const WMenuBar *menubar, unsigned int idx, int color)
         tty_setcolor (MENU_ENTRY_COLOR);
 
         widget_gotoyx (menubar, y, x - 1);
-        tty_print_alt_char (ACS_LTEE, FALSE);
-        tty_draw_hline (w->y + y, w->x + x, ACS_HLINE, menu->max_entry_len + 3);
+        tty_print_char (mc_tty_frm[MC_TTY_FRM_DLEFTMIDDLE]);
+        tty_draw_hline (w->y + y, w->x + x, mc_tty_frm[MC_TTY_FRM_HORIZ], menu->max_entry_len + 3);
         widget_gotoyx (menubar, y, x + menu->max_entry_len + 3);
-        tty_print_alt_char (ACS_RTEE, FALSE);
+        tty_print_char (mc_tty_frm[MC_TTY_FRM_DRIGHTMIDDLE]);
     }
     else
     {

--- a/misc/skins/sand256.ini
+++ b/misc/skins/sand256.ini
@@ -54,12 +54,12 @@
     256colors = true
 
 [Lines]
-    horiz = ─
-    vert = │
-    lefttop = ┌
-    righttop = ┐
-    leftbottom = └
-    rightbottom = ┘
+    horiz = ╌
+    vert = ┆
+    lefttop = ╭
+    righttop = ╮
+    leftbottom = ╰
+    rightbottom = ╯
     topmiddle = ┬
     bottommiddle = ┴
     leftmiddle = ├
@@ -67,10 +67,10 @@
     cross = ┼
     dhoriz = ─
     dvert = │
-    dlefttop = ┌
-    drighttop = ┐
-    dleftbottom = └
-    drightbottom = ┘
+    dlefttop = ╭
+    drighttop = ╮
+    dleftbottom = ╰
+    drightbottom = ╯
     dtopmiddle = ┬
     dbottommiddle = ┴
     dleftmiddle = ├

--- a/src/diffviewer/ydiff.c
+++ b/src/diffviewer/ydiff.c
@@ -2774,18 +2774,18 @@ dview_update (WDiff *dview)
             if (xwidth < width1 - 1)
             {
                 tty_gotoyx (1, xwidth);
-                tty_print_alt_char (ACS_TTEE, FALSE);
+                tty_print_char (mc_tty_frm[MC_TTY_FRM_DTOPMIDDLE]);
                 tty_gotoyx (height, xwidth);
-                tty_print_alt_char (ACS_BTEE, FALSE);
-                tty_draw_vline (2, xwidth, ACS_VLINE, height - 2);
+                tty_print_char (mc_tty_frm[MC_TTY_FRM_DBOTTOMMIDDLE]);
+                tty_draw_vline (2, xwidth, mc_tty_frm[MC_TTY_FRM_VERT], height - 2);
             }
             if (xwidth < width2 - 1)
             {
                 tty_gotoyx (1, width1 + xwidth);
-                tty_print_alt_char (ACS_TTEE, FALSE);
+                tty_print_char (mc_tty_frm[MC_TTY_FRM_DTOPMIDDLE]);
                 tty_gotoyx (height, width1 + xwidth);
-                tty_print_alt_char (ACS_BTEE, FALSE);
-                tty_draw_vline (2, width1 + xwidth, ACS_VLINE, height - 2);
+                tty_print_char (mc_tty_frm[MC_TTY_FRM_DBOTTOMMIDDLE]);
+                tty_draw_vline (2, width1 + xwidth, mc_tty_frm[MC_TTY_FRM_VERT], height - 2);
             }
         }
         dview->new_frame = FALSE;

--- a/src/editor/editdraw.c
+++ b/src/editor/editdraw.c
@@ -343,7 +343,7 @@ edit_draw_frame (const WEdit *edit, int color, gboolean active)
     {
         tty_setcolor (EDITOR_FRAME_DRAG);
         widget_gotoyx (w, w->rect.lines - 1, w->rect.cols - 1);
-        tty_print_alt_char (ACS_LRCORNER, TRUE);
+        tty_print_char (mc_tty_frm[MC_TTY_FRM_RIGHTBOTTOM]);
     }
 }
 

--- a/src/filemanager/info.c
+++ b/src/filemanager/info.c
@@ -95,10 +95,10 @@ info_box (WInfo *info)
     tty_printf (" %s ", title);
 
     widget_gotoyx (w, 2, 0);
-    tty_print_alt_char (ACS_LTEE, FALSE);
+    tty_print_char (mc_tty_frm[MC_TTY_FRM_DLEFTMIDDLE]);
     widget_gotoyx (w, 2, w->rect.cols - 1);
-    tty_print_alt_char (ACS_RTEE, FALSE);
-    tty_draw_hline (w->rect.y + 2, w->rect.x + 1, ACS_HLINE, w->rect.cols - 2);
+    tty_print_char (mc_tty_frm[MC_TTY_FRM_DRIGHTMIDDLE]);
+    tty_draw_hline (w->rect.y + 2, w->rect.x + 1, mc_tty_frm[MC_TTY_FRM_HORIZ], w->rect.cols - 2);
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/src/filemanager/layout.c
+++ b/src/filemanager/layout.c
@@ -1045,7 +1045,7 @@ rotate_dash (gboolean show)
     tty_setcolor (NORMAL_COLOR);
 
     if (!show)
-        tty_print_alt_char (ACS_URCORNER, FALSE);
+        tty_print_char (mc_tty_frm[MC_TTY_FRM_DRIGHTTOP]);
     else
     {
         static const char rotating_dash[4] MC_NONSTRING = "|/-\\";

--- a/src/filemanager/panel.c
+++ b/src/filemanager/panel.c
@@ -1050,7 +1050,8 @@ mini_info_separator (const WPanel *panel)
         y = panel_lines (panel) + 2;
 
         tty_setcolor (NORMAL_COLOR);
-        tty_draw_hline (w->rect.y + y, w->rect.x + 1, ACS_HLINE, w->rect.cols - 2);
+        tty_draw_hline (w->rect.y + y, w->rect.x + 1, mc_tty_frm[MC_TTY_FRM_HORIZ],
+                        w->rect.cols - 2);
         /* Status displays total marked size.
          * Centered in panel, full format. */
         display_total_marked_size (panel, y, -1, FALSE);
@@ -1197,9 +1198,9 @@ show_dir (const WPanel *panel)
         y = panel_lines (panel) + 2;
 
         widget_gotoyx (w, y, 0);
-        tty_print_alt_char (ACS_LTEE, FALSE);
+        tty_print_char (mc_tty_frm[MC_TTY_FRM_DLEFTMIDDLE]);
         widget_gotoyx (w, y, w->rect.cols - 1);
-        tty_print_alt_char (ACS_RTEE, FALSE);
+        tty_print_char (mc_tty_frm[MC_TTY_FRM_DRIGHTMIDDLE]);
     }
 
     widget_gotoyx (w, 0, 1);

--- a/src/filemanager/tree.c
+++ b/src/filemanager/tree.c
@@ -368,9 +368,6 @@ show_tree (WTree *tree)
                                                tree_cols + (tree->is_panel ? 0 : 1), J_LEFT_FIT));
         else
         {
-            // Sub level directory
-            tty_set_alt_charset (TRUE);
-
             // Output branch parts
             for (j = 0; j < current->sublevel - topsublevel - 1; j++)
             {
@@ -378,7 +375,7 @@ show_tree (WTree *tree)
                     break;
                 tty_print_char (' ');
                 if ((current->submask & (1 << (j + topsublevel + 1))) != 0)
-                    tty_print_char (ACS_VLINE);
+                    tty_print_char (mc_tty_frm[MC_TTY_FRM_VERT]);
                 else
                     tty_print_char (' ');
                 tty_print_char (' ');
@@ -386,11 +383,10 @@ show_tree (WTree *tree)
             tty_print_char (' ');
             j++;
             if (current->next == NULL || (current->next->submask & (1 << current->sublevel)) == 0)
-                tty_print_char (ACS_LLCORNER);
+                tty_print_char (mc_tty_frm[MC_TTY_FRM_LEFTBOTTOM]);
             else
-                tty_print_char (ACS_LTEE);
-            tty_print_char (ACS_HLINE);
-            tty_set_alt_charset (FALSE);
+                tty_print_char (mc_tty_frm[MC_TTY_FRM_LEFTMIDDLE]);
+            tty_print_char (mc_tty_frm[MC_TTY_FRM_HORIZ]);
 
             // Show sub-name
             tty_print_char (' ');
@@ -1133,10 +1129,11 @@ tree_frame (WDialog *h, WTree *tree)
 
             y = w->rect.lines - 3;
             widget_gotoyx (w, y, 0);
-            tty_print_alt_char (ACS_LTEE, FALSE);
+            tty_print_char (mc_tty_frm[MC_TTY_FRM_DLEFTMIDDLE]);
             widget_gotoyx (w, y, w->rect.cols - 1);
-            tty_print_alt_char (ACS_RTEE, FALSE);
-            tty_draw_hline (w->rect.y + y, w->rect.x + 1, ACS_HLINE, w->rect.cols - 2);
+            tty_print_char (mc_tty_frm[MC_TTY_FRM_DRIGHTMIDDLE]);
+            tty_draw_hline (w->rect.y + y, w->rect.x + 1, mc_tty_frm[MC_TTY_FRM_HORIZ],
+                            w->rect.cols - 2);
         }
     }
 }

--- a/src/help.c
+++ b/src/help.c
@@ -450,27 +450,49 @@ mc_acs_map (int c)
     switch (c)
     {
     case 'q':
-        return mc_global.utf8_display ? 0x2500 : MC_ACS_HLINE;
+        return mc_global.tty.ugly_line_drawing ? '-'
+            : mc_global.utf8_display           ? 0x2500
+                                               : MC_ACS_HLINE;
     case 'x':
-        return mc_global.utf8_display ? 0x2502 : MC_ACS_VLINE;
+        return mc_global.tty.ugly_line_drawing ? '|'
+            : mc_global.utf8_display           ? 0x2502
+                                               : MC_ACS_VLINE;
     case 'l':
-        return mc_global.utf8_display ? 0x250C : MC_ACS_ULCORNER;
+        return mc_global.tty.ugly_line_drawing ? '+'
+            : mc_global.utf8_display           ? 0x250C
+                                               : MC_ACS_ULCORNER;
     case 'k':
-        return mc_global.utf8_display ? 0x2510 : MC_ACS_URCORNER;
+        return mc_global.tty.ugly_line_drawing ? '+'
+            : mc_global.utf8_display           ? 0x2510
+                                               : MC_ACS_URCORNER;
     case 'm':
-        return mc_global.utf8_display ? 0x2514 : MC_ACS_LLCORNER;
+        return mc_global.tty.ugly_line_drawing ? '+'
+            : mc_global.utf8_display           ? 0x2514
+                                               : MC_ACS_LLCORNER;
     case 'j':
-        return mc_global.utf8_display ? 0x2518 : MC_ACS_LRCORNER;
+        return mc_global.tty.ugly_line_drawing ? '+'
+            : mc_global.utf8_display           ? 0x2518
+                                               : MC_ACS_LRCORNER;
     case 't':
-        return mc_global.utf8_display ? 0x251C : MC_ACS_LTEE;
+        return mc_global.tty.ugly_line_drawing ? '|'
+            : mc_global.utf8_display           ? 0x251C
+                                               : MC_ACS_LTEE;
     case 'u':
-        return mc_global.utf8_display ? 0x2524 : MC_ACS_RTEE;
+        return mc_global.tty.ugly_line_drawing ? '|'
+            : mc_global.utf8_display           ? 0x2524
+                                               : MC_ACS_RTEE;
     case 'w':
-        return mc_global.utf8_display ? 0x252C : MC_ACS_TTEE;
+        return mc_global.tty.ugly_line_drawing ? '-'
+            : mc_global.utf8_display           ? 0x252C
+                                               : MC_ACS_TTEE;
     case 'v':
-        return mc_global.utf8_display ? 0x2534 : MC_ACS_BTEE;
+        return mc_global.tty.ugly_line_drawing ? '-'
+            : mc_global.utf8_display           ? 0x2534
+                                               : MC_ACS_BTEE;
     case 'n':
-        return mc_global.utf8_display ? 0x253C : MC_ACS_PLUS;
+        return mc_global.tty.ugly_line_drawing ? '+'
+            : mc_global.utf8_display           ? 0x253C
+                                               : MC_ACS_PLUS;
 
     default:
         return c;

--- a/src/help.c
+++ b/src/help.c
@@ -444,6 +444,41 @@ help_print_word (WDialog *h, GString *word, int *col, int *line, gboolean add_sp
 
 /* --------------------------------------------------------------------------------------------- */
 
+static mc_tty_char_t
+mc_acs_map (int c)
+{
+    switch (c)
+    {
+    case 'q':
+        return mc_global.utf8_display ? 0x2500 : MC_ACS_HLINE;
+    case 'x':
+        return mc_global.utf8_display ? 0x2502 : MC_ACS_VLINE;
+    case 'l':
+        return mc_global.utf8_display ? 0x250C : MC_ACS_ULCORNER;
+    case 'k':
+        return mc_global.utf8_display ? 0x2510 : MC_ACS_URCORNER;
+    case 'm':
+        return mc_global.utf8_display ? 0x2514 : MC_ACS_LLCORNER;
+    case 'j':
+        return mc_global.utf8_display ? 0x2518 : MC_ACS_LRCORNER;
+    case 't':
+        return mc_global.utf8_display ? 0x251C : MC_ACS_LTEE;
+    case 'u':
+        return mc_global.utf8_display ? 0x2524 : MC_ACS_RTEE;
+    case 'w':
+        return mc_global.utf8_display ? 0x252C : MC_ACS_TTEE;
+    case 'v':
+        return mc_global.utf8_display ? 0x2534 : MC_ACS_BTEE;
+    case 'n':
+        return mc_global.utf8_display ? 0x253C : MC_ACS_PLUS;
+
+    default:
+        return c;
+    }
+}
+
+/* --------------------------------------------------------------------------------------------- */
+
 static void
 help_show (WDialog *h, const char *paint_start)
 {
@@ -563,16 +598,7 @@ help_show (WDialog *h, const char *paint_start)
                     else if (col < HELP_WINDOW_WIDTH)
                     {
                         widget_gotoyx (h, line + 2, col + 2);
-
-                        if ((c == ' ') || (c == '.'))
-                            tty_print_char (c);
-                        else
-#ifndef HAVE_SLANG
-                            tty_print_char (acs_map[c]);
-#else
-                            SLsmg_draw_object (WIDGET (h)->rect.y + line + 2,
-                                               WIDGET (h)->rect.x + col + 2, c);
-#endif
+                        tty_print_char (mc_acs_map (c));
                         col++;
                     }
                 }


### PR DESCRIPTION
## Proposed changes

Refactor frame handling, fixing double lines in ncurses build, fixing the look in 8-bit locales.

To be thorougly tested with ncurses, slang, old ncurses, non-wide ncurses etc.; combined with utf-8, koi8-{r,u}, latin-x etc. locales; combined with various skins.

* Resolves: #3158
* Resolves: #3820
* Resolves: #4301 
* Resolves: #4799
* Resolves: #4860

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
