### PR TITLE
Ticket #4920: Don't show menu bar's inactive hotkeys when menu is dropped

### DIFF
--- a/lib/widget/menu.c
+++ b/lib/widget/menu.c
@@ -243,7 +243,7 @@ menubar_draw (const WMenuBar *menubar)
 
         if (menu->text.hotkey != NULL)
         {
-            menubar_set_color (menubar, is_selected, TRUE);
+            menubar_set_color (menubar, is_selected, !menubar->is_dropped);
             tty_print_string (menu->text.hotkey);
             menubar_set_color (menubar, is_selected, FALSE);
         }


### PR DESCRIPTION
## Proposed changes

Don't show menu bar's inactive hotkeys when menu is dropped

* Resolves: #4920

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
