### PR TITLE
Ticket #4861: add extension-based fallbacks for handling JAR and WAR files to mc.ext

### DIFF
--- a/misc/mc.ext.ini.in
+++ b/misc/mc.ext.ini.in
@@ -1159,9 +1159,15 @@ Type=\\(Zip archive
 Open=%cd %p/uzip://
 View=%view{ascii} @EXTHELPERSDIR@/archive.sh view zip
 
-[jar]
+[jar-war-by-type]
 Type=\\(Java (Jar file|archive) data \\((zip|JAR)\\)\\)
 TypeIgnoreCase=true
+Open=%cd %p/uzip://
+View=%view{ascii} @EXTHELPERSDIR@/archive.sh view zip
+
+[jar-war-by-regex]
+Regex=\\.[jw]ar$
+RegexIgnoreCase=true
 Open=%cd %p/uzip://
 View=%view{ascii} @EXTHELPERSDIR@/archive.sh view zip
 


### PR DESCRIPTION
## Proposed changes

Fix/add support for JAR/WAR files with shell associations.

The `file` command apparently behaves inconsistently between Linux distributions—that prevents opening JAR files (which are just ZIP files with metadata) in Manjaro/Arch Linux within Midnight Commander; and inspecting/editing source code within those compressed files.

WAR files were missing (that was reported here): https://bugs.launchpad.net/mc/+bug/2062968/comments/16 - this PR adds support for them via extension match.

* Resolves: #4861

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [ ] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
