### PR TITLE
Bugfix: N_ macro used instead of _

### DIFF
--- a/src/editor/editwidget.c
+++ b/src/editor/editwidget.c
@@ -140,7 +140,7 @@ edit_about (void)
     char *ver, *desc;
 
     ver = g_strdup_printf ("MCEdit %s", mc_global.mc_version);
-    desc = g_strdup_printf (N_ ("A user friendly text editor\n"
+    desc = g_strdup_printf (_ ("A user friendly text editor\n"
                                 "written for the %s."),
                             PACKAGE_NAME);
 

--- a/src/filemanager/boxes.c
+++ b/src/filemanager/boxes.c
@@ -499,9 +499,9 @@ about_box (void)
     const char *name_cp_source = get_codepage_name (mc_global.source_codepage);
 
     label_cp_display =
-        g_strdup_printf ("%s: %s", N_ ("Detected display codepage"), name_cp_display);
+        g_strdup_printf ("%s: %s", _ ("Detected display codepage"), name_cp_display);
     label_cp_source =
-        g_strdup_printf ("%s: %s", N_ ("Selected source (file I/O) codepage"), name_cp_source);
+        g_strdup_printf ("%s: %s", _ ("Selected source (file I/O) codepage"), name_cp_source);
 
     quick_widget_t quick_widgets[] = {
         QUICK_LABEL (version, NULL),


### PR DESCRIPTION
## Proposed changes

Currently, `N_` macro is errorneously used instead `_` in some places related to the About box (see issue #4868). This causes related messages in the About boxes of MC and mcedit to be displayed in English instead of localized. This PR aims to correct this error.

* Resolves: #4868 

## Checklist

<!-- _Put an `x` in the boxes that apply:_ -->

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [ ] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
