### PR TITLE
Fix shadows not working with ncurses

### DIFF
--- a/lib/tty/tty-ncurses.h
+++ b/lib/tty/tty-ncurses.h
@@ -27,7 +27,7 @@
 #endif
 
 /* do not draw shadows if NCurses is built with --disable-widec */
-#if defined(NCURSES_WIDECHAR) && (NCURSES_WIDECHAR - 0 < 1)
+#ifdef HAVE_NCURSES_WIDECHAR
 #define ENABLE_SHADOWS 1
 #endif
 

--- a/m4.include/mc-with-screen-ncurses.m4
+++ b/m4.include/mc-with-screen-ncurses.m4
@@ -84,7 +84,8 @@ AC_DEFUN([mc_WITH_NCURSES], [
             ])
         ])
 
-    AC_CHECK_FUNC([addwstr], [],
+    AC_CHECK_FUNC([addwstr],
+        [AC_DEFINE(HAVE_NCURSES_WIDECHAR, 1, [Define if ncurses library has wide characters support])],
         [AC_MSG_WARN([NCurses(w) library found without wide characters support])])
 
     dnl


### PR DESCRIPTION
## Proposed changes

Fix shadows not working with ncurses

Fix a bug in preprocessor statement that caused shadows to be always disabled in ncurses, instead of intended behavior of being disabled only when the non-wide ncurses library was used.

To be able to do this, also add autoconf check for wide/non-wide ncurses.

* Resolves: #4817
