### PR TITLE
Add Natural sort algorithm

### DIFF
--- a/lib/strutil/strutil.c
+++ b/lib/strutil/strutil.c
@@ -316,6 +316,7 @@ str_choose_str_functions (void)
         used_class = str_8bit_init ();
     else
         used_class = str_ascii_init ();
+    used_class.key_collate = alphanum_cmp;
 }
 
 /* --------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
## Proposed changes

Many file managers use "natural sorting"/"alphanumerical sorting" instead of alphabetical sorting for comparing file names (see https://en.wikipedia.org/wiki/Natural_sort_order).

Example of dolphin vs midnight commander

<img width="655" height="257" alt="natural-sorting" src="https://github.com/user-attachments/assets/976bebb2-d896-4f4e-b512-1e8683ee9888" />

I believe natural sorting is more natural, and probably also expected, since it is implemented in many other file managers.


I've created a proof-of-concept branch where I've added a first revision of a natural sort algorithm, but I have one difficulty: the function `key_collate` does not take as parameter the file names, but whatever is returned by `create_key_for_filename`

In my environment, `user_data` is initialized by `str_utf8_init`, thus `create_key_for_filename` returns whatever `str_utf8_create_key_gen` returns, which transforms the file names when `case_sen != 0`.

Thus with `case_sen != 0`, even a simple test like sorting following the files in the picture (ascii, all lowercase) fails.

I would thus like to know, before I invest more time:

 * is such change welcome?
 * what is the best way to proceed? I assume changing `str_utf8_create_key_gen`, but I fail to understand which invariant should hold for the returned value (and did not see any documentation).

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [ ] I have referenced the issue(s) resolved by this PR (if any)
- [ ] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
