### PR TITLE
Ticket #4899: Add xterm-direct* as recognized terminal types

### DIFF
--- a/misc/mc.lib
+++ b/misc/mc.lib
@@ -105,6 +105,15 @@ copy=xterm
 [terminal:xterm-256color]
 copy=xterm
 
+[terminal:xterm-direct]
+copy=xterm
+
+[terminal:xterm-direct16]
+copy=xterm
+
+[terminal:xterm-direct256]
+copy=xterm
+
 [terminal:screen]
 copy=xterm
 


### PR DESCRIPTION
This fixes the handling of shifted function keys in slang.

## Proposed changes

* Resolves: #4899

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
