### PR TITLE
Ticket #4871: Fix the editor's replacement character color in some skins

### DIFF
--- a/misc/skins/gray-green-purple256.ini
+++ b/misc/skins/gray-green-purple256.ini
@@ -111,7 +111,7 @@
     editbold = rgb400
     editmarked = ;main1
     editwhitespace = rgb400;bgdarker
-    editnonprintable = ;black
+    editnonprintable = black;bgdarker
     editlinestate = ;bgdarker
     bookmark = ;rgb531
     bookmarkfound = ;main2

--- a/misc/skins/gray-green-purple256.ini
+++ b/misc/skins/gray-green-purple256.ini
@@ -113,7 +113,7 @@
     editwhitespace = rgb400;bgdarker
     editnonprintable = black;bgdarker
     editlinestate = ;bgdarker
-    bookmark = ;rgb531
+    bookmark = ;main1
     bookmarkfound = ;main2
     editrightmargin = rgb400;bgdarker
 #    editbg =

--- a/misc/skins/gray-orange-blue256.ini
+++ b/misc/skins/gray-orange-blue256.ini
@@ -111,7 +111,7 @@
     editbold = rgb400
     editmarked = ;main1
     editwhitespace = rgb400;bgdarker
-    editnonprintable = ;black
+    editnonprintable = black;bgdarker
     editlinestate = ;bgdarker
     bookmark = ;rgb531
     bookmarkfound = ;main2

--- a/misc/skins/gray-orange-blue256.ini
+++ b/misc/skins/gray-orange-blue256.ini
@@ -113,7 +113,7 @@
     editwhitespace = rgb400;bgdarker
     editnonprintable = black;bgdarker
     editlinestate = ;bgdarker
-    bookmark = ;rgb531
+    bookmark = ;main1
     bookmarkfound = ;main2
     editrightmargin = rgb400;bgdarker
 #    editbg =

--- a/misc/skins/sand256.ini
+++ b/misc/skins/sand256.ini
@@ -156,7 +156,7 @@
     editbold = rgb400
     editmarked = ;rgb452;italic
     editwhitespace = rgb400;rgb553
-    editnonprintable = ;black
+    editnonprintable = black;rgb452;italic
     editlinestate = ;rgb553
     bookmark = ;rgb551
     bookmarkfound = ;rgb530

--- a/misc/skins/seasons-autumn16M.ini
+++ b/misc/skins/seasons-autumn16M.ini
@@ -155,7 +155,7 @@
     editbold = MarkedFg;;bold
     editmarked = ;Selected
     editwhitespace = ;EditorWhitespace
-    editnonprintable = ;black
+    editnonprintable = #000;Bottom
     editlinestate = #000;EditorLineNumber
     bookmark = #000;EditorBookmark
     bookmarkfound = #000;EditorFindAll

--- a/misc/skins/seasons-spring16M.ini
+++ b/misc/skins/seasons-spring16M.ini
@@ -155,7 +155,7 @@
     editbold = MarkedFg;;bold
     editmarked = ;Selected
     editwhitespace = ;EditorWhitespace
-    editnonprintable = ;black
+    editnonprintable = #000;Bottom
     editlinestate = #000;EditorLineNumber
     bookmark = #000;EditorBookmark
     bookmarkfound = #000;EditorFindAll

--- a/misc/skins/seasons-summer16M.ini
+++ b/misc/skins/seasons-summer16M.ini
@@ -155,7 +155,7 @@
     editbold = MarkedFg;;bold
     editmarked = ;Selected
     editwhitespace = ;EditorWhitespace
-    editnonprintable = ;black
+    editnonprintable = #000;Bottom
     editlinestate = #000;EditorLineNumber
     bookmark = #000;EditorBookmark
     bookmarkfound = #000;EditorFindAll

--- a/misc/skins/seasons-winter16M.ini
+++ b/misc/skins/seasons-winter16M.ini
@@ -155,7 +155,7 @@
     editbold = MarkedFg;;bold
     editmarked = ;Selected
     editwhitespace = ;EditorWhitespace
-    editnonprintable = ;black
+    editnonprintable = #000;Bottom
     editlinestate = #000;EditorLineNumber
     bookmark = #000;EditorBookmark
     bookmarkfound = #000;EditorFindAll


### PR DESCRIPTION
## Proposed changes

Fix the editor's replacement character color in some skins.

They've been broken since 1b3684e0e1edeac1c598801856a78516676aaf1c introduced this new category.

After a quick test, other 256-color skins seemed to look fine to me. (In case I missed something, we should get the author of that skin to adjust.)

* Resolves: #4871

## Checklist

<!-- _Put an `x` in the boxes that apply:_ -->

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [ ] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
