### PR TITLE
vfs: shell: Add support of UTF-8 encoding for SSH connections

### DIFF
--- a/src/vfs/shell/shell.c
+++ b/src/vfs/shell/shell.c
@@ -459,6 +459,9 @@ shell_set_env (int flags)
 
     ret = g_string_sized_new (256);
 
+    g_string_append (ret, "LANG=C.UTF-8; export LANG; ");
+    g_string_append (ret, "LC_ALL=C.UTF-8; export LC_ALL; ");
+
     if ((flags & SHELL_HAVE_HEAD) != 0)
         g_string_append (ret, "SHELL_HAVE_HEAD=1 export SHELL_HAVE_HEAD; ");
 
@@ -631,7 +634,7 @@ shell_open_archive_int (struct vfs_class *me, struct vfs_s_super *super)
 
     // Set up remote locale to C, otherwise dates cannot be recognized
     if (shell_command (me, super, WAIT_REPLY,
-                       "LANG=C LC_ALL=C LC_TIME=C; export LANG LC_ALL LC_TIME;\n"
+                       "LANG=C.UTF-8 LC_ALL=C.UTF-8 LC_TIME=C; export LANG LC_ALL LC_TIME;\n"
                        "echo '### 200'\n",
                        -1)
         != COMPLETE)


### PR DESCRIPTION
Most linux distributions today use UTF-8 encoding for theirs filesystems, because of that use LANG=C and LC_ALL=C make filenames unreadable and unusable on SSH connections (it fill names by question marks).

<img width="550" height="126" alt="2" src="https://github.com/user-attachments/assets/645fa33d-f443-46d2-8bf4-daddf9c7310d" />

<img width="772" height="140" alt="3" src="https://github.com/user-attachments/assets/90ebdb7f-3a1f-4e47-90a9-89e66e7e5e19" />

Change all mentions of LANG=C to LANG=C.UTF-8, also use as default env.

<img width="511" height="166" alt="1" src="https://github.com/user-attachments/assets/7d0f660c-f31b-4e1c-b085-0c477016d841" />

<img width="642" height="219" alt="5" src="https://github.com/user-attachments/assets/19c7c266-03c1-41da-a69c-dce1e308b5f7" />
