### PR TITLE
Ticket #4915: Fix the help window's title color

### DIFF
--- a/lib/widget/dialog.c
+++ b/lib/widget/dialog.c
@@ -54,6 +54,7 @@
 dlg_colors_t dialog_colors;
 dlg_colors_t alarm_colors;
 dlg_colors_t listbox_colors;
+dlg_colors_t help_colors;
 
 /* A hook list for idle events */
 hook_t *idle_hook = NULL;
@@ -475,6 +476,14 @@ dlg_set_default_colors (void)
     listbox_colors[DLG_COLOR_SELECTED_NORMAL] = PMENU_SELECTED_COLOR;  // unused
     listbox_colors[DLG_COLOR_SELECTED_FOCUS] = PMENU_SELECTED_COLOR;   // unused
     listbox_colors[DLG_COLOR_TITLE] = PMENU_TITLE_COLOR;
+
+    help_colors[DLG_COLOR_NORMAL] = HELP_NORMAL_COLOR;
+    help_colors[DLG_COLOR_FOCUS] = 0;  // unused
+    help_colors[DLG_COLOR_HOT_NORMAL] = HELP_BOLD_COLOR;
+    help_colors[DLG_COLOR_HOT_FOCUS] = 0;        // unused
+    help_colors[DLG_COLOR_SELECTED_NORMAL] = 0;  // unused
+    help_colors[DLG_COLOR_SELECTED_FOCUS] = 0;   // unused
+    help_colors[DLG_COLOR_TITLE] = HELP_TITLE_COLOR;
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/widget/dialog.h
+++ b/lib/widget/dialog.h
@@ -91,6 +91,7 @@ struct WDialog
 extern dlg_colors_t dialog_colors;
 extern dlg_colors_t alarm_colors;
 extern dlg_colors_t listbox_colors;
+extern dlg_colors_t help_colors;
 
 /* A hook list for idle events */
 extern hook_t *idle_hook;

--- a/src/help.c
+++ b/src/help.c
@@ -1121,14 +1121,6 @@ gboolean
 help_interactive_display (const gchar *event_group_name, const gchar *event_name,
                           gpointer init_data, gpointer data)
 {
-    const dlg_colors_t help_colors = {
-        HELP_NORMAL_COLOR,  // common text color
-        0,                  // unused in help
-        HELP_BOLD_COLOR,    // bold text color
-        0,                  // unused in help
-        HELP_TITLE_COLOR    // title color
-    };
-
     Widget *wh;
     WGroup *g;
     WButtonBar *help_bar;


### PR DESCRIPTION
This broke in recent commit e99555c35.

## Proposed changes

Use named indices rather than just listing the struct items which can easily go out of sync.

For consistency, moved the code to where other similar structs are initialized.

* Resolves: #4915

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
