### PR TITLE
Ticket #4815: Fix no colored prompt after switching panels off for the first time

### DIFF
--- a/src/filemanager/filemanager.c
+++ b/src/filemanager/filemanager.c
@@ -109,7 +109,7 @@ WLabel *the_hint;
 WButtonBar *the_bar;
 
 /* The prompt */
-const char *mc_prompt = NULL;
+char *mc_prompt = NULL;
 
 /*** file scope macro definitions ****************************************************************/
 

--- a/src/filemanager/filemanager.h
+++ b/src/filemanager/filemanager.h
@@ -35,7 +35,7 @@ extern WPanel *left_panel;
 extern WPanel *right_panel;
 extern WPanel *current_panel;
 
-extern const char *mc_prompt;
+extern char *mc_prompt;
 
 /*** declarations of public functions ************************************************************/
 

--- a/src/main.c
+++ b/src/main.c
@@ -419,7 +419,7 @@ main (int argc, char *argv[])
         enable_bracketed_paste ();
 
         // subshell_prompt is NULL here
-        mc_prompt = (geteuid () == 0) ? "# " : "$ ";
+        mc_prompt = g_strdup ((geteuid () == 0) ? "# " : "$ ");
     }
 
     // Program main loop
@@ -427,6 +427,8 @@ main (int argc, char *argv[])
         exit_code = EXIT_SUCCESS;
     else
         exit_code = do_nc () ? EXIT_SUCCESS : EXIT_FAILURE;
+
+    g_free (mc_prompt);
 
     disable_bracketed_paste ();
 


### PR DESCRIPTION
Fix the issue by strictly distinguishing between `mc_prompt`, which should be stripped using `strip_ctrl_codes()`, and `subshell_prompt`, which should always hold the original, non-stripped `PS1`. Make `mc_prompt` heap-based.

* Resolves: #4815
