### PR TITLE
Ticket #3869: actually use the .netrc password for ftp vfs

### DIFF
--- a/src/vfs/ftpfs/ftpfs.c
+++ b/src/vfs/ftpfs/ftpfs.c
@@ -371,12 +371,13 @@ ftpfs_correct_url_parameters (const vfs_path_element_t *velement)
 
         ftpfs_netrc_lookup (path_element->host, &new_user, &new_passwd);
 
-        // If user is different, remove password
-        if (new_user != NULL && strcmp (path_element->user, new_user) != 0)
-            MC_PTR_FREE (path_element->password);
+        // Use the password if it matches the user
+        if (new_user != NULL && strcmp (path_element->user, new_user) == 0)
+            path_element->password = new_passwd;
+        else
+            g_free (new_passwd);
 
         g_free (new_user);
-        g_free (new_passwd);
     }
 
     return path_element;


### PR DESCRIPTION
## Proposed changes

This fixes #3869, when one wants to log into an ftp server only providing username and hostname, and relies on mc to retrieve the password from the .netrc file. Without this, mc retrieves the password from the .netrc file, but doesn't actually use it to login, and asks the user for a password instead.

Please review, this works for me, but I'm not 100% sure it's the best solution.

* Resolves: #3869

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
