### PR TITLE
Ticket #3767: Panelize mode - document and extend to results of external panelize

### DIFF
--- a/doc/man/mc.1.in
+++ b/doc/man/mc.1.in
@@ -912,6 +912,15 @@ half name | size:7 | type mode:3
 .PP
 Panels may also be set to the following modes:
 .TP
+.B "Quick View"
+In this mode, the panel will switch to a reduced
+.\"LINK2"
+viewer
+.\"Internal File Viewer"
+that displays the contents of the currently selected file, if you
+select the panel (with the tab key or the mouse), you will have access
+to the usual viewer commands.
+.TP
 .B "Info"
 The info view display information related to the currently
 selected file and if possible information about the current file
@@ -924,14 +933,16 @@ directory tree
 .\"Directory Tree"
 feature. See the section about it for more information.
 .TP
-.B "Quick View"
-In this mode, the panel will switch to a reduced
+.B "Panelize"
+This mode shows the results of the latest
 .\"LINK2"
-viewer
-.\"Internal File Viewer"
-that displays the contents of the currently selected file, if you
-select the panel (with the tab key or the mouse), you will have access
-to the usual viewer commands.
+External panelize
+.\"External panelize"
+or
+.\"LINK2"
+Find file
+.\"Find File"
+commands.
 .\"NODE "    Sort Order..."
 .SH "    Sort Order..."
 The eight sort orders are by name (alphabetical sort or version sort,
@@ -1413,7 +1424,8 @@ search. The Quit button quits the search operation. The Panelize
 button will place the found files to the current directory panel so
 that you can do additional operations on them (view, copy, move,
 delete and so on). To return to the normal file listing, change directory
-to "..".
+to ".."; to see the panelized search results again, select the Panelize
+mode in the Left and Right menu.
 .PP
 The 'Enable ignore directories' checkbox and input field below it
 allow one to set up the list of directories that should be skip during the search
@@ -1455,7 +1467,9 @@ find . \-type l \-print
 .PP
 Upon command completion, the directory contents of the panel will no
 longer be the directory listing of the current directory, but all the
-files that are symbolic links.
+files that are symbolic links. To return to the normal file listing,
+change directory to ".."; to see the command output again, select
+the Panelize mode in the Left and Right menu.
 .PP
 If you want to panelize all of the files that have been downloaded
 from your FTP server, you can use this awk command to extract the file

--- a/src/filemanager/filemanager.c
+++ b/src/filemanager/filemanager.c
@@ -195,6 +195,7 @@ create_panel_menu (void)
     entries = g_list_prepend (entries, menu_entry_new (_ ("&Quick view"), CK_PanelQuickView));
     entries = g_list_prepend (entries, menu_entry_new (_ ("&Info"), CK_PanelInfo));
     entries = g_list_prepend (entries, menu_entry_new (_ ("&Tree"), CK_PanelTree));
+    entries = g_list_prepend (entries, menu_entry_new (_ ("Paneli&ze"), CK_Panelize));
     entries = g_list_prepend (entries, menu_separator_new ());
     entries =
         g_list_prepend (entries, menu_entry_new (_ ("&Listing format..."), CK_SetupListingFormat));
@@ -211,7 +212,6 @@ create_panel_menu (void)
 #ifdef ENABLE_VFS_SFTP
     entries = g_list_prepend (entries, menu_entry_new (_ ("SFTP li&nk..."), CK_ConnectSftp));
 #endif
-    entries = g_list_prepend (entries, menu_entry_new (_ ("Paneli&ze"), CK_Panelize));
     entries = g_list_prepend (entries, menu_separator_new ());
     entries = g_list_prepend (entries, menu_entry_new (_ ("&Rescan"), CK_Reread));
 

--- a/src/filemanager/filemanager.c
+++ b/src/filemanager/filemanager.c
@@ -1230,7 +1230,7 @@ midnight_execute_cmd (Widget *sender, long command)
         break;
 #endif
     case CK_Panelize:
-        panel_panelize_cd ();
+        panel_panelize_restore ();
         break;
     case CK_Help:
         help_cmd ();

--- a/src/filemanager/panel.c
+++ b/src/filemanager/panel.c
@@ -5252,8 +5252,12 @@ panel_get_user_possible_fields (gsize *array_size)
 
 /* --------------------------------------------------------------------------------------------- */
 
+/**
+ * Restores the contents of the panel from a snapshot previously saved by
+ * panel_panelize_save()
+ */
 void
-panel_panelize_cd (void)
+panel_panelize_restore (void)
 {
     WPanel *panel;
     int i;
@@ -5373,6 +5377,10 @@ panel_panelize_absolutize_if_needed (WPanel *panel)
 
 /* --------------------------------------------------------------------------------------------- */
 
+/**
+ * Saves the contents of the panel into a snapshot, so it may be restored later
+ * by panel_panelize_restore().
+ */
 void
 panel_panelize_save (WPanel *panel)
 {

--- a/src/filemanager/panel.h
+++ b/src/filemanager/panel.h
@@ -192,7 +192,7 @@ char **panel_get_user_possible_fields (gsize *array_size);
 void panel_set_cwd (WPanel *panel, const vfs_path_t *vpath);
 void panel_set_lwd (WPanel *panel, const vfs_path_t *vpath);
 
-void panel_panelize_cd (void);
+void panel_panelize_restore (void);
 void panel_panelize_change_root (WPanel *panel, const vfs_path_t *new_root);
 void panel_panelize_absolutize_if_needed (WPanel *panel);
 void panel_panelize_save (WPanel *panel);

--- a/src/filemanager/panelize.c
+++ b/src/filemanager/panelize.c
@@ -424,6 +424,7 @@ do_external_panelize (const char *command)
 
     current_panel->is_panelized = TRUE;
     panel_panelize_absolutize_if_needed (current_panel);
+    panel_panelize_save (current_panel);
 
     panel_set_current_by_name (current_panel, NULL);
     panel_re_sort (current_panel);


### PR DESCRIPTION
## Proposed changes

This ports the patches proposed by mooffie in #3767 to the current code base.

Commit messages should be pretty self-explanatory.
The only differences wrt the original patches are:
- I didn't rename the "Panelize" menu command to "Restore panelization": I think the new documentation in the man page is clear enough, and "Panelize" is more consistent with the names of other panel modes ("File listing", "Quick view", etc)
- I moved the "Panelize" menu entry from the current position to below the "Tree" entry; it seems to me it fits better there than in the menu section it's currently in ("FTP link", "Shell link" etc)

I think this is enough to cover the issues raised in #3767, of course we could improve further: e.g. if one chooses "Panelize" when no prior "External panelize" or "Find file" commands have been executed, currently an empty panel is shown, which could seem odd: maybe in this case a popup message could be shown instead, advising the user to run one of the above two commands before. 

* Resolves: #3767

## Checklist

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
