### PR TITLE
Ticket #4891: Speed up Find file by using d_type

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -266,6 +266,8 @@ AC_STRUCT_ST_BLOCKS
 AC_CHECK_MEMBERS([struct stat.st_blksize, struct stat.st_rdev, struct stat.st_mtim, struct stat.st_mtimespec, struct stat.st_mtimensec])
 gl_STAT_SIZE
 
+AC_STRUCT_DIRENT_D_TYPE
+
 AH_TEMPLATE([sig_atomic_t],
             [/* Define to `int' if <signal.h> doesn't define.])
 AH_TEMPLATE([SIG_ATOMIC_VOLATILE_T],

--- a/lib/unixcompat.h
+++ b/lib/unixcompat.h
@@ -67,6 +67,12 @@
 #define STDERR_FILENO 2
 #endif
 
+#ifndef HAVE_STRUCT_DIRENT_D_TYPE
+#define DT_UNKNOWN 0
+#define DT_DIR     101  // the value doesn't matter, just needs to be different from DT_UNKNOWN
+#define DT_LNK     102  // ditto
+#endif
+
 /* The O_BINARY definition was taken from gettext */
 #if !defined O_BINARY && defined _O_BINARY
 // For MSC-compatible compilers.

--- a/lib/vfs/direntry.c
+++ b/lib/vfs/direntry.c
@@ -464,7 +464,7 @@ vfs_s_readdir (void *data)
 
     name = VFS_ENTRY (info->cur->data)->name;
     if (name != NULL)
-        dir = vfs_dirent_init (NULL, name, 0);
+        dir = vfs_dirent_init (NULL, name, 0, DT_UNKNOWN);
     else
         vfs_die ("Null in structure-cannot happen");
 

--- a/lib/vfs/interface.c
+++ b/lib/vfs/interface.c
@@ -470,7 +470,7 @@ mc_readdir (DIR *dirp)
 
         g_string_set_size (vfs_str_buffer, 0);
         str_vfs_convert_from (vfs_path_element->dir.converter, entry->d_name, vfs_str_buffer);
-        vfs_dirent_assign (mc_readdir_result, vfs_str_buffer->str, entry->d_ino);
+        vfs_dirent_assign (mc_readdir_result, vfs_str_buffer->str, entry->d_ino, entry->d_type);
         vfs_dirent_free (entry);
     }
     if (entry == NULL)

--- a/lib/vfs/vfs.c
+++ b/lib/vfs/vfs.c
@@ -458,7 +458,7 @@ vfs_init (void)
 
     vfs_str_buffer = g_string_new ("");
 
-    mc_readdir_result = vfs_dirent_init (NULL, "", -1);
+    mc_readdir_result = vfs_dirent_init (NULL, "", -1, DT_UNKNOWN);
 }
 
 /* --------------------------------------------------------------------------------------------- */
@@ -521,7 +521,7 @@ vfs_shut (void)
  */
 
 struct vfs_dirent *
-vfs_dirent_init (struct vfs_dirent *d, const char *fname, ino_t ino)
+vfs_dirent_init (struct vfs_dirent *d, const char *fname, ino_t ino, unsigned char type)
 {
     struct vfs_dirent *ret = d;
 
@@ -531,7 +531,7 @@ vfs_dirent_init (struct vfs_dirent *d, const char *fname, ino_t ino)
     if (ret->d_name_str == NULL)
         ret->d_name_str = g_string_sized_new (MC_MAXFILENAMELEN);
 
-    vfs_dirent_assign (ret, fname, ino);
+    vfs_dirent_assign (ret, fname, ino, type);
 
     return ret;
 }
@@ -546,12 +546,13 @@ vfs_dirent_init (struct vfs_dirent *d, const char *fname, ino_t ino)
  */
 
 void
-vfs_dirent_assign (struct vfs_dirent *d, const char *fname, ino_t ino)
+vfs_dirent_assign (struct vfs_dirent *d, const char *fname, ino_t ino, unsigned char type)
 {
     g_string_assign (d->d_name_str, fname);
     d->d_name = d->d_name_str->str;
     d->d_len = d->d_name_str->len;
     d->d_ino = ino;
+    d->d_type = type;
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/vfs/vfs.h
+++ b/lib/vfs/vfs.h
@@ -219,6 +219,7 @@ struct vfs_dirent
     ino_t d_ino;
     char *d_name;  // Alias of d_name_str->str
     size_t d_len;  // Alias of d_name_str->len
+    unsigned char d_type;
 };
 
 /*** global variables defined in .c file *********************************************************/
@@ -279,8 +280,9 @@ void vfs_stamp_path (const vfs_path_t *path);
 
 void vfs_release_path (const vfs_path_t *vpath);
 
-struct vfs_dirent *vfs_dirent_init (struct vfs_dirent *d, const char *fname, ino_t ino);
-void vfs_dirent_assign (struct vfs_dirent *d, const char *fname, ino_t ino);
+struct vfs_dirent *vfs_dirent_init (struct vfs_dirent *d, const char *fname, ino_t ino,
+                                    unsigned char type);
+void vfs_dirent_assign (struct vfs_dirent *d, const char *fname, ino_t ino, unsigned char type);
 void vfs_dirent_free (struct vfs_dirent *d);
 
 void vfs_fill_names (fill_names_f);

--- a/src/filemanager/find.c
+++ b/src/filemanager/find.c
@@ -1333,18 +1333,31 @@ do_search (WDialog *h)
                 {
                     vfs_path_t *tmp_vpath;
                     int stat_res;
+                    gboolean descend = FALSE;
 
-                    tmp_vpath = vfs_path_build_filename (directory, dp->d_name, (char *) NULL);
+                    if (dp->d_type == DT_UNKNOWN || dp->d_type == DT_DIR
+                        || (dp->d_type == DT_LNK && options.follow_symlinks))
+                    {
+                        tmp_vpath = vfs_path_build_filename (directory, dp->d_name, (char *) NULL);
 
-                    if (options.follow_symlinks)
-                        stat_res = mc_stat (tmp_vpath, &tmp_stat);
-                    else
-                        stat_res = mc_lstat (tmp_vpath, &tmp_stat);
+                        if (dp->d_type == DT_DIR)
+                            descend = TRUE;
+                        else
+                        {
+                            if (options.follow_symlinks)
+                                stat_res = mc_stat (tmp_vpath, &tmp_stat);
+                            else
+                                stat_res = mc_lstat (tmp_vpath, &tmp_stat);
 
-                    if (stat_res == 0 && S_ISDIR (tmp_stat.st_mode))
-                        push_directory (tmp_vpath);
-                    else
-                        vfs_path_free (tmp_vpath, TRUE);
+                            if (stat_res == 0 && S_ISDIR (tmp_stat.st_mode))
+                                descend = TRUE;
+                        }
+
+                        if (descend)
+                            push_directory (tmp_vpath);
+                        else
+                            vfs_path_free (tmp_vpath, TRUE);
+                    }
                 }
             }
 

--- a/src/vfs/extfs/extfs.c
+++ b/src/vfs/extfs/extfs.c
@@ -1214,7 +1214,7 @@ extfs_readdir (void *data)
     if (*info == NULL)
         return NULL;
 
-    dir = vfs_dirent_init (NULL, VFS_ENTRY ((*info)->data)->name, 0);  // FIXME: inode
+    dir = vfs_dirent_init (NULL, VFS_ENTRY ((*info)->data)->name, 0, DT_UNKNOWN);  // FIXME: inode
 
     *info = g_list_next (*info);
 

--- a/src/vfs/local/local.c
+++ b/src/vfs/local/local.c
@@ -127,10 +127,20 @@ static struct vfs_dirent *
 local_readdir (void *data)
 {
     struct dirent *d;
+    unsigned char type;
 
     d = readdir (*(DIR **) data);
 
-    return (d != NULL ? vfs_dirent_init (NULL, d->d_name, d->d_ino) : NULL);
+    if (d == NULL)
+        return NULL;
+
+#ifdef HAVE_STRUCT_DIRENT_D_TYPE
+    type = d->d_type;
+#else
+    type = DT_UNKNOWN;
+#endif
+
+    return vfs_dirent_init (NULL, d->d_name, d->d_ino, type);
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/src/vfs/sftpfs/dir.c
+++ b/src/vfs/sftpfs/dir.c
@@ -127,7 +127,7 @@ sftpfs_readdir (void *data, GError **mcerror)
     }
     while (rc == LIBSSH2_ERROR_EAGAIN);
 
-    return (rc != 0 ? vfs_dirent_init (NULL, mem, 0) : NULL);  // FIXME: inode
+    return (rc != 0 ? vfs_dirent_init (NULL, mem, 0, DT_UNKNOWN) : NULL);  // FIXME: inode
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/src/vfs/undelfs/undelfs.c
+++ b/src/vfs/undelfs/undelfs.c
@@ -402,14 +402,15 @@ undelfs_readdir (void *vfs_info)
     if (readdir_ptr == num_delarray)
         return NULL;
     if (readdir_ptr < 0)
-        dirent = vfs_dirent_init (NULL, readdir_ptr == -2 ? "." : "..", 0);  // FIXME: inode
+        dirent =
+            vfs_dirent_init (NULL, readdir_ptr == -2 ? "." : "..", 0, DT_UNKNOWN);  // FIXME: inode
     else
     {
         char dirent_dest[MC_MAXPATHLEN];
 
         g_snprintf (dirent_dest, MC_MAXPATHLEN, "%ld:%d", (long) delarray[readdir_ptr].ino,
                     delarray[readdir_ptr].num_blocks);
-        dirent = vfs_dirent_init (NULL, dirent_dest, 0);  // FIXME: inode
+        dirent = vfs_dirent_init (NULL, dirent_dest, 0, DT_UNKNOWN);  // FIXME: inode
     }
     readdir_ptr++;
 


### PR DESCRIPTION
On supporting systems, use struct dirent's d_type field to save a stat call determining the entry's type and thus whether we need to descend to that during recursive file search. This can result in massive speedup.

## Proposed changes

* Resolves: #4891

## Checklist

<!-- _Put an `x` in the boxes that apply:_ -->

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)

