### PR TITLE
4931 skin frame colors

### DIFF
--- a/lib/filehighlight/get-color.c
+++ b/lib/filehighlight/get-color.c
@@ -282,7 +282,7 @@ mc_fhl_get_color (const mc_fhl_t *fhl, const file_entry_t *fe)
     int ret;
 
     if (fhl == NULL)
-        return NORMAL_COLOR;
+        return CORE_NORMAL_COLOR;
 
     for (i = 0; i < fhl->filters->len; i++)
     {
@@ -306,7 +306,7 @@ mc_fhl_get_color (const mc_fhl_t *fhl, const file_entry_t *fe)
             break;
         }
     }
-    return NORMAL_COLOR;
+    return CORE_NORMAL_COLOR;
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/skin.h
+++ b/lib/skin.h
@@ -23,94 +23,101 @@
 #define CORE_COMMAND_MARK_COLOR    mc_skin_color__cache[7]
 #define CORE_HEADER_COLOR          mc_skin_color__cache[8]
 #define CORE_SHADOW_COLOR          mc_skin_color__cache[9]
+#define CORE_FRAME_COLOR           mc_skin_color__cache[10]
 
 /* Dialog colors */
-#define DIALOG_NORMAL_COLOR          mc_skin_color__cache[10]
-#define DIALOG_FOCUS_COLOR           mc_skin_color__cache[11]
-#define DIALOG_HOT_NORMAL_COLOR      mc_skin_color__cache[12]
-#define DIALOG_HOT_FOCUS_COLOR       mc_skin_color__cache[13]
-#define DIALOG_SELECTED_NORMAL_COLOR mc_skin_color__cache[14]
-#define DIALOG_SELECTED_FOCUS_COLOR  mc_skin_color__cache[15]
-#define DIALOG_TITLE_COLOR           mc_skin_color__cache[16]
+#define DIALOG_NORMAL_COLOR          mc_skin_color__cache[11]
+#define DIALOG_FOCUS_COLOR           mc_skin_color__cache[12]
+#define DIALOG_HOT_NORMAL_COLOR      mc_skin_color__cache[13]
+#define DIALOG_HOT_FOCUS_COLOR       mc_skin_color__cache[14]
+#define DIALOG_SELECTED_NORMAL_COLOR mc_skin_color__cache[15]
+#define DIALOG_SELECTED_FOCUS_COLOR  mc_skin_color__cache[16]
+#define DIALOG_TITLE_COLOR           mc_skin_color__cache[17]
+#define DIALOG_FRAME_COLOR           mc_skin_color__cache[18]
 
 /* Error dialog colors */
-#define ERROR_NORMAL_COLOR     mc_skin_color__cache[17]
-#define ERROR_FOCUS_COLOR      mc_skin_color__cache[18]
-#define ERROR_HOT_NORMAL_COLOR mc_skin_color__cache[19]
-#define ERROR_HOT_FOCUS_COLOR  mc_skin_color__cache[20]
-#define ERROR_TITLE_COLOR      mc_skin_color__cache[21]
+#define ERROR_NORMAL_COLOR     mc_skin_color__cache[19]
+#define ERROR_FOCUS_COLOR      mc_skin_color__cache[20]
+#define ERROR_HOT_NORMAL_COLOR mc_skin_color__cache[21]
+#define ERROR_HOT_FOCUS_COLOR  mc_skin_color__cache[22]
+#define ERROR_TITLE_COLOR      mc_skin_color__cache[23]
+#define ERROR_FRAME_COLOR      mc_skin_color__cache[24]
 
 /* Menu colors */
-#define MENU_ENTRY_COLOR    mc_skin_color__cache[22]
-#define MENU_SELECTED_COLOR mc_skin_color__cache[23]
-#define MENU_HOT_COLOR      mc_skin_color__cache[24]
-#define MENU_HOTSEL_COLOR   mc_skin_color__cache[25]
-#define MENU_INACTIVE_COLOR mc_skin_color__cache[26]
+#define MENU_ENTRY_COLOR    mc_skin_color__cache[25]
+#define MENU_SELECTED_COLOR mc_skin_color__cache[26]
+#define MENU_HOT_COLOR      mc_skin_color__cache[27]
+#define MENU_HOTSEL_COLOR   mc_skin_color__cache[28]
+#define MENU_INACTIVE_COLOR mc_skin_color__cache[29]
+#define MENU_FRAME_COLOR    mc_skin_color__cache[30]
 
 /* Popup menu colors */
-#define PMENU_ENTRY_COLOR      mc_skin_color__cache[27]
-#define PMENU_SELECTED_COLOR   mc_skin_color__cache[28]
-#define PMENU_HOT_COLOR        mc_skin_color__cache[29]  // unused: not implemented yet
-#define PMENU_HOTSEL_COLOR     mc_skin_color__cache[30]  // unused: not implemented yet
-#define PMENU_TITLE_COLOR      mc_skin_color__cache[31]
+#define PMENU_ENTRY_COLOR      mc_skin_color__cache[31]
+#define PMENU_SELECTED_COLOR   mc_skin_color__cache[32]
+#define PMENU_HOT_COLOR        mc_skin_color__cache[33]  // unused: not implemented yet
+#define PMENU_HOTSEL_COLOR     mc_skin_color__cache[34]  // unused: not implemented yet
+#define PMENU_TITLE_COLOR      mc_skin_color__cache[35]
+#define PMENU_FRAME_COLOR      mc_skin_color__cache[36]
 
-#define BUTTONBAR_HOTKEY_COLOR mc_skin_color__cache[32]
-#define BUTTONBAR_BUTTON_COLOR mc_skin_color__cache[33]
+#define BUTTONBAR_HOTKEY_COLOR mc_skin_color__cache[37]
+#define BUTTONBAR_BUTTON_COLOR mc_skin_color__cache[38]
 
-#define STATUSBAR_COLOR        mc_skin_color__cache[34]
+#define STATUSBAR_COLOR        mc_skin_color__cache[39]
 
 /*
  * This should be selectable independently. Default has to be black background
  * foreground does not matter at all.
  */
-#define CORE_GAUGE_COLOR           mc_skin_color__cache[35]
-#define CORE_INPUT_COLOR           mc_skin_color__cache[36]
-#define CORE_INPUT_UNCHANGED_COLOR mc_skin_color__cache[37]
-#define CORE_INPUT_MARK_COLOR      mc_skin_color__cache[38]
-#define CORE_INPUT_HISTORY_COLOR   mc_skin_color__cache[39]
-#define CORE_COMMAND_HISTORY_COLOR mc_skin_color__cache[40]
+#define CORE_GAUGE_COLOR           mc_skin_color__cache[40]
+#define CORE_INPUT_COLOR           mc_skin_color__cache[41]
+#define CORE_INPUT_UNCHANGED_COLOR mc_skin_color__cache[42]
+#define CORE_INPUT_MARK_COLOR      mc_skin_color__cache[43]
+#define CORE_INPUT_HISTORY_COLOR   mc_skin_color__cache[44]
+#define CORE_COMMAND_HISTORY_COLOR mc_skin_color__cache[45]
 
-#define HELP_NORMAL_COLOR          mc_skin_color__cache[41]
-#define HELP_ITALIC_COLOR          mc_skin_color__cache[42]
-#define HELP_BOLD_COLOR            mc_skin_color__cache[43]
-#define HELP_LINK_COLOR            mc_skin_color__cache[44]
-#define HELP_SLINK_COLOR           mc_skin_color__cache[45]
-#define HELP_TITLE_COLOR           mc_skin_color__cache[46]
+#define HELP_NORMAL_COLOR          mc_skin_color__cache[46]
+#define HELP_ITALIC_COLOR          mc_skin_color__cache[47]
+#define HELP_BOLD_COLOR            mc_skin_color__cache[48]
+#define HELP_LINK_COLOR            mc_skin_color__cache[49]
+#define HELP_SLINK_COLOR           mc_skin_color__cache[50]
+#define HELP_TITLE_COLOR           mc_skin_color__cache[51]
+#define HELP_FRAME_COLOR           mc_skin_color__cache[52]
 
-#define VIEWER_NORMAL_COLOR        mc_skin_color__cache[47]
-#define VIEWER_BOLD_COLOR          mc_skin_color__cache[48]
-#define VIEWER_UNDERLINED_COLOR    mc_skin_color__cache[49]
-#define VIEWER_SELECTED_COLOR      mc_skin_color__cache[50]
+#define VIEWER_NORMAL_COLOR        mc_skin_color__cache[53]
+#define VIEWER_BOLD_COLOR          mc_skin_color__cache[54]
+#define VIEWER_UNDERLINED_COLOR    mc_skin_color__cache[55]
+#define VIEWER_SELECTED_COLOR      mc_skin_color__cache[56]
+#define VIEWER_FRAME_COLOR         mc_skin_color__cache[57]
 
 /*
  * editor colors - only 4 for normal, search->found, select, and whitespace
  * respectively
  * Last is defined to view color.
  */
-#define EDITOR_NORMAL_COLOR       mc_skin_color__cache[51]
-#define EDITOR_NONPRINTABLE_COLOR mc_skin_color__cache[52]
-#define EDITOR_BOLD_COLOR         mc_skin_color__cache[53]
-#define EDITOR_MARKED_COLOR       mc_skin_color__cache[54]
-#define EDITOR_WHITESPACE_COLOR   mc_skin_color__cache[55]
-#define EDITOR_RIGHT_MARGIN_COLOR mc_skin_color__cache[56]
-#define EDITOR_BACKGROUND_COLOR   mc_skin_color__cache[57]
-#define EDITOR_FRAME_COLOR        mc_skin_color__cache[58]
-#define EDITOR_FRAME_ACTIVE_COLOR mc_skin_color__cache[59]
-#define EDITOR_FRAME_DRAG_COLOR   mc_skin_color__cache[60]
+#define EDITOR_NORMAL_COLOR       mc_skin_color__cache[58]
+#define EDITOR_NONPRINTABLE_COLOR mc_skin_color__cache[59]
+#define EDITOR_BOLD_COLOR         mc_skin_color__cache[60]
+#define EDITOR_MARKED_COLOR       mc_skin_color__cache[61]
+#define EDITOR_WHITESPACE_COLOR   mc_skin_color__cache[62]
+#define EDITOR_RIGHT_MARGIN_COLOR mc_skin_color__cache[63]
+#define EDITOR_BACKGROUND_COLOR   mc_skin_color__cache[64]
+#define EDITOR_FRAME_COLOR        mc_skin_color__cache[65]
+#define EDITOR_FRAME_ACTIVE_COLOR mc_skin_color__cache[66]
+#define EDITOR_FRAME_DRAG_COLOR   mc_skin_color__cache[67]
 /* color of left 8 char status per line */
-#define EDITOR_LINE_STATE_COLOR     mc_skin_color__cache[61]
-#define EDITOR_BOOKMARK_COLOR       mc_skin_color__cache[62]
-#define EDITOR_BOOKMARK_FOUND_COLOR mc_skin_color__cache[63]
+#define EDITOR_LINE_STATE_COLOR     mc_skin_color__cache[68]
+#define EDITOR_BOOKMARK_COLOR       mc_skin_color__cache[69]
+#define EDITOR_BOOKMARK_FOUND_COLOR mc_skin_color__cache[70]
 
 /* Diff colors */
-#define DIFFVIEWER_ADDED_COLOR       mc_skin_color__cache[64]
-#define DIFFVIEWER_CHANGEDLINE_COLOR mc_skin_color__cache[65]
-#define DIFFVIEWER_CHANGEDNEW_COLOR  mc_skin_color__cache[66]
-#define DIFFVIEWER_CHANGED_COLOR     mc_skin_color__cache[67]
-#define DIFFVIEWER_REMOVED_COLOR     mc_skin_color__cache[68]
-#define DIFFVIEWER_ERROR_COLOR       mc_skin_color__cache[69]
+#define DIFFVIEWER_ADDED_COLOR       mc_skin_color__cache[71]
+#define DIFFVIEWER_CHANGEDLINE_COLOR mc_skin_color__cache[72]
+#define DIFFVIEWER_CHANGEDNEW_COLOR  mc_skin_color__cache[73]
+#define DIFFVIEWER_CHANGED_COLOR     mc_skin_color__cache[74]
+#define DIFFVIEWER_REMOVED_COLOR     mc_skin_color__cache[75]
+#define DIFFVIEWER_ERROR_COLOR       mc_skin_color__cache[76]
 
-#define MC_SKIN_COLOR_CACHE_COUNT    70
+#define MC_SKIN_COLOR_CACHE_COUNT    77
 
 /*** enums ***************************************************************************************/
 

--- a/lib/skin.h
+++ b/lib/skin.h
@@ -13,32 +13,32 @@
    See color-slang.h (A_*) */
 
 /* cache often used colors */
-#define DEFAULT_COLOR         mc_skin_color__cache[0]
-#define NORMAL_COLOR          mc_skin_color__cache[1]
-#define MARKED_COLOR          mc_skin_color__cache[2]
-#define SELECTED_COLOR        mc_skin_color__cache[3]
-#define MARKED_SELECTED_COLOR mc_skin_color__cache[4]
-#define DISABLED_COLOR        mc_skin_color__cache[5]
-#define REVERSE_COLOR         mc_skin_color__cache[6]
-#define COMMAND_MARK_COLOR    mc_skin_color__cache[7]
-#define HEADER_COLOR          mc_skin_color__cache[8]
-#define SHADOW_COLOR          mc_skin_color__cache[9]
+#define CORE_DEFAULT_COLOR         mc_skin_color__cache[0]
+#define CORE_NORMAL_COLOR          mc_skin_color__cache[1]
+#define CORE_MARKED_COLOR          mc_skin_color__cache[2]
+#define CORE_SELECTED_COLOR        mc_skin_color__cache[3]
+#define CORE_MARKED_SELECTED_COLOR mc_skin_color__cache[4]
+#define CORE_DISABLED_COLOR        mc_skin_color__cache[5]
+#define CORE_REVERSE_COLOR         mc_skin_color__cache[6]
+#define CORE_COMMAND_MARK_COLOR    mc_skin_color__cache[7]
+#define CORE_HEADER_COLOR          mc_skin_color__cache[8]
+#define CORE_SHADOW_COLOR          mc_skin_color__cache[9]
 
 /* Dialog colors */
-#define COLOR_NORMAL          mc_skin_color__cache[10]
-#define COLOR_FOCUS           mc_skin_color__cache[11]
-#define COLOR_HOT_NORMAL      mc_skin_color__cache[12]
-#define COLOR_HOT_FOCUS       mc_skin_color__cache[13]
-#define COLOR_SELECTED_NORMAL mc_skin_color__cache[14]
-#define COLOR_SELECTED_FOCUS  mc_skin_color__cache[15]
-#define COLOR_TITLE           mc_skin_color__cache[16]
+#define DIALOG_NORMAL_COLOR          mc_skin_color__cache[10]
+#define DIALOG_FOCUS_COLOR           mc_skin_color__cache[11]
+#define DIALOG_HOT_NORMAL_COLOR      mc_skin_color__cache[12]
+#define DIALOG_HOT_FOCUS_COLOR       mc_skin_color__cache[13]
+#define DIALOG_SELECTED_NORMAL_COLOR mc_skin_color__cache[14]
+#define DIALOG_SELECTED_FOCUS_COLOR  mc_skin_color__cache[15]
+#define DIALOG_TITLE_COLOR           mc_skin_color__cache[16]
 
 /* Error dialog colors */
-#define ERROR_COLOR      mc_skin_color__cache[17]
-#define ERROR_FOCUS      mc_skin_color__cache[18]
-#define ERROR_HOT_NORMAL mc_skin_color__cache[19]
-#define ERROR_HOT_FOCUS  mc_skin_color__cache[20]
-#define ERROR_TITLE      mc_skin_color__cache[21]
+#define ERROR_NORMAL_COLOR     mc_skin_color__cache[17]
+#define ERROR_FOCUS_COLOR      mc_skin_color__cache[18]
+#define ERROR_HOT_NORMAL_COLOR mc_skin_color__cache[19]
+#define ERROR_HOT_FOCUS_COLOR  mc_skin_color__cache[20]
+#define ERROR_TITLE_COLOR      mc_skin_color__cache[21]
 
 /* Menu colors */
 #define MENU_ENTRY_COLOR    mc_skin_color__cache[22]
@@ -63,24 +63,24 @@
  * This should be selectable independently. Default has to be black background
  * foreground does not matter at all.
  */
-#define GAUGE_COLOR           mc_skin_color__cache[35]
-#define INPUT_COLOR           mc_skin_color__cache[36]
-#define INPUT_UNCHANGED_COLOR mc_skin_color__cache[37]
-#define INPUT_MARK_COLOR      mc_skin_color__cache[38]
-#define INPUT_HISTORY_COLOR   mc_skin_color__cache[39]
-#define COMMAND_HISTORY_COLOR mc_skin_color__cache[40]
+#define CORE_GAUGE_COLOR           mc_skin_color__cache[35]
+#define CORE_INPUT_COLOR           mc_skin_color__cache[36]
+#define CORE_INPUT_UNCHANGED_COLOR mc_skin_color__cache[37]
+#define CORE_INPUT_MARK_COLOR      mc_skin_color__cache[38]
+#define CORE_INPUT_HISTORY_COLOR   mc_skin_color__cache[39]
+#define CORE_COMMAND_HISTORY_COLOR mc_skin_color__cache[40]
 
-#define HELP_NORMAL_COLOR     mc_skin_color__cache[41]
-#define HELP_ITALIC_COLOR     mc_skin_color__cache[42]
-#define HELP_BOLD_COLOR       mc_skin_color__cache[43]
-#define HELP_LINK_COLOR       mc_skin_color__cache[44]
-#define HELP_SLINK_COLOR      mc_skin_color__cache[45]
-#define HELP_TITLE_COLOR      mc_skin_color__cache[46]
+#define HELP_NORMAL_COLOR          mc_skin_color__cache[41]
+#define HELP_ITALIC_COLOR          mc_skin_color__cache[42]
+#define HELP_BOLD_COLOR            mc_skin_color__cache[43]
+#define HELP_LINK_COLOR            mc_skin_color__cache[44]
+#define HELP_SLINK_COLOR           mc_skin_color__cache[45]
+#define HELP_TITLE_COLOR           mc_skin_color__cache[46]
 
-#define VIEW_NORMAL_COLOR     mc_skin_color__cache[47]
-#define VIEW_BOLD_COLOR       mc_skin_color__cache[48]
-#define VIEW_UNDERLINED_COLOR mc_skin_color__cache[49]
-#define VIEW_SELECTED_COLOR   mc_skin_color__cache[50]
+#define VIEWER_NORMAL_COLOR        mc_skin_color__cache[47]
+#define VIEWER_BOLD_COLOR          mc_skin_color__cache[48]
+#define VIEWER_UNDERLINED_COLOR    mc_skin_color__cache[49]
+#define VIEWER_SELECTED_COLOR      mc_skin_color__cache[50]
 
 /*
  * editor colors - only 4 for normal, search->found, select, and whitespace
@@ -93,24 +93,24 @@
 #define EDITOR_MARKED_COLOR       mc_skin_color__cache[54]
 #define EDITOR_WHITESPACE_COLOR   mc_skin_color__cache[55]
 #define EDITOR_RIGHT_MARGIN_COLOR mc_skin_color__cache[56]
-#define EDITOR_BACKGROUND         mc_skin_color__cache[57]
-#define EDITOR_FRAME              mc_skin_color__cache[58]
-#define EDITOR_FRAME_ACTIVE       mc_skin_color__cache[59]
-#define EDITOR_FRAME_DRAG         mc_skin_color__cache[60]
+#define EDITOR_BACKGROUND_COLOR   mc_skin_color__cache[57]
+#define EDITOR_FRAME_COLOR        mc_skin_color__cache[58]
+#define EDITOR_FRAME_ACTIVE_COLOR mc_skin_color__cache[59]
+#define EDITOR_FRAME_DRAG_COLOR   mc_skin_color__cache[60]
 /* color of left 8 char status per line */
-#define LINE_STATE_COLOR      mc_skin_color__cache[61]
-#define BOOK_MARK_COLOR       mc_skin_color__cache[62]
-#define BOOK_MARK_FOUND_COLOR mc_skin_color__cache[63]
+#define EDITOR_LINE_STATE_COLOR     mc_skin_color__cache[61]
+#define EDITOR_BOOKMARK_COLOR       mc_skin_color__cache[62]
+#define EDITOR_BOOKMARK_FOUND_COLOR mc_skin_color__cache[63]
 
 /* Diff colors */
-#define DFF_ADD_COLOR             mc_skin_color__cache[64]
-#define DFF_CHG_COLOR             mc_skin_color__cache[65]
-#define DFF_CHH_COLOR             mc_skin_color__cache[66]
-#define DFF_CHD_COLOR             mc_skin_color__cache[67]
-#define DFF_DEL_COLOR             mc_skin_color__cache[68]
-#define DFF_ERROR_COLOR           mc_skin_color__cache[69]
+#define DIFFVIEWER_ADDED_COLOR       mc_skin_color__cache[64]
+#define DIFFVIEWER_CHANGEDLINE_COLOR mc_skin_color__cache[65]
+#define DIFFVIEWER_CHANGEDNEW_COLOR  mc_skin_color__cache[66]
+#define DIFFVIEWER_CHANGED_COLOR     mc_skin_color__cache[67]
+#define DIFFVIEWER_REMOVED_COLOR     mc_skin_color__cache[68]
+#define DIFFVIEWER_ERROR_COLOR       mc_skin_color__cache[69]
 
-#define MC_SKIN_COLOR_CACHE_COUNT 70
+#define MC_SKIN_COLOR_CACHE_COUNT    70
 
 /*** enums ***************************************************************************************/
 

--- a/lib/skin/colors.c
+++ b/lib/skin/colors.c
@@ -254,6 +254,7 @@ mc_skin_color_cache_init (void)
     CORE_HEADER_COLOR = mc_skin_color_get ("core", "header");
     CORE_COMMAND_MARK_COLOR = mc_skin_color_get ("core", "commandlinemark");
     CORE_SHADOW_COLOR = mc_skin_color_get ("core", "shadow");
+    CORE_FRAME_COLOR = mc_skin_color_get ("core", "frame");
 
     DIALOG_NORMAL_COLOR = mc_skin_color_get ("dialog", "_default_");
     DIALOG_FOCUS_COLOR = mc_skin_color_get ("dialog", "dfocus");
@@ -262,22 +263,26 @@ mc_skin_color_cache_init (void)
     DIALOG_SELECTED_NORMAL_COLOR = mc_skin_color_get ("dialog", "dselnormal");
     DIALOG_SELECTED_FOCUS_COLOR = mc_skin_color_get ("dialog", "dselfocus");
     DIALOG_TITLE_COLOR = mc_skin_color_get ("dialog", "dtitle");
+    DIALOG_FRAME_COLOR = mc_skin_color_get ("dialog", "dframe");
 
     ERROR_NORMAL_COLOR = mc_skin_color_get ("error", "_default_");
     ERROR_FOCUS_COLOR = mc_skin_color_get ("error", "errdfocus");
     ERROR_HOT_NORMAL_COLOR = mc_skin_color_get ("error", "errdhotnormal");
     ERROR_HOT_FOCUS_COLOR = mc_skin_color_get ("error", "errdhotfocus");
     ERROR_TITLE_COLOR = mc_skin_color_get ("error", "errdtitle");
+    ERROR_FRAME_COLOR = mc_skin_color_get ("error", "errdframe");
 
     MENU_ENTRY_COLOR = mc_skin_color_get ("menu", "_default_");
     MENU_SELECTED_COLOR = mc_skin_color_get ("menu", "menusel");
     MENU_HOT_COLOR = mc_skin_color_get ("menu", "menuhot");
     MENU_HOTSEL_COLOR = mc_skin_color_get ("menu", "menuhotsel");
     MENU_INACTIVE_COLOR = mc_skin_color_get ("menu", "menuinactive");
+    MENU_FRAME_COLOR = mc_skin_color_get ("menu", "menuframe");
 
     PMENU_ENTRY_COLOR = mc_skin_color_get ("popupmenu", "_default_");
     PMENU_SELECTED_COLOR = mc_skin_color_get ("popupmenu", "menusel");
     PMENU_TITLE_COLOR = mc_skin_color_get ("popupmenu", "menutitle");
+    PMENU_FRAME_COLOR = mc_skin_color_get ("popupmenu", "menuframe");
 
     BUTTONBAR_HOTKEY_COLOR = mc_skin_color_get ("buttonbar", "hotkey");
     BUTTONBAR_BUTTON_COLOR = mc_skin_color_get ("buttonbar", "button");
@@ -297,11 +302,13 @@ mc_skin_color_cache_init (void)
     HELP_LINK_COLOR = mc_skin_color_get ("help", "helplink");
     HELP_SLINK_COLOR = mc_skin_color_get ("help", "helpslink");
     HELP_TITLE_COLOR = mc_skin_color_get ("help", "helptitle");
+    HELP_FRAME_COLOR = mc_skin_color_get ("help", "helpframe");
 
     VIEWER_NORMAL_COLOR = mc_skin_color_get ("viewer", "_default_");
     VIEWER_BOLD_COLOR = mc_skin_color_get ("viewer", "viewbold");
     VIEWER_UNDERLINED_COLOR = mc_skin_color_get ("viewer", "viewunderline");
     VIEWER_SELECTED_COLOR = mc_skin_color_get ("viewer", "viewselected");
+    VIEWER_FRAME_COLOR = mc_skin_color_get ("viewer", "viewframe");
 
     EDITOR_NORMAL_COLOR = mc_skin_color_get ("editor", "_default_");
     EDITOR_BOLD_COLOR = mc_skin_color_get ("editor", "editbold");

--- a/lib/skin/colors.c
+++ b/lib/skin/colors.c
@@ -244,30 +244,30 @@ mc_skin_color_set_default_for_terminal (mc_skin_t *mc_skin)
 static void
 mc_skin_color_cache_init (void)
 {
-    DEFAULT_COLOR = mc_skin_color_get ("skin", "terminal_default_color");
-    NORMAL_COLOR = mc_skin_color_get ("core", "_default_");
-    MARKED_COLOR = mc_skin_color_get ("core", "marked");
-    SELECTED_COLOR = mc_skin_color_get ("core", "selected");
-    MARKED_SELECTED_COLOR = mc_skin_color_get ("core", "markselect");
-    DISABLED_COLOR = mc_skin_color_get ("core", "disabled");
-    REVERSE_COLOR = mc_skin_color_get ("core", "reverse");
-    HEADER_COLOR = mc_skin_color_get ("core", "header");
-    COMMAND_MARK_COLOR = mc_skin_color_get ("core", "commandlinemark");
-    SHADOW_COLOR = mc_skin_color_get ("core", "shadow");
+    CORE_DEFAULT_COLOR = mc_skin_color_get ("skin", "terminal_default_color");
+    CORE_NORMAL_COLOR = mc_skin_color_get ("core", "_default_");
+    CORE_MARKED_COLOR = mc_skin_color_get ("core", "marked");
+    CORE_SELECTED_COLOR = mc_skin_color_get ("core", "selected");
+    CORE_MARKED_SELECTED_COLOR = mc_skin_color_get ("core", "markselect");
+    CORE_DISABLED_COLOR = mc_skin_color_get ("core", "disabled");
+    CORE_REVERSE_COLOR = mc_skin_color_get ("core", "reverse");
+    CORE_HEADER_COLOR = mc_skin_color_get ("core", "header");
+    CORE_COMMAND_MARK_COLOR = mc_skin_color_get ("core", "commandlinemark");
+    CORE_SHADOW_COLOR = mc_skin_color_get ("core", "shadow");
 
-    COLOR_NORMAL = mc_skin_color_get ("dialog", "_default_");
-    COLOR_FOCUS = mc_skin_color_get ("dialog", "dfocus");
-    COLOR_HOT_NORMAL = mc_skin_color_get ("dialog", "dhotnormal");
-    COLOR_HOT_FOCUS = mc_skin_color_get ("dialog", "dhotfocus");
-    COLOR_SELECTED_NORMAL = mc_skin_color_get ("dialog", "dselnormal");
-    COLOR_SELECTED_FOCUS = mc_skin_color_get ("dialog", "dselfocus");
-    COLOR_TITLE = mc_skin_color_get ("dialog", "dtitle");
+    DIALOG_NORMAL_COLOR = mc_skin_color_get ("dialog", "_default_");
+    DIALOG_FOCUS_COLOR = mc_skin_color_get ("dialog", "dfocus");
+    DIALOG_HOT_NORMAL_COLOR = mc_skin_color_get ("dialog", "dhotnormal");
+    DIALOG_HOT_FOCUS_COLOR = mc_skin_color_get ("dialog", "dhotfocus");
+    DIALOG_SELECTED_NORMAL_COLOR = mc_skin_color_get ("dialog", "dselnormal");
+    DIALOG_SELECTED_FOCUS_COLOR = mc_skin_color_get ("dialog", "dselfocus");
+    DIALOG_TITLE_COLOR = mc_skin_color_get ("dialog", "dtitle");
 
-    ERROR_COLOR = mc_skin_color_get ("error", "_default_");
-    ERROR_FOCUS = mc_skin_color_get ("error", "errdfocus");
-    ERROR_HOT_NORMAL = mc_skin_color_get ("error", "errdhotnormal");
-    ERROR_HOT_FOCUS = mc_skin_color_get ("error", "errdhotfocus");
-    ERROR_TITLE = mc_skin_color_get ("error", "errdtitle");
+    ERROR_NORMAL_COLOR = mc_skin_color_get ("error", "_default_");
+    ERROR_FOCUS_COLOR = mc_skin_color_get ("error", "errdfocus");
+    ERROR_HOT_NORMAL_COLOR = mc_skin_color_get ("error", "errdhotnormal");
+    ERROR_HOT_FOCUS_COLOR = mc_skin_color_get ("error", "errdhotfocus");
+    ERROR_TITLE_COLOR = mc_skin_color_get ("error", "errdtitle");
 
     MENU_ENTRY_COLOR = mc_skin_color_get ("menu", "_default_");
     MENU_SELECTED_COLOR = mc_skin_color_get ("menu", "menusel");
@@ -284,12 +284,12 @@ mc_skin_color_cache_init (void)
 
     STATUSBAR_COLOR = mc_skin_color_get ("statusbar", "_default_");
 
-    GAUGE_COLOR = mc_skin_color_get ("core", "gauge");
-    INPUT_COLOR = mc_skin_color_get ("core", "input");
-    INPUT_HISTORY_COLOR = mc_skin_color_get ("core", "inputhistory");
-    COMMAND_HISTORY_COLOR = mc_skin_color_get ("core", "commandhistory");
-    INPUT_MARK_COLOR = mc_skin_color_get ("core", "inputmark");
-    INPUT_UNCHANGED_COLOR = mc_skin_color_get ("core", "inputunchanged");
+    CORE_GAUGE_COLOR = mc_skin_color_get ("core", "gauge");
+    CORE_INPUT_COLOR = mc_skin_color_get ("core", "input");
+    CORE_INPUT_HISTORY_COLOR = mc_skin_color_get ("core", "inputhistory");
+    CORE_COMMAND_HISTORY_COLOR = mc_skin_color_get ("core", "commandhistory");
+    CORE_INPUT_MARK_COLOR = mc_skin_color_get ("core", "inputmark");
+    CORE_INPUT_UNCHANGED_COLOR = mc_skin_color_get ("core", "inputunchanged");
 
     HELP_NORMAL_COLOR = mc_skin_color_get ("help", "_default_");
     HELP_ITALIC_COLOR = mc_skin_color_get ("help", "helpitalic");
@@ -298,10 +298,10 @@ mc_skin_color_cache_init (void)
     HELP_SLINK_COLOR = mc_skin_color_get ("help", "helpslink");
     HELP_TITLE_COLOR = mc_skin_color_get ("help", "helptitle");
 
-    VIEW_NORMAL_COLOR = mc_skin_color_get ("viewer", "_default_");
-    VIEW_BOLD_COLOR = mc_skin_color_get ("viewer", "viewbold");
-    VIEW_UNDERLINED_COLOR = mc_skin_color_get ("viewer", "viewunderline");
-    VIEW_SELECTED_COLOR = mc_skin_color_get ("viewer", "viewselected");
+    VIEWER_NORMAL_COLOR = mc_skin_color_get ("viewer", "_default_");
+    VIEWER_BOLD_COLOR = mc_skin_color_get ("viewer", "viewbold");
+    VIEWER_UNDERLINED_COLOR = mc_skin_color_get ("viewer", "viewunderline");
+    VIEWER_SELECTED_COLOR = mc_skin_color_get ("viewer", "viewselected");
 
     EDITOR_NORMAL_COLOR = mc_skin_color_get ("editor", "_default_");
     EDITOR_BOLD_COLOR = mc_skin_color_get ("editor", "editbold");
@@ -309,21 +309,21 @@ mc_skin_color_cache_init (void)
     EDITOR_WHITESPACE_COLOR = mc_skin_color_get ("editor", "editwhitespace");
     EDITOR_NONPRINTABLE_COLOR = mc_skin_color_get ("editor", "editnonprintable");
     EDITOR_RIGHT_MARGIN_COLOR = mc_skin_color_get ("editor", "editrightmargin");
-    LINE_STATE_COLOR = mc_skin_color_get ("editor", "editlinestate");
-    EDITOR_BACKGROUND = mc_skin_color_get ("editor", "editbg");
-    EDITOR_FRAME = mc_skin_color_get ("editor", "editframe");
-    EDITOR_FRAME_ACTIVE = mc_skin_color_get ("editor", "editframeactive");
-    EDITOR_FRAME_DRAG = mc_skin_color_get ("editor", "editframedrag");
+    EDITOR_LINE_STATE_COLOR = mc_skin_color_get ("editor", "editlinestate");
+    EDITOR_BACKGROUND_COLOR = mc_skin_color_get ("editor", "editbg");
+    EDITOR_FRAME_COLOR = mc_skin_color_get ("editor", "editframe");
+    EDITOR_FRAME_ACTIVE_COLOR = mc_skin_color_get ("editor", "editframeactive");
+    EDITOR_FRAME_DRAG_COLOR = mc_skin_color_get ("editor", "editframedrag");
 
-    BOOK_MARK_COLOR = mc_skin_color_get ("editor", "bookmark");
-    BOOK_MARK_FOUND_COLOR = mc_skin_color_get ("editor", "bookmarkfound");
+    EDITOR_BOOKMARK_COLOR = mc_skin_color_get ("editor", "bookmark");
+    EDITOR_BOOKMARK_FOUND_COLOR = mc_skin_color_get ("editor", "bookmarkfound");
 
-    DFF_ADD_COLOR = mc_skin_color_get ("diffviewer", "added");
-    DFF_CHG_COLOR = mc_skin_color_get ("diffviewer", "changedline");
-    DFF_CHH_COLOR = mc_skin_color_get ("diffviewer", "changednew");
-    DFF_CHD_COLOR = mc_skin_color_get ("diffviewer", "changed");
-    DFF_DEL_COLOR = mc_skin_color_get ("diffviewer", "removed");
-    DFF_ERROR_COLOR = mc_skin_color_get ("diffviewer", "error");
+    DIFFVIEWER_ADDED_COLOR = mc_skin_color_get ("diffviewer", "added");
+    DIFFVIEWER_CHANGEDLINE_COLOR = mc_skin_color_get ("diffviewer", "changedline");
+    DIFFVIEWER_CHANGEDNEW_COLOR = mc_skin_color_get ("diffviewer", "changednew");
+    DIFFVIEWER_CHANGED_COLOR = mc_skin_color_get ("diffviewer", "changed");
+    DIFFVIEWER_REMOVED_COLOR = mc_skin_color_get ("diffviewer", "removed");
+    DIFFVIEWER_ERROR_COLOR = mc_skin_color_get ("diffviewer", "error");
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/widget/buttonbar.c
+++ b/lib/widget/buttonbar.c
@@ -180,7 +180,7 @@ buttonbar_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void 
         {
             buttonbar_init_button_positions (bb);
             widget_gotoyx (w, 0, 0);
-            tty_setcolor (DEFAULT_COLOR);
+            tty_setcolor (CORE_DEFAULT_COLOR);
             tty_printf ("%-*s", w->rect.cols, "");
             widget_gotoyx (w, 0, 0);
 

--- a/lib/widget/dialog.c
+++ b/lib/widget/dialog.c
@@ -453,21 +453,21 @@ dlg_create (gboolean modal, int y1, int x1, int lines, int cols, widget_pos_flag
 void
 dlg_set_default_colors (void)
 {
-    dialog_colors[DLG_COLOR_NORMAL] = COLOR_NORMAL;
-    dialog_colors[DLG_COLOR_FOCUS] = COLOR_FOCUS;
-    dialog_colors[DLG_COLOR_HOT_NORMAL] = COLOR_HOT_NORMAL;
-    dialog_colors[DLG_COLOR_HOT_FOCUS] = COLOR_HOT_FOCUS;
-    dialog_colors[DLG_COLOR_SELECTED_NORMAL] = COLOR_SELECTED_NORMAL;
-    dialog_colors[DLG_COLOR_SELECTED_FOCUS] = COLOR_SELECTED_FOCUS;
-    dialog_colors[DLG_COLOR_TITLE] = COLOR_TITLE;
+    dialog_colors[DLG_COLOR_NORMAL] = DIALOG_NORMAL_COLOR;
+    dialog_colors[DLG_COLOR_FOCUS] = DIALOG_FOCUS_COLOR;
+    dialog_colors[DLG_COLOR_HOT_NORMAL] = DIALOG_HOT_NORMAL_COLOR;
+    dialog_colors[DLG_COLOR_HOT_FOCUS] = DIALOG_HOT_FOCUS_COLOR;
+    dialog_colors[DLG_COLOR_SELECTED_NORMAL] = DIALOG_SELECTED_NORMAL_COLOR;
+    dialog_colors[DLG_COLOR_SELECTED_FOCUS] = DIALOG_SELECTED_FOCUS_COLOR;
+    dialog_colors[DLG_COLOR_TITLE] = DIALOG_TITLE_COLOR;
 
-    alarm_colors[DLG_COLOR_NORMAL] = ERROR_COLOR;
-    alarm_colors[DLG_COLOR_FOCUS] = ERROR_FOCUS;
-    alarm_colors[DLG_COLOR_HOT_NORMAL] = ERROR_HOT_NORMAL;
-    alarm_colors[DLG_COLOR_HOT_FOCUS] = ERROR_HOT_FOCUS;
-    alarm_colors[DLG_COLOR_SELECTED_NORMAL] = ERROR_HOT_FOCUS;  // unused
-    alarm_colors[DLG_COLOR_SELECTED_FOCUS] = ERROR_FOCUS;       // unused
-    alarm_colors[DLG_COLOR_TITLE] = ERROR_TITLE;
+    alarm_colors[DLG_COLOR_NORMAL] = ERROR_NORMAL_COLOR;
+    alarm_colors[DLG_COLOR_FOCUS] = ERROR_FOCUS_COLOR;
+    alarm_colors[DLG_COLOR_HOT_NORMAL] = ERROR_HOT_NORMAL_COLOR;
+    alarm_colors[DLG_COLOR_HOT_FOCUS] = ERROR_HOT_FOCUS_COLOR;
+    alarm_colors[DLG_COLOR_SELECTED_NORMAL] = ERROR_HOT_FOCUS_COLOR;  // unused
+    alarm_colors[DLG_COLOR_SELECTED_FOCUS] = ERROR_FOCUS_COLOR;       // unused
+    alarm_colors[DLG_COLOR_TITLE] = ERROR_TITLE_COLOR;
 
     listbox_colors[DLG_COLOR_NORMAL] = PMENU_ENTRY_COLOR;
     listbox_colors[DLG_COLOR_FOCUS] = PMENU_SELECTED_COLOR;

--- a/lib/widget/dialog.c
+++ b/lib/widget/dialog.c
@@ -460,6 +460,7 @@ dlg_set_default_colors (void)
     dialog_colors[DLG_COLOR_SELECTED_NORMAL] = DIALOG_SELECTED_NORMAL_COLOR;
     dialog_colors[DLG_COLOR_SELECTED_FOCUS] = DIALOG_SELECTED_FOCUS_COLOR;
     dialog_colors[DLG_COLOR_TITLE] = DIALOG_TITLE_COLOR;
+    dialog_colors[DLG_COLOR_FRAME] = DIALOG_FRAME_COLOR;
 
     alarm_colors[DLG_COLOR_NORMAL] = ERROR_NORMAL_COLOR;
     alarm_colors[DLG_COLOR_FOCUS] = ERROR_FOCUS_COLOR;
@@ -468,6 +469,7 @@ dlg_set_default_colors (void)
     alarm_colors[DLG_COLOR_SELECTED_NORMAL] = ERROR_HOT_FOCUS_COLOR;  // unused
     alarm_colors[DLG_COLOR_SELECTED_FOCUS] = ERROR_FOCUS_COLOR;       // unused
     alarm_colors[DLG_COLOR_TITLE] = ERROR_TITLE_COLOR;
+    alarm_colors[DLG_COLOR_FRAME] = ERROR_FRAME_COLOR;
 
     listbox_colors[DLG_COLOR_NORMAL] = PMENU_ENTRY_COLOR;
     listbox_colors[DLG_COLOR_FOCUS] = PMENU_SELECTED_COLOR;
@@ -476,6 +478,7 @@ dlg_set_default_colors (void)
     listbox_colors[DLG_COLOR_SELECTED_NORMAL] = PMENU_SELECTED_COLOR;  // unused
     listbox_colors[DLG_COLOR_SELECTED_FOCUS] = PMENU_SELECTED_COLOR;   // unused
     listbox_colors[DLG_COLOR_TITLE] = PMENU_TITLE_COLOR;
+    listbox_colors[DLG_COLOR_FRAME] = PMENU_FRAME_COLOR;
 
     help_colors[DLG_COLOR_NORMAL] = HELP_NORMAL_COLOR;
     help_colors[DLG_COLOR_FOCUS] = 0;  // unused
@@ -484,6 +487,7 @@ dlg_set_default_colors (void)
     help_colors[DLG_COLOR_SELECTED_NORMAL] = 0;  // unused
     help_colors[DLG_COLOR_SELECTED_FOCUS] = 0;   // unused
     help_colors[DLG_COLOR_TITLE] = HELP_TITLE_COLOR;
+    help_colors[DLG_COLOR_FRAME] = HELP_FRAME_COLOR;
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/widget/dialog.h
+++ b/lib/widget/dialog.h
@@ -40,6 +40,7 @@ typedef enum
     DLG_COLOR_SELECTED_NORMAL,
     DLG_COLOR_SELECTED_FOCUS,
     DLG_COLOR_TITLE,
+    DLG_COLOR_FRAME,
     DLG_COLOR_COUNT
 } dlg_colors_enum_t;
 

--- a/lib/widget/frame.c
+++ b/lib/widget/frame.c
@@ -79,6 +79,7 @@ frame_draw (const WFrame *f)
 
     tty_setcolor (colors[FRAME_COLOR_NORMAL]);
     tty_fill_region (w->y, w->x, w->lines, w->cols, ' ');
+    tty_setcolor (colors[FRAME_COLOR_FRAME]);
     tty_draw_box (w->y + d, w->x + d, w->lines - 2 * d, w->cols - 2 * d, f->single);
 
     if (f->title != NULL)

--- a/lib/widget/frame.c
+++ b/lib/widget/frame.c
@@ -75,7 +75,7 @@ frame_draw (const WFrame *f)
     colors = widget_get_colors (wf);
 
     if (mc_global.tty.shadows)
-        tty_draw_box_shadow (w->y, w->x, w->lines, w->cols, SHADOW_COLOR);
+        tty_draw_box_shadow (w->y, w->x, w->lines, w->cols, CORE_SHADOW_COLOR);
 
     tty_setcolor (colors[FRAME_COLOR_NORMAL]);
     tty_fill_region (w->y, w->x, w->lines, w->cols, ' ');

--- a/lib/widget/frame.h
+++ b/lib/widget/frame.h
@@ -13,6 +13,7 @@
 
 #define FRAME_COLOR_NORMAL DLG_COLOR_NORMAL
 #define FRAME_COLOR_TITLE  DLG_COLOR_TITLE
+#define FRAME_COLOR_FRAME  DLG_COLOR_FRAME
 
 /*** enums ***************************************************************************************/
 

--- a/lib/widget/gauge.c
+++ b/lib/widget/gauge.c
@@ -101,7 +101,7 @@ gauge_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void *dat
             tty_print_char ('[');
             if (g->from_left_to_right)
             {
-                tty_setcolor (GAUGE_COLOR);
+                tty_setcolor (CORE_GAUGE_COLOR);
                 tty_printf ("%*s", columns, "");
                 tty_setcolor (colors[DLG_COLOR_NORMAL]);
                 tty_printf ("%*s] %3d%%", gauge_len - columns, "", percentage);
@@ -110,7 +110,7 @@ gauge_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void *dat
             {
                 tty_setcolor (colors[DLG_COLOR_NORMAL]);
                 tty_printf ("%*s", gauge_len - columns, "");
-                tty_setcolor (GAUGE_COLOR);
+                tty_setcolor (CORE_GAUGE_COLOR);
                 tty_printf ("%*s", columns, "");
                 tty_setcolor (colors[DLG_COLOR_NORMAL]);
                 tty_printf ("] %3d%%", percentage);

--- a/lib/widget/groupbox.c
+++ b/lib/widget/groupbox.c
@@ -71,12 +71,12 @@ groupbox_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void *
         colors = widget_get_colors (w);
 
         disabled = widget_get_state (w, WST_DISABLED);
-        tty_setcolor (disabled ? DISABLED_COLOR : colors[DLG_COLOR_NORMAL]);
+        tty_setcolor (disabled ? CORE_DISABLED_COLOR : colors[DLG_COLOR_NORMAL]);
         tty_draw_box (w->rect.y, w->rect.x, w->rect.lines, w->rect.cols, TRUE);
 
         if (g->title != NULL)
         {
-            tty_setcolor (disabled ? DISABLED_COLOR : colors[DLG_COLOR_TITLE]);
+            tty_setcolor (disabled ? CORE_DISABLED_COLOR : colors[DLG_COLOR_TITLE]);
             widget_gotoyx (w, 0, 1);
             tty_print_string (g->title);
         }

--- a/lib/widget/groupbox.c
+++ b/lib/widget/groupbox.c
@@ -71,7 +71,7 @@ groupbox_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void *
         colors = widget_get_colors (w);
 
         disabled = widget_get_state (w, WST_DISABLED);
-        tty_setcolor (disabled ? CORE_DISABLED_COLOR : colors[DLG_COLOR_NORMAL]);
+        tty_setcolor (disabled ? CORE_DISABLED_COLOR : colors[DLG_COLOR_FRAME]);
         tty_draw_box (w->rect.y, w->rect.x, w->rect.lines, w->rect.cols, TRUE);
 
         if (g->title != NULL)

--- a/lib/widget/hline.c
+++ b/lib/widget/hline.c
@@ -101,7 +101,7 @@ hline_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void *dat
 
     case MSG_DRAW:
         if (l->transparent)
-            tty_setcolor (DEFAULT_COLOR);
+            tty_setcolor (CORE_DEFAULT_COLOR);
         else
         {
             const int *colors;

--- a/lib/widget/hline.c
+++ b/lib/widget/hline.c
@@ -107,7 +107,7 @@ hline_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void *dat
             const int *colors;
 
             colors = widget_get_colors (w);
-            tty_setcolor (colors[DLG_COLOR_NORMAL]);
+            tty_setcolor (colors[DLG_COLOR_FRAME]);
         }
 
         tty_draw_hline (w->rect.y, w->rect.x + 1, mc_tty_frm[MC_TTY_FRM_HORIZ], w->rect.cols - 2);

--- a/lib/widget/input.c
+++ b/lib/widget/input.c
@@ -115,7 +115,7 @@ draw_history_button (WInput *in)
 
     widget_gotoyx (in, 0, WIDGET (in)->rect.cols - HISTORY_BUTTON_WIDTH);
     disabled = widget_get_state (WIDGET (in), WST_DISABLED);
-    tty_setcolor (disabled ? DISABLED_COLOR : in->color[WINPUTC_HISTORY]);
+    tty_setcolor (disabled ? CORE_DISABLED_COLOR : in->color[WINPUTC_HISTORY]);
 
 #ifdef LARGE_HISTORY_BUTTON
     tty_print_string ("[ ]");
@@ -1081,10 +1081,10 @@ input_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void *dat
 void
 input_set_default_colors (void)
 {
-    input_colors[WINPUTC_MAIN] = INPUT_COLOR;
-    input_colors[WINPUTC_MARK] = INPUT_MARK_COLOR;
-    input_colors[WINPUTC_UNCHANGED] = INPUT_UNCHANGED_COLOR;
-    input_colors[WINPUTC_HISTORY] = INPUT_HISTORY_COLOR;
+    input_colors[WINPUTC_MAIN] = CORE_INPUT_COLOR;
+    input_colors[WINPUTC_MARK] = CORE_INPUT_MARK_COLOR;
+    input_colors[WINPUTC_UNCHANGED] = CORE_INPUT_UNCHANGED_COLOR;
+    input_colors[WINPUTC_HISTORY] = CORE_INPUT_HISTORY_COLOR;
 }
 
 /* --------------------------------------------------------------------------------------------- */
@@ -1224,7 +1224,7 @@ input_update (WInput *in, gboolean clear_first)
         draw_history_button (in);
 
     if (widget_get_state (wi, WST_DISABLED))
-        tty_setcolor (DISABLED_COLOR);
+        tty_setcolor (CORE_DISABLED_COLOR);
     else if (in->first)
         tty_setcolor (in->color[WINPUTC_UNCHANGED]);
     else

--- a/lib/widget/label.c
+++ b/lib/widget/label.c
@@ -80,13 +80,13 @@ label_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void *dat
         disabled = widget_get_state (w, WST_DISABLED);
 
         if (l->transparent)
-            tty_setcolor (disabled ? DISABLED_COLOR : DEFAULT_COLOR);
+            tty_setcolor (disabled ? CORE_DISABLED_COLOR : CORE_DEFAULT_COLOR);
         else
         {
             const int *colors;
 
             colors = widget_get_colors (w);
-            tty_setcolor (disabled ? DISABLED_COLOR : colors[DLG_COLOR_NORMAL]);
+            tty_setcolor (disabled ? CORE_DISABLED_COLOR : colors[DLG_COLOR_NORMAL]);
         }
 
         align = (w->pos_flags & WPOS_CENTER_HORZ) != 0 ? J_CENTER_LEFT : J_LEFT;

--- a/lib/widget/listbox.c
+++ b/lib/widget/listbox.c
@@ -137,7 +137,7 @@ listbox_draw (WListbox *l, gboolean focused)
     const WRect *w = &CONST_WIDGET (l)->rect;
     const int *colors;
     gboolean disabled;
-    int normalc, selc;
+    int normalc, selc, scrollbarc;
     int length = 0;
     GList *le = NULL;
     int pos;
@@ -150,6 +150,7 @@ listbox_draw (WListbox *l, gboolean focused)
     normalc = disabled ? CORE_DISABLED_COLOR : colors[DLG_COLOR_NORMAL];
     selc = disabled ? CORE_DISABLED_COLOR
                     : colors[focused ? DLG_COLOR_SELECTED_FOCUS : DLG_COLOR_SELECTED_NORMAL];
+    scrollbarc = disabled ? CORE_DISABLED_COLOR : colors[DLG_COLOR_FRAME];
 
     if (l->list != NULL)
     {
@@ -191,7 +192,7 @@ listbox_draw (WListbox *l, gboolean focused)
 
     if (l->scrollbar && length > w->lines)
     {
-        tty_setcolor (normalc);
+        tty_setcolor (scrollbarc);
         listbox_drawscroll (l);
     }
 }

--- a/lib/widget/listbox.c
+++ b/lib/widget/listbox.c
@@ -147,8 +147,8 @@ listbox_draw (WListbox *l, gboolean focused)
     colors = widget_get_colors (wl);
 
     disabled = widget_get_state (wl, WST_DISABLED);
-    normalc = disabled ? DISABLED_COLOR : colors[DLG_COLOR_NORMAL];
-    selc = disabled ? DISABLED_COLOR
+    normalc = disabled ? CORE_DISABLED_COLOR : colors[DLG_COLOR_NORMAL];
+    selc = disabled ? CORE_DISABLED_COLOR
                     : colors[focused ? DLG_COLOR_SELECTED_FOCUS : DLG_COLOR_SELECTED_NORMAL];
 
     if (l->list != NULL)

--- a/lib/widget/menu.c
+++ b/lib/widget/menu.c
@@ -137,7 +137,7 @@ menubar_paint_idx (const WMenuBar *menubar, unsigned int idx, int color)
     if (entry == NULL)
     {
         // menu separator
-        tty_setcolor (MENU_ENTRY_COLOR);
+        tty_setcolor (MENU_FRAME_COLOR);
 
         widget_gotoyx (menubar, y, x - 1);
         tty_print_char (mc_tty_frm[MC_TTY_FRM_DLEFTMIDDLE]);
@@ -196,7 +196,7 @@ menubar_draw_drop (const WMenuBar *menubar)
         tty_draw_box_shadow (w->y + 1, w->x + column, count + 2, menu->max_entry_len + 4,
                              CORE_SHADOW_COLOR);
 
-    tty_setcolor (MENU_ENTRY_COLOR);
+    tty_setcolor (MENU_FRAME_COLOR);
     tty_draw_box (w->y + 1, w->x + column, count + 2, menu->max_entry_len + 4, FALSE);
 
     for (i = 0; i < count; i++)

--- a/lib/widget/menu.c
+++ b/lib/widget/menu.c
@@ -194,7 +194,7 @@ menubar_draw_drop (const WMenuBar *menubar)
 
     if (mc_global.tty.shadows)
         tty_draw_box_shadow (w->y + 1, w->x + column, count + 2, menu->max_entry_len + 4,
-                             SHADOW_COLOR);
+                             CORE_SHADOW_COLOR);
 
     tty_setcolor (MENU_ENTRY_COLOR);
     tty_draw_box (w->y + 1, w->x + column, count + 2, menu->max_entry_len + 4, FALSE);

--- a/lib/widget/widget-common.c
+++ b/lib/widget/widget-common.c
@@ -462,7 +462,7 @@ widget_selectcolor (const Widget *w, gboolean focused, gboolean hotkey)
     colors = widget_get_colors (w);
 
     if (widget_get_state (w, WST_DISABLED))
-        color = DISABLED_COLOR;
+        color = CORE_DISABLED_COLOR;
     else if (hotkey)
         color = colors[focused ? DLG_COLOR_HOT_FOCUS : DLG_COLOR_HOT_NORMAL];
     else

--- a/misc/skins/dark.ini
+++ b/misc/skins/dark.ini
@@ -40,6 +40,7 @@
     inputhistory =
     commandhistory =
     shadow = gray;black
+    frame = lightgray;black
 
 [dialog]
     _default_ = brightcyan;blue
@@ -49,6 +50,7 @@
     dselnormal = blue;cyan
     dselfocus = white;cyan
     dtitle = white;
+    dframe = brightcyan;blue
 
 [error]
     _default_ = white;red
@@ -56,6 +58,7 @@
     errdhotnormal = yellow;red
     errdhotfocus = yellow;lightgray
     errdtitle = yellow;red
+    errdframe = white;red
 
 [filehighlight]
     directory = white;
@@ -80,11 +83,13 @@
     menuhot = white;blue
     menuhotsel = white;cyan
     menuinactive = black;lightgray
+    menuframe = lightgray;blue
 
 [popupmenu]
     _default_ = lightgray;blue
     menusel = black;cyan
     menutitle = lightgray;blue
+    menuframe = lightgray;blue
 
 [buttonbar]
     hotkey = red;lightgray
@@ -100,6 +105,7 @@
     helplink = black;cyan
     helpslink = yellow;blue
     helptitle = blue;lightgray
+    helpframe = black;lightgray
 
 [editor]
     _default_ = lightgray;black
@@ -121,6 +127,7 @@
     viewbold = yellow;black
     viewunderline = brightred;black
     viewselected = yellow;cyan
+    viewframe = lightgray;black
 
 [diffviewer]
     added = white;green

--- a/misc/skins/darkfar.ini
+++ b/misc/skins/darkfar.ini
@@ -40,6 +40,7 @@
     inputhistory =
     commandhistory =
     shadow = gray;black
+    frame = lightgray;black
 
 [dialog]
     _default_ = brightcyan;blue
@@ -49,6 +50,7 @@
     dselnormal = blue;cyan
     dselfocus = white;cyan
     dtitle = white;
+    dframe = brightcyan;blue
 
 [error]
     _default_ = white;red
@@ -56,6 +58,7 @@
     errdhotnormal = yellow;red
     errdhotfocus = yellow;lightgray
     errdtitle = yellow;red
+    errdframe = white;red
 
 [filehighlight]
     directory = white;
@@ -80,11 +83,13 @@
     menuhot = white;blue
     menuhotsel = white;cyan
     menuinactive = black;lightgray
+    menuframe = lightgray;blue
 
 [popupmenu]
     _default_ = lightgray;blue
     menusel = black;cyan
     menutitle = lightgray;blue
+    menuframe = lightgray;blue
 
 [buttonbar]
     hotkey = red;lightgray
@@ -100,6 +105,7 @@
     helplink = black;cyan
     helpslink = yellow;blue
     helptitle = blue;lightgray
+    helpframe = black;lightgray
 
 [editor]
     _default_ = lightgray;black
@@ -121,6 +127,7 @@
     viewbold = yellow;black
     viewunderline = brightred;black
     viewselected = yellow;cyan
+    viewframe = lightgray;black
 
 [diffviewer]
     added = white;green

--- a/misc/skins/default.ini
+++ b/misc/skins/default.ini
@@ -40,6 +40,7 @@
     inputhistory =
     commandhistory =
     shadow = gray;black
+    frame = lightgray;blue
 
 [dialog]
     _default_ = black;lightgray
@@ -49,6 +50,7 @@
     dselnormal = black;cyan
     dselfocus = blue;cyan
     dtitle = blue;lightgray
+    dframe = black;lightgray
 
 [error]
     _default_ = white;red
@@ -56,6 +58,7 @@
     errdhotnormal = yellow;red
     errdhotfocus = yellow;lightgray
     errdtitle = yellow;red
+    errdframe = white;red
 
 [filehighlight]
     directory = white;
@@ -80,11 +83,13 @@
     menuhot = yellow;cyan
     menuhotsel = yellow;black
     menuinactive = black;cyan
+    menuframe = white;cyan
 
 [popupmenu]
     _default_ = white;cyan
     menusel = yellow;black
     menutitle = yellow;cyan
+    menuframe = white;cyan
 
 [buttonbar]
     hotkey = white;black
@@ -100,6 +105,7 @@
     helplink = black;cyan
     helpslink = yellow;blue
     helptitle = blue;lightgray
+    helpframe = black;lightgray
 
 [editor]
     _default_ = lightgray;blue
@@ -121,6 +127,7 @@
     viewbold = yellow;blue
     viewunderline = brightred;blue
     viewselected = yellow;cyan
+    viewframe = lightgray;blue
 
 [diffviewer]
     added = white;green

--- a/misc/skins/double-lines.ini
+++ b/misc/skins/double-lines.ini
@@ -40,6 +40,7 @@
     inputhistory =
     commandhistory =
     shadow = gray;black
+    frame = lightgray;blue
 
 [dialog]
     _default_ = black;lightgray
@@ -49,6 +50,7 @@
     dselnormal = black;cyan
     dselfocus = blue;cyan
     dtitle = blue;lightgray
+    dframe = black;lightgray
 
 [error]
     _default_ = white;red
@@ -56,6 +58,7 @@
     errdhotnormal = yellow;red
     errdhotfocus = yellow;lightgray
     errdtitle = yellow;red
+    errdframe = white;red
 
 [filehighlight]
     directory = white;
@@ -80,11 +83,13 @@
     menuhot = yellow;cyan
     menuhotsel = yellow;black
     menuinactive = lightgray;blue
+    menuframe = white;cyan
 
 [popupmenu]
     _default_ = white;cyan
     menusel = white;black
     menutitle = white;cyan
+    menuframe = white;cyan
 
 [buttonbar]
     hotkey = lightgray;blue
@@ -100,6 +105,7 @@
     helplink = black;cyan
     helpslink = yellow;blue
     helptitle = blue;lightgray
+    helpframe = black;lightgray
 
 [editor]
     _default_ = lightgray;blue
@@ -121,6 +127,7 @@
     viewbold = yellow;blue
     viewunderline = brightred;blue
     viewselected = yellow;cyan
+    viewframe = lightgray;blue
 
 [diffviewer]
     added = white;green

--- a/misc/skins/featured-plus.ini
+++ b/misc/skins/featured-plus.ini
@@ -42,6 +42,7 @@
     inputhistory =
     commandhistory =
     shadow = gray;black
+    frame = lightgray;blue
 
 [dialog]
     _default_ = black;lightgray
@@ -51,6 +52,7 @@
     dselnormal = black;cyan
     dselfocus = blue;cyan
     dtitle = blue;lightgray
+    dframe = black;lightgray
 
 [error]
     _default_ = white;red
@@ -58,6 +60,7 @@
     errdhotnormal = yellow;red
     errdhotfocus = yellow;lightgray
     errdtitle = yellow;red
+    errdframe = white;red
 
 [filehighlight]
     directory = brightcyan;blue;bold
@@ -82,11 +85,13 @@
     menuhot = yellow;cyan
     menuhotsel = yellow;black
     menuinactive = black;cyan
+    menuframe = white;cyan
 
 [popupmenu]
     _default_ = white;cyan
     menusel = white;black
     menutitle = white;cyan
+    menuframe = white;cyan
 
 [buttonbar]
     hotkey = white;black
@@ -102,6 +107,7 @@
     helplink = black;cyan
     helpslink = yellow;blue
     helptitle = blue;lightgray
+    helpframe = black;lightgray
 
 [editor]
     _default_ = lightgray;blue
@@ -123,6 +129,7 @@
     viewbold = yellow;blue
     viewunderline = brightred;blue
     viewselected = yellow;cyan
+    viewframe = lightgray;blue
 
 [diffviewer]
     added = white;green

--- a/misc/skins/featured.ini
+++ b/misc/skins/featured.ini
@@ -42,6 +42,7 @@
     inputhistory =
     commandhistory =
     shadow = gray;black
+    frame = lightgray;blue
 
 [dialog]
     _default_ = black;lightgray
@@ -51,6 +52,7 @@
     dselnormal = black;cyan
     dselfocus = blue;cyan
     dtitle = blue;lightgray
+    dframe = black;lightgray
 
 [error]
     _default_ = white;red
@@ -58,6 +60,7 @@
     errdhotnormal = yellow;red
     errdhotfocus = yellow;lightgray
     errdtitle = yellow;red
+    errdframe = white;red
 
 [filehighlight]
     directory = white;
@@ -82,11 +85,13 @@
     menuhot = yellow;cyan
     menuhotsel = yellow;black
     menuinactive = black;cyan
+    menuframe = white;cyan
 
 [popupmenu]
     _default_ = white;cyan
     menusel = white;black
     menutitle = white;cyan
+    menuframe = white;cyan
 
 [buttonbar]
     hotkey = white;black
@@ -102,6 +107,7 @@
     helplink = black;cyan
     helpslink = yellow;blue
     helptitle = blue;lightgray
+    helpframe = black;lightgray
 
 [editor]
     _default_ = lightgray;blue
@@ -123,6 +129,7 @@
     viewbold = yellow;blue
     viewunderline = brightred;blue
     viewselected = yellow;cyan
+    viewframe = lightgray;blue
 
 [diffviewer]
     added = white;green

--- a/misc/skins/gotar.ini
+++ b/misc/skins/gotar.ini
@@ -37,6 +37,7 @@
     inputhistory =
     commandhistory =
     shadow = gray;black
+    frame = lightgray;black
 
 [dialog]
     _default_ = brightcyan;blue
@@ -46,6 +47,7 @@
     dselnormal = brightred;black
     dselfocus = yellow;black
     dtitle = brightred;
+    dframe = brightcyan;blue
 
 [error]
     _default_ = white;red
@@ -53,6 +55,7 @@
     errdhotnormal = yellow;
     errdhotfocus = yellow;blue
     errdtitle = yellow;
+    errdframe = white;red
 
 [filehighlight]
     directory = brightcyan;
@@ -77,11 +80,13 @@
     menuhot = brightred;
     menuhotsel = yellow;
     menuinactive = lightgray;
+    menuframe = brightgreen;black
 
 [popupmenu]
     _default_ = brightgreen;black
     menusel = brightcyan;blue
     menutitle = brightcyan;black
+    menuframe = brightgreen;black
 
 [buttonbar]
     hotkey = lightgray;black
@@ -97,6 +102,7 @@
     helplink = white;
     helpslink = yellow;blue
     helptitle = brightgreen;
+    helpframe = brightred;black
 
 [editor]
     _default_ = lightgray;black
@@ -118,6 +124,7 @@
     viewbold = brightred;black
     viewunderline = brightgreen;black
     viewselected = yellow;black
+    viewframe = lightgray;black
 
 [diffviewer]
     _default_ = lightgray;black

--- a/misc/skins/gray-green-purple256.ini
+++ b/misc/skins/gray-green-purple256.ini
@@ -46,6 +46,7 @@
     commandlinemark = ;main1
     header = main2
     shadow = black;gray12
+    frame = black;bgmain
 
 [dialog]
     _default_ = black;bgdarker
@@ -55,6 +56,7 @@
     dselnormal = ;main1
     dselfocus = main2;main1
     dtitle = main2
+    dframe = black;bgdarker
 
 [error]
     # "white" might change color when going bold, so use "rgb555" instead
@@ -63,6 +65,7 @@
     errdhotnormal = main1
     errdhotfocus = main1;main2
     errdtitle = main1
+    errdframe = rgb555;rgb400;bold
 
 [filehighlight]
     directory =
@@ -87,11 +90,13 @@
     menuhot = main2
     menuhotsel = main2;main1
     menuinactive =
+    menuframe = black;bgdarker
 
 [popupmenu]
     _default_ = black;bgdarker
     menusel = ;main1
     menutitle = main2
+    menuframe = black;bgdarker
 
 [buttonbar]
     hotkey = black;bgmain
@@ -107,6 +112,7 @@
     helplink = main2;;underline
     helpslink = bgdarker;main2
     helptitle = main2
+    helpframe = black;bgdarker
 
 [editor]
     _default_ = black;bgmain
@@ -129,6 +135,7 @@
     viewbold = rgb000;;bold
     viewunderline = ;;underline
     viewselected = main2;main1;bold
+    viewframe = black;bgmain
 
 [diffviewer]
     added = ;rgb340

--- a/misc/skins/gray-orange-blue256.ini
+++ b/misc/skins/gray-orange-blue256.ini
@@ -46,6 +46,7 @@
     commandlinemark = ;main1
     header = main2
     shadow = black;gray12
+    frame = black;bgmain
 
 [dialog]
     _default_ = black;bgdarker
@@ -55,6 +56,7 @@
     dselnormal = ;main1
     dselfocus = main2;main1
     dtitle = main2
+    dframe = black;bgdarker
 
 [error]
     # "white" might change color when going bold, so use "rgb555" instead
@@ -63,6 +65,7 @@
     errdhotnormal = main1
     errdhotfocus = main1;main2
     errdtitle = main1
+    errdframe = rgb555;rgb400;bold
 
 [filehighlight]
     directory =
@@ -87,11 +90,13 @@
     menuhot = main2
     menuhotsel = main2;main1
     menuinactive =
+    menuframe = black;bgdarker
 
 [popupmenu]
     _default_ = black;bgdarker
     menusel = ;main1
     menutitle = main2
+    menuframe = black;bgdarker
 
 [buttonbar]
     hotkey = black;bgmain
@@ -107,6 +112,7 @@
     helplink = main2;;underline
     helpslink = bgdarker;main2
     helptitle = main2
+    helpframe = black;bgdarker
 
 [editor]
     _default_ = black;bgmain
@@ -129,6 +135,7 @@
     viewbold = rgb000;;bold
     viewunderline = ;;underline
     viewselected = main2;main1;bold
+    viewframe = black;bgmain
 
 [diffviewer]
     added = ;rgb340

--- a/misc/skins/julia256.ini
+++ b/misc/skins/julia256.ini
@@ -43,6 +43,7 @@
     inputhistory =
     commandhistory =
     shadow = gray;black
+    frame = lightgray;color237
 
 [dialog]
     _default_ = black;lightgray
@@ -52,6 +53,7 @@
     dselnormal = black;cyan
     dselfocus = red;cyan
     dtitle = black;
+    dframe = black;lightgray
 
 [error]
     _default_ = white;red
@@ -59,6 +61,7 @@
     errdhotnormal = yellow;red
     errdhotfocus = red;lightgray
     errdtitle = yellow;red
+    errdframe = white;red
 
 [filehighlight]
     directory = white;
@@ -83,11 +86,13 @@
     menuhot = white;blue
     menuhotsel = white;cyan
     menuinactive = black;lightgray
+    menuframe = lightgray;blue
 
 [popupmenu]
     _default_ = lightgray;blue
     menusel = black;cyan
     menutitle = yellow;blue
+    menuframe = lightgray;blue
 
 [buttonbar]
     hotkey = red;lightgray
@@ -103,6 +108,7 @@
     helplink = black;cyan
     helpslink = yellow;blue
     helptitle = blue;lightgray
+    helpframe = black;lightgray
 
 [editor]
     _default_ = lightgray;black
@@ -126,6 +132,7 @@
     viewbold = yellow;black
     viewunderline = brightred;black
     viewselected = yellow;cyan
+    viewframe = lightgray;black
 
 [diffviewer]
     added = white;green

--- a/misc/skins/julia256root.ini
+++ b/misc/skins/julia256root.ini
@@ -43,6 +43,7 @@
     inputhistory =
     commandhistory =
     shadow = gray;black
+    frame = lightgray;color237
 
 [dialog]
     _default_ = black;lightgray
@@ -52,6 +53,7 @@
     dselnormal = black;cyan
     dselfocus = red;cyan
     dtitle = black;
+    dframe = black;lightgray
 
 [error]
     _default_ = white;red
@@ -59,6 +61,7 @@
     errdhotnormal = yellow;red
     errdhotfocus = red;lightgray
     errdtitle = yellow;red
+    errdframe = white;red
 
 [filehighlight]
     directory = white;
@@ -83,11 +86,13 @@
     menuhot = white;blue
     menuhotsel = white;cyan
     menuinactive = black;lightgray
+    menuframe = lightgray;blue
 
 [popupmenu]
     _default_ = lightgray;blue
     menusel = black;cyan
     menutitle = yellow;blue
+    menuframe = lightgray;blue
 
 [buttonbar]
     hotkey = red;lightgray
@@ -103,6 +108,7 @@
     helplink = black;cyan
     helpslink = yellow;blue
     helptitle = blue;lightgray
+    helpframe = black;lightgray
 
 [editor]
     _default_ = lightgray;black
@@ -126,6 +132,7 @@
     viewbold = yellow;black
     viewunderline = brightred;black
     viewselected = yellow;cyan
+    viewframe = lightgray;black
 
 [diffviewer]
     added = white;green

--- a/misc/skins/mc46.ini
+++ b/misc/skins/mc46.ini
@@ -40,6 +40,7 @@
     inputhistory =
     commandhistory =
     shadow = gray;black
+    frame = lightgray;blue
 
 [dialog]
     _default_ = black;lightgray
@@ -49,6 +50,7 @@
     dselnormal = black;cyan
     dselfocus = blue;cyan
     dtitle = blue;lightgray
+    dframe = black;lightgray
 
 [error]
     _default_ = white;red
@@ -56,6 +58,7 @@
     errdhotnormal = yellow;red
     errdhotfocus = yellow;lightgray
     errdtitle = yellow;red
+    errdframe = white;red
 
 [filehighlight]
     directory = white;
@@ -71,11 +74,13 @@
     menuhot = yellow;cyan
     menuhotsel = yellow;black
     menuinactive = gray;cyan
+    menuframe = black;cyan
 
 [popupmenu]
     _default_ = white;cyan
     menusel = yellow;black
     menutitle = yellow;cyan
+    menuframe = white;cyan
 
 [buttonbar]
     hotkey = lightgray;black
@@ -91,6 +96,7 @@
     helplink = black;cyan
     helpslink = yellow;blue
     helptitle = blue;lightgray
+    helpframe = black;lightgray
 
 [editor]
     _default_ = lightgray;blue
@@ -112,6 +118,7 @@
     viewbold = yellow;blue
     viewunderline = brightred;blue
     viewselected = yellow;cyan
+    viewframe = lightgray;blue
 
 [diffviewer]
     added = white;green

--- a/misc/skins/modarcon16-defbg-thin.ini
+++ b/misc/skins/modarcon16-defbg-thin.ini
@@ -81,6 +81,7 @@
     disabled = color8;color7
     #inputhistory =
     #commandhistory =
+    frame = color7;default
 
 [dialog]
     _default_ = color0;color7
@@ -90,6 +91,7 @@
     dselnormal = color11;color2;bold
     dselfocus = color3;color2
     dtitle = color11;;bold
+    dframe = color0;color7
 
 [error]
     _default_ = color15;color1
@@ -97,6 +99,7 @@
     errdhotnormal = color13
     errdhotfocus = color13;color2
     errdtitle = color11;;bold
+    errdframe = color15;color1
 
 [filehighlight]
     directory = color15;;bold
@@ -121,11 +124,13 @@
     menuhot = color3
     menuhotsel = color3;color2
     menuinactive = color8
+    menuframe = color7;default
 
 [popupmenu]
     _default_ = color7;default
     menusel = color11;color2;bold
     menutitle = color11;;bold
+    menuframe = color7;default
 
 [buttonbar]
     button = color7
@@ -141,6 +146,7 @@
     helplink = color14
     helpslink = color11;color2;bold
     helptitle = color11;;bold
+    helpframe = color0;color7
 
 [editor]
     _default_ = color7;default
@@ -157,6 +163,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color11;color2;bold
+    viewframe = color7;default
 
 [diffviewer]
     changedline = color15;color4

--- a/misc/skins/modarcon16-defbg.ini
+++ b/misc/skins/modarcon16-defbg.ini
@@ -82,6 +82,7 @@
     #inputhistory =
     #commandhistory =
     shadow = color7;color0
+    frame = color7;default
 
 [dialog]
     _default_ = color0;color7
@@ -91,6 +92,7 @@
     dselnormal = color11;color2;bold
     dselfocus = color3;color2
     dtitle = color11;;bold
+    dframe = color0;color7
 
 [error]
     _default_ = color15;color1
@@ -98,6 +100,7 @@
     errdhotnormal = color13
     errdhotfocus = color13;color2
     errdtitle = color11;;bold
+    errdframe = color15;color1
 
 [filehighlight]
     directory = color15;;bold
@@ -122,11 +125,13 @@
     menuhot = color3
     menuhotsel = color3;color2
     menuinactive = color8
+    menuframe = color7;default
 
 [popupmenu]
     _default_ = color7;default
     menusel = color11;color2;bold
     menutitle = color11;;bold
+    menuframe = color7;default
 
 [buttonbar]
     button = color7
@@ -142,6 +147,7 @@
     helplink = color14
     helpslink = color11;color2;bold
     helptitle = color11;;bold
+    helpframe = color0;color7
 
 [editor]
     _default_ = color7;default
@@ -159,6 +165,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color11;color2;bold
+    viewframe = color7;default
 
 [diffviewer]
     changedline = color15;color4

--- a/misc/skins/modarcon16-thin.ini
+++ b/misc/skins/modarcon16-thin.ini
@@ -81,6 +81,7 @@
     disabled = color8;color7
     #inputhistory =
     #commandhistory =
+    frame = color7;color0
 
 [dialog]
     _default_ = color0;color7
@@ -90,6 +91,7 @@
     dselnormal = color11;color2;bold
     dselfocus = color3;color2
     dtitle = color11;;bold
+    dframe = color0;color7
 
 [error]
     _default_ = color15;color1
@@ -97,6 +99,7 @@
     errdhotnormal = color13
     errdhotfocus = color13;color2
     errdtitle = color11;;bold
+    errdframe = color15;color1
 
 [filehighlight]
     directory = color15;;bold
@@ -121,11 +124,13 @@
     menuhot = color3
     menuhotsel = color3;color2
     menuinactive = color8
+    menuframe = color0;color7
 
 [popupmenu]
     _default_ = color0;color7
     menusel = color11;color2;bold
     menutitle = color11;;bold
+    menuframe = color0;color7
 
 [buttonbar]
     button = color7
@@ -141,6 +146,7 @@
     helplink = color14
     helpslink = color11;color2;bold
     helptitle = color11;;bold
+    helpframe = color0;color7
 
 [editor]
     _default_ = color7;color0
@@ -157,6 +163,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color11;color2;bold
+    viewframe = color7;color0
 
 [diffviewer]
     changedline = color15;color4

--- a/misc/skins/modarcon16.ini
+++ b/misc/skins/modarcon16.ini
@@ -82,6 +82,7 @@
     #inputhistory =
     #commandhistory =
     shadow = color7;color0
+    frame = color7;color0
 
 [dialog]
     _default_ = color0;color7
@@ -91,6 +92,7 @@
     dselnormal = color11;color2;bold
     dselfocus = color3;color2
     dtitle = color11;;bold
+    dframe = color0;color7
 
 [error]
     _default_ = color15;color1
@@ -98,6 +100,7 @@
     errdhotnormal = color13
     errdhotfocus = color13;color2
     errdtitle = color11;;bold
+    errdframe = color15;color1
 
 [filehighlight]
     directory = color15;;bold
@@ -122,11 +125,13 @@
     menuhot = color3
     menuhotsel = color3;color2
     menuinactive = color8
+    menuframe = color0;color7
 
 [popupmenu]
     _default_ = color0;color7
     menusel = color11;color2;bold
     menutitle = color11;;bold
+    menuframe = color0;color7
 
 [buttonbar]
     button = color7
@@ -142,6 +147,7 @@
     helplink = color14
     helpslink = color11;color2;bold
     helptitle = color11;;bold
+    helpframe = color0;color7
 
 [editor]
     _default_ = color7;color0
@@ -159,6 +165,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color11;color2;bold
+    viewframe = color7;color0
 
 [diffviewer]
     changedline = color15;color4

--- a/misc/skins/modarcon16root-defbg-thin.ini
+++ b/misc/skins/modarcon16root-defbg-thin.ini
@@ -81,6 +81,7 @@
     disabled = color8;color7
     #inputhistory =
     #commandhistory =
+    frame = color7;default
 
 [dialog]
     _default_ = color0;color7
@@ -90,6 +91,7 @@
     dselnormal = color11;color1;bold
     dselfocus = color5;color1;bold
     dtitle = color11;;bold
+    dframe = color0;color7
 
 [error]
     _default_ = color15;color1
@@ -97,6 +99,7 @@
     errdhotnormal = color13
     errdhotfocus = color13;color3
     errdtitle = color11;;bold
+    errdframe = color15;color1
 
 [filehighlight]
     directory = color15;;bold
@@ -121,11 +124,13 @@
     menuhot = color3
     menuhotsel = color5;color1;bold
     menuinactive = color8
+    menuframe = color7;default
 
 [popupmenu]
     _default_ = color7;default
     menusel = color11;color1;bold
     menutitle = color11;;bold
+    menuframe = color7;default
 
 [buttonbar]
     button = color7
@@ -141,6 +146,7 @@
     helplink = color14
     helpslink = color11;color1;bold
     helptitle = color11;;bold
+    helpframe = color0;color7
 
 [editor]
     _default_ = color7;default
@@ -157,6 +163,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color11;color1;bold
+    viewframe = color7;default
 
 [diffviewer]
     changedline = color15;color4

--- a/misc/skins/modarcon16root-defbg.ini
+++ b/misc/skins/modarcon16root-defbg.ini
@@ -82,6 +82,7 @@
     #inputhistory =
     #commandhistory =
     shadow = color7;color0
+    frame = color7;default
 
 [dialog]
     _default_ = color0;color7
@@ -91,6 +92,7 @@
     dselnormal = color11;color1;bold
     dselfocus = color5;color1;bold
     dtitle = color11;;bold
+    dframe = color0;color7
 
 [error]
     _default_ = color15;color1
@@ -98,6 +100,7 @@
     errdhotnormal = color13
     errdhotfocus = color13;color3
     errdtitle = color11;;bold
+    errdframe = color15;color1
 
 [filehighlight]
     directory = color15;;bold
@@ -122,11 +125,13 @@
     menuhot = color3
     menuhotsel = color5;color1;bold
     menuinactive = color8
+    menuframe = color7;default
 
 [popupmenu]
     _default_ = color7;default
     menusel = color11;color1;bold
     menutitle = color11;;bold
+    menuframe = color7;default
 
 [buttonbar]
     button = color7
@@ -142,6 +147,7 @@
     helplink = color14
     helpslink = color11;color1;bold
     helptitle = color11;;bold
+    helpframe = color0;color7
 
 [editor]
     _default_ = color7;default
@@ -159,6 +165,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color11;color1;bold
+    viewframe = color7;default
 
 [diffviewer]
     changedline = color15;color4

--- a/misc/skins/modarcon16root-thin.ini
+++ b/misc/skins/modarcon16root-thin.ini
@@ -81,6 +81,7 @@
     disabled = color8;color7
     #inputhistory =
     #commandhistory =
+    frame = color7;color0
 
 [dialog]
     _default_ = color0;color7
@@ -90,6 +91,7 @@
     dselnormal = color11;color1;bold
     dselfocus = color5;color1;bold
     dtitle = color11;;bold
+    dframe = color0;color7
 
 [error]
     _default_ = color15;color1
@@ -97,6 +99,7 @@
     errdhotnormal = color13
     errdhotfocus = color13;color3
     errdtitle = color11;;bold
+    errdframe = color15;color1
 
 [filehighlight]
     directory = color15;;bold
@@ -121,11 +124,13 @@
     menuhot = color3
     menuhotsel = color5;color1;bold
     menuinactive = color8
+    menuframe = color0;color7
 
 [popupmenu]
     _default_ = color0;color7
     menusel = color11;color1;bold
     menutitle = color11;;bold
+    menuframe = color0;color7
 
 [buttonbar]
     button = color7
@@ -141,6 +146,7 @@
     helplink = color14
     helpslink = color11;color1;bold
     helptitle = color11;;bold
+    helpframe = color0;color7
 
 [editor]
     _default_ = color7;color0
@@ -157,6 +163,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color11;color1;bold
+    viewframe = color7;color0
 
 [diffviewer]
     changedline = color15;color4

--- a/misc/skins/modarcon16root.ini
+++ b/misc/skins/modarcon16root.ini
@@ -82,6 +82,7 @@
     #inputhistory =
     #commandhistory =
     shadow = color7;color0
+    frame = color7;color0
 
 [dialog]
     _default_ = color0;color7
@@ -91,6 +92,7 @@
     dselnormal = color11;color1;bold
     dselfocus = color5;color1;bold
     dtitle = color11;;bold
+    dframe = color0;color7
 
 [error]
     _default_ = color15;color1
@@ -98,6 +100,7 @@
     errdhotnormal = color13
     errdhotfocus = color13;color3
     errdtitle = color11;;bold
+    errdframe = color15;color1
 
 [filehighlight]
     directory = color15;;bold
@@ -122,11 +125,13 @@
     menuhot = color3
     menuhotsel = color5;color1;bold
     menuinactive = color8
+    menuframe = color0;color7
 
 [popupmenu]
     _default_ = color0;color7
     menusel = color11;color1;bold
     menutitle = color11;;bold
+    menuframe = color0;color7
 
 [buttonbar]
     button = color7
@@ -142,6 +147,7 @@
     helplink = color14
     helpslink = color11;color1;bold
     helptitle = color11;;bold
+    helpframe = color0;color7
 
 [editor]
     _default_ = color7;color0
@@ -159,6 +165,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color11;color1;bold
+    viewframe = color7;color0
 
 [diffviewer]
     changedline = color15;color4

--- a/misc/skins/modarin256-defbg-thin.ini
+++ b/misc/skins/modarin256-defbg-thin.ini
@@ -81,6 +81,7 @@
     disabled = color246;color239
     #inputhistory =
     #commandhistory =
+    frame = color250;default
 
 [dialog]
     _default_ = color252;color239
@@ -90,6 +91,7 @@
     dselnormal = color228;color23;bold
     dselfocus = color214;color23
     dtitle = color180;;bold
+    dframe = color252;color239
 
 [error]
     _default_ = color230;color52
@@ -97,6 +99,7 @@
     errdhotnormal = color203;color52
     errdhotfocus = color203;color23;bold
     errdtitle = color227;;bold
+    errdframe = color230;color52
 
 [filehighlight]
     directory = color144;;bold
@@ -121,11 +124,13 @@
     menuhot = color214
     menuhotsel = color214;color23
     menuinactive = color245
+    menuframe = color250;default
 
 [popupmenu]
     _default_ = color250;default
     menusel = color253;color23
     menutitle = color180;;bold
+    menuframe = color250;default
 
 [buttonbar]
     button = color253;color236
@@ -141,6 +146,7 @@
     helplink = color45
     helpslink = color228;color23;bold
     helptitle = color180;;bold
+    helpframe = color252;color239
 
 [editor]
     _default_ = color250;default
@@ -157,6 +163,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color228;color23;bold
+    viewframe = color250;default
 
 [diffviewer]
     changedline = color231;color29

--- a/misc/skins/modarin256-defbg.ini
+++ b/misc/skins/modarin256-defbg.ini
@@ -82,6 +82,7 @@
     #inputhistory =
     #commandhistory =
     shadow = color240;color0
+    frame = color250;default
 
 [dialog]
     _default_ = color252;color239
@@ -91,6 +92,7 @@
     dselnormal = color228;color23;bold
     dselfocus = color214;color23
     dtitle = color180;;bold
+    dframe = color252;color239
 
 [error]
     _default_ = color230;color52
@@ -98,6 +100,7 @@
     errdhotnormal = color203;color52
     errdhotfocus = color203;color23;bold
     errdtitle = color227;;bold
+    errdframe = color230;color52
 
 [filehighlight]
     directory = color144;;bold
@@ -122,11 +125,13 @@
     menuhot = color214
     menuhotsel = color214;color23
     menuinactive = color245
+    menuframe = color250;default
 
 [popupmenu]
     _default_ = color250;default
     menusel = color253;color23
     menutitle = color180;;bold
+    menuframe = color250;default
 
 [buttonbar]
     button = color253;color236
@@ -142,6 +147,7 @@
     helplink = color45
     helpslink = color228;color23;bold
     helptitle = color180;;bold
+    helpframe = color252;color239
 
 [editor]
     _default_ = color250;default
@@ -159,6 +165,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color228;color23;bold
+    viewframe = color250;default
 
 [diffviewer]
     changedline = color231;color29

--- a/misc/skins/modarin256-thin.ini
+++ b/misc/skins/modarin256-thin.ini
@@ -81,6 +81,7 @@
     disabled = color246;color239
     #inputhistory =
     #commandhistory =
+    frame = color252;color237
 
 [dialog]
     _default_ = color252;color239
@@ -90,6 +91,7 @@
     dselnormal = color228;color23;bold
     dselfocus = color214;color23
     dtitle = color180;;bold
+    dframe = color252;color239
 
 [error]
     _default_ = color230;color52
@@ -97,6 +99,7 @@
     errdhotnormal = color203;color52
     errdhotfocus = color203;color23;bold
     errdtitle = color227;;bold
+    errdframe = color230;color52
 
 [filehighlight]
     directory = color144;;bold
@@ -121,11 +124,13 @@
     menuhot = color214
     menuhotsel = color214;color23
     menuinactive = color246
+    menuframe = color252;color239
 
 [popupmenu]
     _default_ = color252;color239
     menusel = color253;color23
     menutitle = color180;;bold
+    menuframe = color252;color239
 
 [buttonbar]
     button = color253;color236
@@ -141,6 +146,7 @@
     helplink = color45
     helpslink = color228;color23;bold
     helptitle = color180;;bold
+    helpframe = color252;color239
 
 [editor]
     _default_ = color252;color237
@@ -157,6 +163,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color228;color23;bold
+    viewframe = color252;color237
 
 [diffviewer]
     changedline = color231;color29

--- a/misc/skins/modarin256.ini
+++ b/misc/skins/modarin256.ini
@@ -82,6 +82,7 @@
     #inputhistory =
     #commandhistory =
     shadow = color240;color0
+    frame = color252;color237
 
 [dialog]
     _default_ = color252;color239
@@ -91,6 +92,7 @@
     dselnormal = color228;color23;bold
     dselfocus = color214;color23
     dtitle = color180;;bold
+    dframe = color252;color239
 
 [error]
     _default_ = color230;color52
@@ -98,6 +100,7 @@
     errdhotnormal = color203;color52
     errdhotfocus = color203;color23;bold
     errdtitle = color227;;bold
+    errdframe = color230;color52
 
 [filehighlight]
     directory = color144;;bold
@@ -122,11 +125,13 @@
     menuhot = color214
     menuhotsel = color214;color23
     menuinactive = color246
+    menuframe = color252;color239
 
 [popupmenu]
     _default_ = color252;color239
     menusel = color253;color23
     menutitle = color180;;bold
+    menuframe = color252;color239
 
 [buttonbar]
     button = color253;color236
@@ -142,6 +147,7 @@
     helplink = color45
     helpslink = color228;color23;bold
     helptitle = color180;;bold
+    helpframe = color252;color239
 
 [editor]
     _default_ = color252;color237
@@ -159,6 +165,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color228;color23;bold
+    viewframe = color252;color237
 
 [diffviewer]
     changedline = color231;color29

--- a/misc/skins/modarin256root-defbg-thin.ini
+++ b/misc/skins/modarin256root-defbg-thin.ini
@@ -81,6 +81,7 @@
     disabled = color246;color239
     #inputhistory =
     #commandhistory =
+    frame = color250;default
 
 [dialog]
     _default_ = color252;color239
@@ -90,6 +91,7 @@
     dselnormal = color228;color88;bold
     dselfocus = color214;color88;bold
     dtitle = color180;;bold
+    dframe = color252;color239
 
 [error]
     _default_ = color230;color52
@@ -97,6 +99,7 @@
     errdhotnormal = color203;color52
     errdhotfocus = color203;color95;bold
     errdtitle = color227;;bold
+    errdframe = color230;color52
 
 [filehighlight]
     directory = color144;;bold
@@ -121,11 +124,13 @@
     menuhot = color214
     menuhotsel = color214;color88
     menuinactive = color245
+    menuframe = color250;default
 
 [popupmenu]
     _default_ = color250;default
     menusel = color253;color88
     menutitle = color180;;bold
+    menuframe = color250;default
 
 [buttonbar]
     button = color253;color236
@@ -141,6 +146,7 @@
     helplink = color45
     helpslink = color228;color88;bold
     helptitle = color180;;bold
+    helpframe = color252;color239
 
 [editor]
     _default_ = color250;default
@@ -157,6 +163,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color228;color88;bold
+    viewframe = color250;default
 
 [diffviewer]
     changedline = color231;color130

--- a/misc/skins/modarin256root-defbg.ini
+++ b/misc/skins/modarin256root-defbg.ini
@@ -82,6 +82,7 @@
     #inputhistory =
     #commandhistory =
     shadow = color240;color0
+    frame = color250;default
 
 [dialog]
     _default_ = color252;color239
@@ -91,6 +92,7 @@
     dselnormal = color228;color88;bold
     dselfocus = color214;color88;bold
     dtitle = color180;;bold
+    dframe = color252;color239
 
 [error]
     _default_ = color230;color52
@@ -98,6 +100,7 @@
     errdhotnormal = color203;color52
     errdhotfocus = color203;color95;bold
     errdtitle = color227;;bold
+    errdframe = color230;color52
 
 [filehighlight]
     directory = color144;;bold
@@ -122,11 +125,13 @@
     menuhot = color214
     menuhotsel = color214;color88
     menuinactive = color245
+    menuframe = color250;default
 
 [popupmenu]
     _default_ = color250;default
     menusel = color253;color88
     menutitle = color180;;bold
+    menuframe = color250;default
 
 [buttonbar]
     button = color253;color236
@@ -142,6 +147,7 @@
     helplink = color45
     helpslink = color228;color88;bold
     helptitle = color180;;bold
+    helpframe = color252;color239
 
 [editor]
     _default_ = color250;default
@@ -159,6 +165,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color228;color88;bold
+    viewframe = color250;default
 
 [diffviewer]
     changedline = color231;color130

--- a/misc/skins/modarin256root-thin.ini
+++ b/misc/skins/modarin256root-thin.ini
@@ -81,6 +81,7 @@
     disabled = color246;color239
     #inputhistory =
     #commandhistory =
+    frame = color252;color237
 
 [dialog]
     _default_ = color252;color239
@@ -90,6 +91,7 @@
     dselnormal = color228;color88;bold
     dselfocus = color214;color88;bold
     dtitle = color180;;bold
+    dframe = color252;color239
 
 [error]
     _default_ = color230;color52
@@ -97,6 +99,7 @@
     errdhotnormal = color203;color52
     errdhotfocus = color203;color95;bold
     errdtitle = color227;;bold
+    errdframe = color230;color52
 
 [filehighlight]
     directory = color144;;bold
@@ -121,11 +124,13 @@
     menuhot = color214
     menuhotsel = color214;color88
     menuinactive = color246
+    menuframe = color252;color239
 
 [popupmenu]
     _default_ = color252;color239
     menusel = color253;color88
     menutitle = color180;;bold
+    menuframe = color252;color239
 
 [buttonbar]
     button = color253;color236
@@ -141,6 +146,7 @@
     helplink = color45
     helpslink = color228;color88;bold
     helptitle = color180;;bold
+    helpframe = color252;color239
 
 [editor]
     _default_ = color252;color237
@@ -157,6 +163,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color228;color88;bold
+    viewframe = color252;color237
 
 [diffviewer]
     changedline = color231;color130

--- a/misc/skins/modarin256root.ini
+++ b/misc/skins/modarin256root.ini
@@ -82,6 +82,7 @@
     #inputhistory =
     #commandhistory =
     shadow = color240;color0
+    frame = color252;color237
 
 [dialog]
     _default_ = color252;color239
@@ -91,6 +92,7 @@
     dselnormal = color228;color88;bold
     dselfocus = color214;color88;bold
     dtitle = color180;;bold
+    dframe = color252;color239
 
 [error]
     _default_ = color230;color52
@@ -98,6 +100,7 @@
     errdhotnormal = color203;color52
     errdhotfocus = color203;color95;bold
     errdtitle = color227;;bold
+    errdframe = color230;color52
 
 [filehighlight]
     directory = color144;;bold
@@ -122,11 +125,13 @@
     menuhot = color214
     menuhotsel = color214;color88
     menuinactive = color246
+    menuframe = color252;color239
 
 [popupmenu]
     _default_ = color252;color239
     menusel = color253;color88
     menutitle = color180;;bold
+    menuframe = color252;color239
 
 [buttonbar]
     button = color253;color236
@@ -142,6 +147,7 @@
     helplink = color45
     helpslink = color228;color88;bold
     helptitle = color180;;bold
+    helpframe = color252;color239
 
 [editor]
     _default_ = color252;color237
@@ -159,6 +165,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color228;color88;bold
+    viewframe = color252;color237
 
 [diffviewer]
     changedline = color231;color130

--- a/misc/skins/nicedark.ini
+++ b/misc/skins/nicedark.ini
@@ -40,6 +40,7 @@
     inputhistory =
     commandhistory =
     shadow = gray;black
+    frame = lightgray;black
 
 [dialog]
     _default_ = lightgray;black
@@ -49,6 +50,7 @@
     dselnormal = lightgray;blue
     dselfocus = brown;blue
     dtitle = brown;black
+    dframe = lightgray;black
 
 [error]
     _default_ = red;black
@@ -56,6 +58,7 @@
     errdhotnormal = brightred;black
     errdhotfocus = brown;red
     errdtitle = brown;black
+    errdframe = red;black
 
 [filehighlight]
     directory = blue;
@@ -80,11 +83,13 @@
     menuhot = brown;black
     menuhotsel = brown;blue
     menuinactive = gray;black
+    menuframe = lightgray;black
 
 [popupmenu]
     _default_ = lightgray;black
     menusel = lightgray;blue
     menutitle = lightgray;black
+    menuframe = lightgray;black
 
 [buttonbar]
     hotkey = lightgray;blue
@@ -100,6 +105,7 @@
     helplink = blue;black
     helpslink = lightgray;blue
     helptitle = brown;black
+    helpframe = lightgray;black
 
 [editor]
     _default_ = lightgray;black
@@ -121,6 +127,7 @@
     viewbold = brown;blue
     viewunderline = brightred;blue
     viewselected = brown;cyan
+    viewframe = lightgray;black
 
 [diffviewer]
     added = white;brown

--- a/misc/skins/sand256.ini
+++ b/misc/skins/sand256.ini
@@ -90,6 +90,7 @@
     commandlinemark = white;gray
     header = red;;italic
     shadow = black;rgb221
+    frame = black;rgb554
 
 [dialog]
     _default_ = black;rgb553
@@ -99,6 +100,7 @@
     dselnormal = ;rgb452
     dselfocus = ;rgb452
     dtitle = ;;italic+underline
+    dframe = black;rgb553
 
 [error]
     _default_ = rgb554;rgb320;bold
@@ -107,6 +109,7 @@
     errdhotnormal = ;;bold+underline
     errdhotfocus = rgb000;rgb452;bold+underline
     errdtitle = ;;bold+italic+underline
+    errdframe = rgb554;rgb320;bold
 
 [filehighlight]
     directory =
@@ -132,11 +135,13 @@
     menuhot = ;;italic+underline
     menuhotsel = ;rgb551;italic+underline
     menuinactive =
+    menuframe = black;rgb452;italic
 
 [popupmenu]
     _default_ = black;rgb553
     menusel = ;rgb452
     menutitle = ;;italic+underline
+    menuframe = black;rgb553
 
 [buttonbar]
     hotkey = black;rgb554;italic
@@ -152,6 +157,7 @@
     helplink = blue;;underline
     helpslink = blue;;reverse
     helptitle = ;;underline
+    helpframe = black;rgb553
 
 [editor]
     _default_ = black;rgb554
@@ -174,6 +180,7 @@
     viewbold = rgb000;;bold
     viewunderline = ;;underline
     viewselected = rgb400;rgb452
+    viewframe = black;rgb554
 
 [diffviewer]
     added = ;rgb450

--- a/misc/skins/sand256.ini
+++ b/misc/skins/sand256.ini
@@ -135,7 +135,7 @@
     menuhot = ;;italic+underline
     menuhotsel = ;rgb551;italic+underline
     menuinactive =
-    menuframe = black;rgb452;italic
+    menuframe = black;rgb452;none
 
 [popupmenu]
     _default_ = black;rgb553

--- a/misc/skins/seasons-autumn16M.ini
+++ b/misc/skins/seasons-autumn16M.ini
@@ -93,6 +93,7 @@
     commandlinemark = #000;DialogFocus
     header = HeaderFg
     shadow = ShadowFg;ShadowBg
+    frame = MainFg;Main
 
 [dialog]
     _default_ = #000;Dialog
@@ -102,6 +103,7 @@
     dselnormal = ;DialogFocus
     dselfocus = ;DialogFocus
     dtitle = ;;bold
+    dframe = #000;Dialog
 
 [error]
     _default_ = #fff;Error
@@ -109,6 +111,7 @@
     errdhotnormal = ;;underline
     errdhotfocus = ;ErrorFocus;underline
     errdtitle = ;;bold
+    errdframe = #fff;Error
 
 [filehighlight]
     directory = DirectoryFg
@@ -133,11 +136,13 @@
     menuhot = ;;underline
     menuhotsel = ;MenuSelected;underline
     menuinactive = ;Top
+    menuframe = #000;MenuActive
 
 [popupmenu]
     _default_ = #000;Dialog
     menusel = ;DialogFocus
     menutitle = ;;bold
+    menuframe = #000;Dialog
 
 [buttonbar]
     hotkey = BottomNumberFg;BottomNumber
@@ -152,6 +157,7 @@
     helpitalic = HelpItalicFg;;italic
     helplink = HelpLinkFg;;underline
     helpslink = Help;HelpLinkFg
+    helpframe = #000;Help
 
 [editor]
     editbold = MarkedFg;;bold
@@ -171,6 +177,7 @@
     viewbold = ViewerBoldFg;;bold
     viewunderline = ViewerUnderlinedFg;;underline
     viewselected = #000;ViewerSelected
+    viewframe = #000;Help
 
 [diffviewer]
     added = ;DiffAdd

--- a/misc/skins/seasons-spring16M.ini
+++ b/misc/skins/seasons-spring16M.ini
@@ -93,6 +93,7 @@
     commandlinemark = #000;DialogFocus
     header = HeaderFg
     shadow = ShadowFg;ShadowBg
+    frame = MainFg;Main
 
 [dialog]
     _default_ = #000;Dialog
@@ -102,6 +103,7 @@
     dselnormal = ;DialogFocus
     dselfocus = ;DialogFocus
     dtitle = ;;bold
+    dframe = #000;Dialog
 
 [error]
     _default_ = #fff;Error
@@ -109,6 +111,7 @@
     errdhotnormal = ;;underline
     errdhotfocus = ;ErrorFocus;underline
     errdtitle = ;;bold
+    errdframe = #fff;Error
 
 [filehighlight]
     directory = DirectoryFg
@@ -133,11 +136,13 @@
     menuhot = ;;underline
     menuhotsel = ;MenuSelected;underline
     menuinactive = ;Top
+    menuframe = #000;MenuActive
 
 [popupmenu]
     _default_ = #000;Dialog
     menusel = ;DialogFocus
     menutitle = ;;bold
+    menuframe = #000;Dialog
 
 [buttonbar]
     hotkey = BottomNumberFg;BottomNumber
@@ -152,6 +157,7 @@
     helpitalic = HelpItalicFg;;italic
     helplink = HelpLinkFg;;underline
     helpslink = Help;HelpLinkFg
+    helpframe = #000;Help
 
 [editor]
     editbold = MarkedFg;;bold
@@ -171,6 +177,7 @@
     viewbold = ViewerBoldFg;;bold
     viewunderline = ViewerUnderlinedFg;;underline
     viewselected = #000;ViewerSelected
+    viewframe = #000;Help
 
 [diffviewer]
     added = ;DiffAdd

--- a/misc/skins/seasons-summer16M.ini
+++ b/misc/skins/seasons-summer16M.ini
@@ -93,6 +93,7 @@
     commandlinemark = #000;DialogFocus
     header = HeaderFg
     shadow = ShadowFg;ShadowBg
+    frame = MainFg;Main
 
 [dialog]
     _default_ = #000;Dialog
@@ -102,6 +103,7 @@
     dselnormal = ;DialogFocus
     dselfocus = ;DialogFocus
     dtitle = ;;bold
+    dframe = #000;Dialog
 
 [error]
     _default_ = #fff;Error
@@ -109,6 +111,7 @@
     errdhotnormal = ;;underline
     errdhotfocus = ;ErrorFocus;underline
     errdtitle = ;;bold
+    errdframe = #fff;Error
 
 [filehighlight]
     directory = DirectoryFg
@@ -133,11 +136,13 @@
     menuhot = ;;underline
     menuhotsel = ;MenuSelected;underline
     menuinactive = ;Top
+    menuframe = #000;MenuActive
 
 [popupmenu]
     _default_ = #000;Dialog
     menusel = ;DialogFocus
     menutitle = ;;bold
+    menuframe = #000;Dialog
 
 [buttonbar]
     hotkey = BottomNumberFg;BottomNumber
@@ -152,6 +157,7 @@
     helpitalic = HelpItalicFg;;italic
     helplink = HelpLinkFg;;underline
     helpslink = Help;HelpLinkFg
+    helpframe = #000;Help
 
 [editor]
     editbold = MarkedFg;;bold
@@ -171,6 +177,7 @@
     viewbold = ViewerBoldFg;;bold
     viewunderline = ViewerUnderlinedFg;;underline
     viewselected = #000;ViewerSelected
+    viewframe = #000;Help
 
 [diffviewer]
     added = ;DiffAdd

--- a/misc/skins/seasons-winter16M.ini
+++ b/misc/skins/seasons-winter16M.ini
@@ -93,6 +93,7 @@
     commandlinemark = #000;DialogFocus
     header = HeaderFg
     shadow = ShadowFg;ShadowBg
+    frame = MainFg;Main
 
 [dialog]
     _default_ = #000;Dialog
@@ -102,6 +103,7 @@
     dselnormal = ;DialogFocus
     dselfocus = ;DialogFocus
     dtitle = ;;bold
+    dframe = #000;Dialog
 
 [error]
     _default_ = #fff;Error
@@ -109,6 +111,7 @@
     errdhotnormal = ;;underline
     errdhotfocus = ;ErrorFocus;underline
     errdtitle = ;;bold
+    errdframe = #fff;Error
 
 [filehighlight]
     directory = DirectoryFg
@@ -133,11 +136,13 @@
     menuhot = ;;underline
     menuhotsel = ;MenuSelected;underline
     menuinactive = ;Top
+    menuframe = #000;MenuActive
 
 [popupmenu]
     _default_ = #000;Dialog
     menusel = ;DialogFocus
     menutitle = ;;bold
+    menuframe = #000;Dialog
 
 [buttonbar]
     hotkey = BottomNumberFg;BottomNumber
@@ -152,6 +157,7 @@
     helpitalic = HelpItalicFg;;italic
     helplink = HelpLinkFg;;underline
     helpslink = Help;HelpLinkFg
+    helpframe = #000;Help
 
 [editor]
     editbold = MarkedFg;;bold
@@ -171,6 +177,7 @@
     viewbold = ViewerBoldFg;;bold
     viewunderline = ViewerUnderlinedFg;;underline
     viewselected = #000;ViewerSelected
+    viewframe = #000;Help
 
 [diffviewer]
     added = ;DiffAdd

--- a/misc/skins/xoria256-thin.ini
+++ b/misc/skins/xoria256-thin.ini
@@ -46,6 +46,7 @@
     markselect = color228;color60
     reverse = color234;color250;
     header = color180;;bold
+    frame = color250;color234
 
     gauge = white;black
 
@@ -69,6 +70,7 @@
     dselnormal = black;color73;
     dselfocus = color88;color73;
     dtitle = color235;;bold
+    dframe = black;color250
 
 [error]
     _default_ = white;red
@@ -76,6 +78,7 @@
     errdhotnormal = yellow;red
     errdhotfocus = yellow;lightgray
     errdtitle = yellow;red;bold
+    errdframe = white;red
 
 [filehighlight]
     directory = ;;bold
@@ -100,11 +103,13 @@
     menuhot = color88;;
     menuhotsel = color88;color73;
     menuinactive = color244
+    menuframe = black;color250
 
 [popupmenu]
     _default_ = black;color250
     menusel = black;color73
     menutitle = ;;bold
+    menuframe = black;color250
 
 [buttonbar]
     button = black;color250
@@ -120,6 +125,7 @@
     helplink = color19;;
     helpslink = black;color73;inverse
     helptitle = color235;;bold
+    helpframe = black;color250
 
 [editor]
     _default_ = color250;color234
@@ -141,6 +147,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color228;color60
+    viewframe = color250;color234
 
 [diffviewer]
     changedline = ;color60

--- a/misc/skins/xoria256.ini
+++ b/misc/skins/xoria256.ini
@@ -46,6 +46,7 @@
     markselect = color228;color60
     reverse = color234;color250;
     header = color180;;bold
+    frame = color250;color234
 
     gauge = white;black
 
@@ -69,6 +70,7 @@
     dselnormal = black;color73;
     dselfocus = color88;color73;
     dtitle = color235;;bold
+    dframe = black;color250
 
 [error]
     _default_ = white;red
@@ -76,6 +78,7 @@
     errdhotnormal = yellow;red
     errdhotfocus = yellow;lightgray
     errdtitle = yellow;red;bold
+    errdframe = white;red
 
 [filehighlight]
     directory = ;;bold
@@ -100,11 +103,13 @@
     menuhot = color88;;
     menuhotsel = color88;color73;
     menuinactive = color244
+    menuframe = black;color250
 
 [popupmenu]
     _default_ = black;color250
     menusel = black;color73
     menutitle = ;;bold
+    menuframe = black;color250
 
 [buttonbar]
     button = black;color250
@@ -120,6 +125,7 @@
     helplink = color19;;
     helpslink = black;color73;inverse
     helptitle = color235;;bold
+    helpframe = black;color250
 
 [editor]
     _default_ = color250;color234
@@ -141,6 +147,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color228;color60
+    viewframe = color250;color234
 
 [diffviewer]
     changedline = ;color60

--- a/misc/skins/xoria256root-thin.ini
+++ b/misc/skins/xoria256root-thin.ini
@@ -46,6 +46,7 @@
     markselect = color228;color60
     reverse = color234;color250;
     header = color180;;bold
+    frame = color250;color234
 
     gauge = white;black
 
@@ -69,6 +70,7 @@
     dselnormal = black;color73;
     dselfocus = color88;color73;
     dtitle = color235;;bold
+    dframe = black;color250
 
 [error]
     _default_ = white;red
@@ -76,6 +78,7 @@
     errdhotnormal = yellow;red
     errdhotfocus = yellow;lightgray
     errdtitle = yellow;red;bold
+    errdframe = white;red
 
 [filehighlight]
     directory = ;;bold
@@ -100,11 +103,13 @@
     menuhot = color88;;
     menuhotsel = color88;color73;
     menuinactive = color244
+    menuframe = black;color250
 
 [popupmenu]
     _default_ = black;color250
     menusel = black;color73
     menutitle = ;;bold
+    menuframe = black;color250
 
 [buttonbar]
     button = black;color250
@@ -120,6 +125,7 @@
     helplink = color19;;
     helpslink = black;color73;inverse
     helptitle = color235;;bold
+    helpframe = black;color250
 
 [editor]
     _default_ = color250;color234
@@ -141,6 +147,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color228;color60
+    viewframe = color250;color234
 
 [diffviewer]
     changedline = ;color60

--- a/misc/skins/yadt256-defbg.ini
+++ b/misc/skins/yadt256-defbg.ini
@@ -49,6 +49,7 @@
     #inputhistory =
     #commandhistory =
     shadow = color239;black
+    frame = color250;default
 
 [dialog]
     _default_ = color252;color239
@@ -58,6 +59,7 @@
     dselnormal = color228;blue;bold
     dselfocus = color214;blue
     dtitle = color180;;bold
+    dframe = color252;color239
 
 [error]
     _default_ = color230;color52
@@ -65,6 +67,7 @@
     errdhotnormal = color203;color52
     errdhotfocus = color203;blue;bold
     errdtitle = color227;;bold
+    errdframe = color230;color52
 
 [filehighlight]
     directory = color144;;bold
@@ -89,11 +92,13 @@
     menuhot = color214
     menuhotsel = color214;blue
     menuinactive = color252
+    menuframe = color252;color239
 
 [popupmenu]
     _default_ = color252;default
     menusel = color252;blue
     menutitle = color180;;bold
+    menuframe = color252;default
 
 [buttonbar]
     button = color252;color236
@@ -109,6 +114,7 @@
     helplink = color45
     helpslink = color228;blue;bold
     helptitle = color180;;bold
+    helpframe = color252;color239
 
 [editor]
     _default_ = color250;default
@@ -126,6 +132,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color228;blue;bold
+    viewframe = color250;default
 
 [diffviewer]
     changedline = color231;color29

--- a/misc/skins/yadt256.ini
+++ b/misc/skins/yadt256.ini
@@ -48,6 +48,7 @@
     #inputhistory =
     #commandhistory =
     shadow = color239;black
+    frame = color250;black
 
 [dialog]
     _default_ = color252;color239
@@ -57,6 +58,7 @@
     dselnormal = color228;blue;bold
     dselfocus = color214;blue
     dtitle = color180;;bold
+    dframe = color252;color239
 
 [error]
     _default_ = color230;color52
@@ -64,6 +66,7 @@
     errdhotnormal = color203;color52
     errdhotfocus = color203;blue;bold
     errdtitle = color227;;bold
+    errdframe = color230;color52
 
 [filehighlight]
     directory = color144;;bold
@@ -88,11 +91,13 @@
     menuhot = color214
     menuhotsel = color214;blue
     menuinactive = color252
+    menuframe = color252;color239
 
 [popupmenu]
     _default_ = color252;color239
     menusel = color252;blue
     menutitle = color180;;bold
+    menuframe = color252;color239
 
 [buttonbar]
     button = color252;color236
@@ -108,6 +113,7 @@
     helplink = color45
     helpslink = color228;blue;bold
     helptitle = color180;;bold
+    helpframe = color252;color239
 
 [editor]
     _default_ = color250;black
@@ -125,6 +131,7 @@
     viewbold = ;;bold
     viewunderline = ;;underline
     viewselected = color228;blue;bold
+    viewframe = color250;black
 
 [diffviewer]
     changedline = color231;color29

--- a/src/diffviewer/ydiff.c
+++ b/src/diffviewer/ydiff.c
@@ -2760,7 +2760,7 @@ dview_update (WDiff *dview)
     {
         int xwidth;
 
-        tty_setcolor (CORE_NORMAL_COLOR);
+        tty_setcolor (CORE_FRAME_COLOR);
         xwidth = dview->display_numbers;
         if (dview->display_symbols)
             xwidth++;

--- a/src/diffviewer/ydiff.c
+++ b/src/diffviewer/ydiff.c
@@ -2526,7 +2526,7 @@ dview_display_file (const WDiff *dview, diff_place_t ord, int r, int c, int heig
 
         p = (DIFFLN *) &g_array_index (dview->a[ord], DIFFLN, i);
         ch = p->ch;
-        tty_setcolor (NORMAL_COLOR);
+        tty_setcolor (CORE_NORMAL_COLOR);
         if (display_symbols)
         {
             tty_gotoyx (r + j, c - 2);
@@ -2541,13 +2541,13 @@ dview_display_file (const WDiff *dview, diff_place_t ord, int r, int c, int heig
                 tty_print_string (str_fit_to_term (buf, nwidth, J_LEFT_FIT));
             }
             if (ch == ADD_CH)
-                tty_setcolor (DFF_ADD_COLOR);
+                tty_setcolor (DIFFVIEWER_ADDED_COLOR);
             if (ch == CHG_CH)
-                tty_setcolor (DFF_CHG_COLOR);
+                tty_setcolor (DIFFVIEWER_CHANGEDLINE_COLOR);
             if (f == NULL)
             {
                 if (i == (size_t) dview->search.last_found_line)
-                    tty_setcolor (MARKED_SELECTED_COLOR);
+                    tty_setcolor (CORE_MARKED_SELECTED_COLOR);
                 else if (dview->hdiff != NULL && g_ptr_array_index (dview->hdiff, i) != NULL)
                 {
                     char att[BUFSIZ];
@@ -2576,7 +2576,8 @@ dview_display_file (const WDiff *dview, diff_place_t ord, int r, int c, int heig
                         else
                             next_ch = dview_get_byte (buf, cnt);
 
-                        tty_setcolor (att[cnt] ? DFF_CHH_COLOR : DFF_CHG_COLOR);
+                        tty_setcolor (att[cnt] ? DIFFVIEWER_CHANGEDNEW_COLOR
+                                               : DIFFVIEWER_CHANGEDLINE_COLOR);
                         if (mc_global.utf8_display)
                         {
                             if (!dview->utf8)
@@ -2594,7 +2595,7 @@ dview_display_file (const WDiff *dview, diff_place_t ord, int r, int c, int heig
                 }
 
                 if (ch == CHG_CH)
-                    tty_setcolor (DFF_CHH_COLOR);
+                    tty_setcolor (DIFFVIEWER_CHANGEDNEW_COLOR);
 
                 if (dview->utf8)
                     k = dview_str_utf8_offset_to_pos (p->p, width);
@@ -2614,9 +2615,9 @@ dview_display_file (const WDiff *dview, diff_place_t ord, int r, int c, int heig
                 tty_print_string (buf);
             }
             if (ch == DEL_CH)
-                tty_setcolor (DFF_DEL_COLOR);
+                tty_setcolor (DIFFVIEWER_REMOVED_COLOR);
             if (ch == CHG_CH)
-                tty_setcolor (DFF_CHD_COLOR);
+                tty_setcolor (DIFFVIEWER_CHANGED_COLOR);
             fill_by_space (buf, width, TRUE);
         }
         tty_gotoyx (r + j, c);
@@ -2652,7 +2653,7 @@ dview_display_file (const WDiff *dview, diff_place_t ord, int r, int c, int heig
         }
     }
 
-    tty_setcolor (NORMAL_COLOR);
+    tty_setcolor (CORE_NORMAL_COLOR);
     k = width;
     if (width < xwidth - 1)
         k = xwidth - 1;
@@ -2759,7 +2760,7 @@ dview_update (WDiff *dview)
     {
         int xwidth;
 
-        tty_setcolor (NORMAL_COLOR);
+        tty_setcolor (CORE_NORMAL_COLOR);
         xwidth = dview->display_numbers;
         if (dview->display_symbols)
             xwidth++;

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -474,7 +474,7 @@ edit_load_position (WEdit *edit, gboolean load_position)
 
     load_file_position (edit->filename_vpath, &line, &column, &offset, &edit->serialized_bookmarks);
     // apply bookmarks in any case
-    book_mark_restore (edit, BOOK_MARK_COLOR);
+    book_mark_restore (edit, EDITOR_BOOKMARK_COLOR);
 
     if (!load_position)
         return;
@@ -506,7 +506,7 @@ edit_save_position (WEdit *edit)
         || *(vfs_path_get_by_index (edit->filename_vpath, 0)->path) == '\0')
         return;
 
-    book_mark_serialize (edit, BOOK_MARK_COLOR);
+    book_mark_serialize (edit, EDITOR_BOOKMARK_COLOR);
     save_file_position (edit->filename_vpath, edit->buffer.curs_line + 1, edit->curs_col,
                         edit->buffer.curs1, edit->serialized_bookmarks);
     edit->serialized_bookmarks = NULL;
@@ -3800,15 +3800,15 @@ edit_execute_cmd (WEdit *edit, long command, int char_for_insertion)
         break;
 
     case CK_Bookmark:
-        book_mark_clear (edit, edit->buffer.curs_line, BOOK_MARK_FOUND_COLOR);
-        if (book_mark_query_color (edit, edit->buffer.curs_line, BOOK_MARK_COLOR))
-            book_mark_clear (edit, edit->buffer.curs_line, BOOK_MARK_COLOR);
+        book_mark_clear (edit, edit->buffer.curs_line, EDITOR_BOOKMARK_FOUND_COLOR);
+        if (book_mark_query_color (edit, edit->buffer.curs_line, EDITOR_BOOKMARK_COLOR))
+            book_mark_clear (edit, edit->buffer.curs_line, EDITOR_BOOKMARK_COLOR);
         else
-            book_mark_insert (edit, edit->buffer.curs_line, BOOK_MARK_COLOR);
+            book_mark_insert (edit, edit->buffer.curs_line, EDITOR_BOOKMARK_COLOR);
         break;
     case CK_BookmarkFlush:
-        book_mark_flush (edit, BOOK_MARK_COLOR);
-        book_mark_flush (edit, BOOK_MARK_FOUND_COLOR);
+        book_mark_flush (edit, EDITOR_BOOKMARK_COLOR);
+        book_mark_flush (edit, EDITOR_BOOKMARK_FOUND_COLOR);
         edit->force |= REDRAW_PAGE;
         break;
     case CK_BookmarkNext:

--- a/src/editor/editdraw.c
+++ b/src/editor/editdraw.c
@@ -341,7 +341,7 @@ edit_draw_frame (const WEdit *edit, int color, gboolean active)
     // draw a drag marker
     if (edit->drag_state == MCEDIT_DRAG_NONE)
     {
-        tty_setcolor (EDITOR_FRAME_DRAG);
+        tty_setcolor (EDITOR_FRAME_DRAG_COLOR);
         widget_gotoyx (w, w->rect.lines - 1, w->rect.cols - 1);
         tty_print_char (mc_tty_frm[MC_TTY_FRM_RIGHTBOTTOM]);
     }
@@ -426,7 +426,7 @@ print_to_widget (WEdit *edit, long row, int start_col, int start_col_real, long 
 
     if (edit_options.line_state)
     {
-        tty_setcolor (LINE_STATE_COLOR);
+        tty_setcolor (EDITOR_LINE_STATE_COLOR);
 
         for (i = 0; i < LINE_STATE_WIDTH; i++)
         {
@@ -502,10 +502,10 @@ edit_draw_this_line (WEdit *edit, off_t b, long row, long start_col, long end_co
     if (row > w->rect.lines - 1 - EDIT_TEXT_VERTICAL_OFFSET - 2 * (edit->fullscreen != 0 ? 0 : 1))
         return;
 
-    if (book_mark_query_color (edit, edit->start_line + row, BOOK_MARK_COLOR))
-        book_mark = BOOK_MARK_COLOR;
-    else if (book_mark_query_color (edit, edit->start_line + row, BOOK_MARK_FOUND_COLOR))
-        book_mark = BOOK_MARK_FOUND_COLOR;
+    if (book_mark_query_color (edit, edit->start_line + row, EDITOR_BOOKMARK_COLOR))
+        book_mark = EDITOR_BOOKMARK_COLOR;
+    else if (book_mark_query_color (edit, edit->start_line + row, EDITOR_BOOKMARK_FOUND_COLOR))
+        book_mark = EDITOR_BOOKMARK_FOUND_COLOR;
 
     if (book_mark != 0)
         abn_style = book_mark << 16;
@@ -537,7 +537,7 @@ edit_draw_this_line (WEdit *edit, off_t b, long row, long start_col, long end_co
             line_stat[LINE_STATE_WIDTH] = '\0';
         }
 
-        if (book_mark_query_color (edit, cur_line, BOOK_MARK_COLOR))
+        if (book_mark_query_color (edit, cur_line, EDITOR_BOOKMARK_COLOR))
             g_snprintf (line_stat, 2, "*");
     }
 
@@ -1020,9 +1020,9 @@ edit_status (WEdit *edit, gboolean active)
     }
     else
     {
-        color = edit->drag_state != MCEDIT_DRAG_NONE ? EDITOR_FRAME_DRAG
-            : active                                 ? EDITOR_FRAME_ACTIVE
-                                                     : EDITOR_FRAME;
+        color = edit->drag_state != MCEDIT_DRAG_NONE ? EDITOR_FRAME_DRAG_COLOR
+            : active                                 ? EDITOR_FRAME_ACTIVE_COLOR
+                                                     : EDITOR_FRAME_COLOR;
         edit_draw_frame (edit, color, active);
         edit_status_window (edit);
     }

--- a/src/editor/editsearch.c
+++ b/src/editor/editsearch.c
@@ -33,7 +33,7 @@
 #include "lib/charsets.h"  // cp_source
 #include "lib/util.h"
 #include "lib/widget.h"
-#include "lib/skin.h"  // BOOK_MARK_FOUND_COLOR
+#include "lib/skin.h"  // EDITOR_BOOKMARK_FOUND_COLOR
 
 #include "src/history.h"  // MC_HISTORY_SHARED_SEARCH
 #include "src/setup.h"    // verbose
@@ -490,7 +490,7 @@ edit_do_search (WEdit *edit)
 
             l += edit_buffer_count_lines (&edit->buffer, q, edit->search->normal_offset);
             if (l != l_last)
-                book_mark_insert (edit, l, BOOK_MARK_FOUND_COLOR);
+                book_mark_insert (edit, l, EDITOR_BOOKMARK_FOUND_COLOR);
             l_last = l;
             q = edit->search->normal_offset + 1;
         }

--- a/src/editor/editwidget.c
+++ b/src/editor/editwidget.c
@@ -1248,7 +1248,7 @@ edit_files (const GList *files)
     g = GROUP (edit_dlg);
 
     edit_dlg->bg = WIDGET (background_new (1, 0, wd->rect.lines - 2, wd->rect.cols,
-                                           EDITOR_BACKGROUND, ' ', edit_dialog_bg_callback));
+                                           EDITOR_BACKGROUND_COLOR, ' ', edit_dialog_bg_callback));
     group_add_widget (g, edit_dlg->bg);
 
     menubar = menubar_new (NULL);

--- a/src/filemanager/achown.c
+++ b/src/filemanager/achown.c
@@ -234,7 +234,7 @@ print_flags (const WDialog *h)
 {
     int i;
 
-    tty_setcolor (COLOR_NORMAL);
+    tty_setcolor (DIALOG_NORMAL_COLOR);
 
     for (i = 0; i < 3; i++)
     {
@@ -273,7 +273,7 @@ print_flags (const WDialog *h)
 static void
 advanced_chown_refresh (const WDialog *h)
 {
-    tty_setcolor (COLOR_NORMAL);
+    tty_setcolor (DIALOG_NORMAL_COLOR);
 
     widget_gotoyx (h, BY - 1, advanced_chown_but[0].x + 5);
     tty_print_string (_ ("owner"));

--- a/src/filemanager/boxes.c
+++ b/src/filemanager/boxes.c
@@ -44,7 +44,7 @@
 #include "lib/tty/tty.h"
 #include "lib/tty/color.h"  // tty_use_colors()
 #include "lib/tty/key.h"    // XCTRL and ALT macros
-#include "lib/skin.h"       // INPUT_COLOR
+#include "lib/skin.h"       // CORE_INPUT_COLOR
 #include "lib/mcconfig.h"   // Load/save user formats
 #include "lib/strutil.h"
 

--- a/src/filemanager/chattr.c
+++ b/src/filemanager/chattr.c
@@ -41,7 +41,7 @@
 
 #include "lib/tty/tty.h"    // tty_print*()
 #include "lib/tty/color.h"  // tty_setcolor()
-#include "lib/skin.h"       // COLOR_NORMAL, DISABLED_COLOR
+#include "lib/skin.h"       // DIALOG_NORMAL_COLOR, CORE_DISABLED_COLOR
 #include "lib/vfs/vfs.h"
 #include "lib/widget.h"
 #include "lib/util.h"  // x_basename()
@@ -284,7 +284,7 @@ fileattrtext_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, vo
     {
     case MSG_DRAW:
     {
-        int color = COLOR_NORMAL;
+        int color = DIALOG_NORMAL_COLOR;
         size_t i;
 
         tty_setcolor (color);
@@ -307,17 +307,17 @@ fileattrtext_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, vo
             // Do not set new color for each symbol. Try to use previous color.
             if (chattr_is_modifiable (i))
             {
-                if (color == DISABLED_COLOR)
+                if (color == CORE_DISABLED_COLOR)
                 {
-                    color = COLOR_NORMAL;
+                    color = DIALOG_NORMAL_COLOR;
                     tty_setcolor (color);
                 }
             }
             else
             {
-                if (color != DISABLED_COLOR)
+                if (color != CORE_DISABLED_COLOR)
                 {
-                    color = DISABLED_COLOR;
+                    color = CORE_DISABLED_COLOR;
                     tty_setcolor (color);
                 }
             }
@@ -394,7 +394,7 @@ chattr_toggle_select (const WChattrBoxes *cb, int Id)
 
     check_attr[Id].selected = !check_attr[Id].selected;
 
-    tty_setcolor (COLOR_NORMAL);
+    tty_setcolor (DIALOG_NORMAL_COLOR);
     chattr_draw_select (w, check_attr[Id].selected);
 }
 

--- a/src/filemanager/chmod.c
+++ b/src/filemanager/chmod.c
@@ -182,7 +182,7 @@ static void
 chmod_toggle_select (const WDialog *h, int Id)
 {
     check_perm[Id].selected = !check_perm[Id].selected;
-    tty_setcolor (COLOR_NORMAL);
+    tty_setcolor (DIALOG_NORMAL_COLOR);
     chmod_draw_select (h, Id);
 }
 
@@ -194,7 +194,7 @@ chmod_refresh (const WDialog *h)
     int i;
     int y, x;
 
-    tty_setcolor (COLOR_NORMAL);
+    tty_setcolor (DIALOG_NORMAL_COLOR);
 
     for (i = 0; i < BUTTONS_PERM; i++)
         chmod_draw_select (h, i);

--- a/src/filemanager/chown.c
+++ b/src/filemanager/chown.c
@@ -128,7 +128,7 @@ chown_refresh (const Widget *h)
     int y = 3;
     int x = 7 + GW * 2;
 
-    tty_setcolor (COLOR_NORMAL);
+    tty_setcolor (DIALOG_NORMAL_COLOR);
 
     widget_gotoyx (h, y + 0, x);
     tty_print_string (_ ("Name"));

--- a/src/filemanager/command.c
+++ b/src/filemanager/command.c
@@ -38,7 +38,7 @@
 
 #include "lib/global.h"
 #include "lib/vfs/vfs.h"  // vfs_current_is_local()
-#include "lib/skin.h"     // DEFAULT_COLOR
+#include "lib/skin.h"     // CORE_DEFAULT_COLOR
 #include "lib/util.h"     // whitespace()
 #include "lib/widget.h"
 
@@ -229,10 +229,10 @@ command_new (int y, int x, int cols)
 void
 command_set_default_colors (void)
 {
-    command_colors[WINPUTC_MAIN] = DEFAULT_COLOR;
-    command_colors[WINPUTC_MARK] = COMMAND_MARK_COLOR;
-    command_colors[WINPUTC_UNCHANGED] = DEFAULT_COLOR;
-    command_colors[WINPUTC_HISTORY] = COMMAND_HISTORY_COLOR;
+    command_colors[WINPUTC_MAIN] = CORE_DEFAULT_COLOR;
+    command_colors[WINPUTC_MARK] = CORE_COMMAND_MARK_COLOR;
+    command_colors[WINPUTC_UNCHANGED] = CORE_DEFAULT_COLOR;
+    command_colors[WINPUTC_HISTORY] = CORE_COMMAND_HISTORY_COLOR;
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/src/filemanager/filemanager.c
+++ b/src/filemanager/filemanager.c
@@ -525,7 +525,7 @@ print_vfs_message (const gchar *event_group_name, const gchar *event_name, gpoin
         tty_getyx (&row, &col);
 
         tty_gotoyx (0, 0);
-        tty_setcolor (NORMAL_COLOR);
+        tty_setcolor (CORE_NORMAL_COLOR);
         tty_print_string (str_fit_to_term (event_data->msg, COLS - 1, J_LEFT));
 
         // Restore cursor position

--- a/src/filemanager/find.c
+++ b/src/filemanager/find.c
@@ -1246,7 +1246,7 @@ do_search (WDialog *h)
             {
                 vfs_path_t *tmp_vpath = NULL;
 
-                tty_setcolor (REVERSE_COLOR);
+                tty_setcolor (CORE_REVERSE_COLOR);
 
                 while (TRUE)
                 {

--- a/src/filemanager/hotlist.c
+++ b/src/filemanager/hotlist.c
@@ -1636,7 +1636,7 @@ hotlist_show (hotlist_t list_type, WPanel *panel)
     init_hotlist (list_type);
 
     // display file info
-    tty_setcolor (SELECTED_COLOR);
+    tty_setcolor (CORE_SELECTED_COLOR);
 
     hotlist_state.running = TRUE;
     res = dlg_run (hotlist_dlg);

--- a/src/filemanager/info.c
+++ b/src/filemanager/info.c
@@ -87,7 +87,7 @@ info_box (WInfo *info)
     const int len = str_term_width1 (title);
 
     tty_set_normal_attrs ();
-    tty_setcolor (NORMAL_COLOR);
+    tty_setcolor (CORE_NORMAL_COLOR);
     widget_erase (w);
     tty_draw_box (w->rect.y, w->rect.x, w->rect.lines, w->rect.cols, FALSE);
 
@@ -120,7 +120,7 @@ info_show_info (WInfo *info)
 
     info_box (info);
 
-    tty_setcolor (MARKED_COLOR);
+    tty_setcolor (CORE_MARKED_COLOR);
     widget_gotoyx (w, 1, 3);
     tty_printf ("%s %s", PACKAGE_NAME, mc_global.mc_version);
 
@@ -152,7 +152,7 @@ info_show_info (WInfo *info)
         i18n_adjust = str_term_width1 (file_label) + 2;
     }
 
-    tty_setcolor (NORMAL_COLOR);
+    tty_setcolor (CORE_NORMAL_COLOR);
 
     buff = g_string_new ("");
 

--- a/src/filemanager/info.c
+++ b/src/filemanager/info.c
@@ -89,16 +89,18 @@ info_box (WInfo *info)
     tty_set_normal_attrs ();
     tty_setcolor (CORE_NORMAL_COLOR);
     widget_erase (w);
+
+    tty_setcolor (CORE_FRAME_COLOR);
     tty_draw_box (w->rect.y, w->rect.x, w->rect.lines, w->rect.cols, FALSE);
-
-    widget_gotoyx (w, 0, (w->rect.cols - len - 2) / 2);
-    tty_printf (" %s ", title);
-
     widget_gotoyx (w, 2, 0);
     tty_print_char (mc_tty_frm[MC_TTY_FRM_DLEFTMIDDLE]);
     widget_gotoyx (w, 2, w->rect.cols - 1);
     tty_print_char (mc_tty_frm[MC_TTY_FRM_DRIGHTMIDDLE]);
     tty_draw_hline (w->rect.y + 2, w->rect.x + 1, mc_tty_frm[MC_TTY_FRM_HORIZ], w->rect.cols - 2);
+
+    tty_setcolor (CORE_NORMAL_COLOR);
+    widget_gotoyx (w, 0, (w->rect.cols - len - 2) / 2);
+    tty_printf (" %s ", title);
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/src/filemanager/layout.c
+++ b/src/filemanager/layout.c
@@ -237,7 +237,7 @@ update_split (const WDialog *h)
         check_options[0].widget->state = panels_layout.vertical_equal;
     widget_draw (WIDGET (check_options[0].widget));
 
-    tty_setcolor (check_options[0].widget->state ? DISABLED_COLOR : COLOR_NORMAL);
+    tty_setcolor (check_options[0].widget->state ? CORE_DISABLED_COLOR : DIALOG_NORMAL_COLOR);
 
     widget_gotoyx (h, 6, 5);
     if (panels_layout.horizontal_split)
@@ -326,7 +326,8 @@ layout_bg_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void 
         if (old_layout.output_lines != _output_lines)
         {
             old_layout.output_lines = _output_lines;
-            tty_setcolor (mc_global.tty.console_flag != '\0' ? COLOR_NORMAL : DISABLED_COLOR);
+            tty_setcolor (mc_global.tty.console_flag != '\0' ? DIALOG_NORMAL_COLOR
+                                                             : CORE_DISABLED_COLOR);
             widget_gotoyx (w, 9, 5);
             tty_print_string (output_lines_label);
             widget_gotoyx (w, 9, 5 + 3 + output_lines_label_len);
@@ -380,7 +381,8 @@ layout_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void *da
         if (old_layout.output_lines != _output_lines)
         {
             old_layout.output_lines = _output_lines;
-            tty_setcolor (mc_global.tty.console_flag != '\0' ? COLOR_NORMAL : DISABLED_COLOR);
+            tty_setcolor (mc_global.tty.console_flag != '\0' ? DIALOG_NORMAL_COLOR
+                                                             : CORE_DISABLED_COLOR);
             widget_gotoyx (h, 9, 5 + 3 + output_lines_label_len);
             tty_printf ("%02d", _output_lines);
         }
@@ -1042,7 +1044,7 @@ rotate_dash (gboolean show)
         return;
 
     widget_gotoyx (w, menubar_visible ? 1 : 0, w->rect.cols - 1);
-    tty_setcolor (NORMAL_COLOR);
+    tty_setcolor (CORE_NORMAL_COLOR);
 
     if (!show)
         tty_print_char (mc_tty_frm[MC_TTY_FRM_DRIGHTTOP]);

--- a/src/filemanager/panel.c
+++ b/src/filemanager/panel.c
@@ -277,7 +277,7 @@ set_colors (const WPanel *panel)
     (void) panel;
 
     tty_set_normal_attrs ();
-    tty_setcolor (NORMAL_COLOR);
+    tty_setcolor (CORE_NORMAL_COLOR);
 }
 
 /* --------------------------------------------------------------------------------------------- */
@@ -329,9 +329,9 @@ add_permission_string (const char *dest, int width, file_entry_t *fe, file_attr_
         if (i >= l && i < r)
         {
             if (attr == FATTR_CURRENT || attr == FATTR_MARKED_CURRENT)
-                tty_setcolor (MARKED_SELECTED_COLOR);
+                tty_setcolor (CORE_MARKED_SELECTED_COLOR);
             else
-                tty_setcolor (MARKED_COLOR);
+                tty_setcolor (CORE_MARKED_COLOR);
         }
         else if (color >= 0)
             tty_setcolor (color);
@@ -654,17 +654,17 @@ file_compute_color (const file_attr_t attr, file_entry_t *fe)
     switch (attr)
     {
     case FATTR_CURRENT:
-        return (SELECTED_COLOR);
+        return (CORE_SELECTED_COLOR);
     case FATTR_MARKED:
-        return (MARKED_COLOR);
+        return (CORE_MARKED_COLOR);
     case FATTR_MARKED_CURRENT:
-        return (MARKED_SELECTED_COLOR);
+        return (CORE_MARKED_SELECTED_COLOR);
     case FATTR_STATUS:
-        return (NORMAL_COLOR);
+        return (CORE_NORMAL_COLOR);
     case FATTR_NORMAL:
     default:
         if (!panels_options.filetype_mode)
-            return (NORMAL_COLOR);
+            return (CORE_NORMAL_COLOR);
     }
 
     return mc_fhl_get_color (mc_filehighlight, fe);
@@ -686,7 +686,7 @@ static filename_scroll_flag_t
 format_file (WPanel *panel, int file_index, int width, file_attr_t attr, gboolean isstatus,
              int *field_length)
 {
-    int color = NORMAL_COLOR;
+    int color = CORE_NORMAL_COLOR;
     int length = 0;
     GSList *format, *home;
     file_entry_t *fe = NULL;
@@ -772,9 +772,9 @@ format_file (WPanel *panel, int file_index, int width, file_attr_t attr, gboolea
         else
         {
             if (attr == FATTR_CURRENT || attr == FATTR_MARKED_CURRENT)
-                tty_setcolor (SELECTED_COLOR);
+                tty_setcolor (CORE_SELECTED_COLOR);
             else
-                tty_setcolor (NORMAL_COLOR);
+                tty_setcolor (CORE_NORMAL_COLOR);
             tty_print_one_vline (TRUE);
             length++;
         }
@@ -832,7 +832,7 @@ repaint_file (WPanel *panel, int file_index, file_attr_t attr)
 
     if (nth_column + 1 < panel->list_cols)
     {
-        tty_setcolor (NORMAL_COLOR);
+        tty_setcolor (CORE_NORMAL_COLOR);
         tty_print_one_vline (TRUE);
     }
 
@@ -849,13 +849,14 @@ repaint_file (WPanel *panel, int file_index, file_attr_t attr)
             }
         }
 
-        const int file_color =
-            attr == FATTR_CURRENT || attr == FATTR_MARKED_CURRENT ? SELECTED_COLOR : NORMAL_COLOR;
+        const int file_color = attr == FATTR_CURRENT || attr == FATTR_MARKED_CURRENT
+            ? CORE_SELECTED_COLOR
+            : CORE_NORMAL_COLOR;
 
         if ((ret_frm & FILENAME_SCROLL_LEFT) != 0)
         {
             const int scroll_left_char_color =
-                panel->list_format == list_long ? file_color : NORMAL_COLOR;
+                panel->list_format == list_long ? file_color : CORE_NORMAL_COLOR;
 
             widget_gotoyx (w, ypos, offset);
             tty_setcolor (scroll_left_char_color);
@@ -869,7 +870,7 @@ repaint_file (WPanel *panel, int file_index, file_attr_t attr)
             const int scroll_right_char_color =
                 panel->list_format != list_long && g_slist_length (panel->format) > 2
                 ? file_color
-                : NORMAL_COLOR;
+                : CORE_NORMAL_COLOR;
 
             widget_gotoyx (w, ypos, offset);
             tty_setcolor (scroll_right_char_color);
@@ -909,7 +910,7 @@ display_mini_info (WPanel *panel)
 
     if (panel->quick_search.active)
     {
-        tty_setcolor (INPUT_COLOR);
+        tty_setcolor (CORE_INPUT_COLOR);
         tty_print_char ('/');
         tty_print_string (
             str_fit_to_term (panel->quick_search.buffer->str, w->rect.cols - 3, J_LEFT));
@@ -1027,7 +1028,7 @@ display_total_marked_size (const WPanel *panel, int y, int x, gboolean size_only
      * y == w->lines - 1             for panel bottom frame
      */
     widget_gotoyx (w, y, x);
-    tty_setcolor (MARKED_COLOR);
+    tty_setcolor (CORE_MARKED_COLOR);
     tty_printf (" %s ", buf);
 }
 
@@ -1042,7 +1043,7 @@ mini_info_separator (const WPanel *panel)
 
         y = panel_lines (panel) + 2;
 
-        tty_setcolor (NORMAL_COLOR);
+        tty_setcolor (CORE_NORMAL_COLOR);
         /* Status displays total marked size.
          * Centered in panel, full format. */
         display_total_marked_size (panel, y, -1, FALSE);
@@ -1091,7 +1092,7 @@ show_free_space (const WPanel *panel)
                         ? 0
                         : (int) (100 * (long double) myfs_stats.avail / myfs_stats.total));
         widget_gotoyx (w, w->rect.lines - 1, w->rect.cols - 2 - (int) strlen (tmp));
-        tty_setcolor (NORMAL_COLOR);
+        tty_setcolor (CORE_NORMAL_COLOR);
         tty_print_string (tmp);
     }
 }
@@ -1269,7 +1270,7 @@ show_dir (const WPanel *panel)
     }
 
     if (panel->active)
-        tty_setcolor (REVERSE_COLOR);
+        tty_setcolor (CORE_REVERSE_COLOR);
 
     tmp = panel_correct_path_to_show (panel);
     tty_printf (" %s ", str_term_trim (tmp, MIN (MAX (w->rect.cols - 12, 0), w->rect.cols)));
@@ -1290,7 +1291,7 @@ show_dir (const WPanel *panel)
 
                 g_snprintf (buffer, sizeof (buffer), " %s ",
                             size_trunc_sep (fe->st.st_size, panels_options.kilobyte_si));
-                tty_setcolor (NORMAL_COLOR);
+                tty_setcolor (CORE_NORMAL_COLOR);
                 widget_gotoyx (w, w->rect.lines - 1, 4);
                 tty_print_string (buffer);
             }
@@ -1535,7 +1536,7 @@ panel_print_header (const WPanel *panel)
 
     widget_gotoyx (w, 1, 1);
     tty_getyx (&y, &x);
-    tty_setcolor (NORMAL_COLOR);
+    tty_setcolor (CORE_NORMAL_COLOR);
     tty_draw_hline (y, x, ' ', w->rect.cols - 2);
 
     format_txt = g_string_new ("");
@@ -1566,19 +1567,19 @@ panel_print_header (const WPanel *panel)
                     g_string_append (format_txt, "]");
                 }
 
-                tty_setcolor (HEADER_COLOR);
+                tty_setcolor (CORE_HEADER_COLOR);
                 tty_print_string (str_fit_to_term (format_txt->str, fi->field_len, J_CENTER_LEFT));
             }
             else
             {
-                tty_setcolor (NORMAL_COLOR);
+                tty_setcolor (CORE_NORMAL_COLOR);
                 tty_print_one_vline (TRUE);
             }
         }
 
         if (i < panel->list_cols - 1)
         {
-            tty_setcolor (NORMAL_COLOR);
+            tty_setcolor (CORE_NORMAL_COLOR);
             tty_print_one_vline (TRUE);
         }
     }

--- a/src/filemanager/panel.c
+++ b/src/filemanager/panel.c
@@ -774,7 +774,7 @@ format_file (WPanel *panel, int file_index, int width, file_attr_t attr, gboolea
             if (attr == FATTR_CURRENT || attr == FATTR_MARKED_CURRENT)
                 tty_setcolor (CORE_SELECTED_COLOR);
             else
-                tty_setcolor (CORE_NORMAL_COLOR);
+                tty_setcolor (CORE_FRAME_COLOR);
             tty_print_one_vline (TRUE);
             length++;
         }
@@ -832,7 +832,7 @@ repaint_file (WPanel *panel, int file_index, file_attr_t attr)
 
     if (nth_column + 1 < panel->list_cols)
     {
-        tty_setcolor (CORE_NORMAL_COLOR);
+        tty_setcolor (CORE_FRAME_COLOR);
         tty_print_one_vline (TRUE);
     }
 
@@ -1204,7 +1204,8 @@ show_dir (const WPanel *panel)
     int col, i;
 
     // paint the basic frame
-    set_colors (panel);
+    tty_set_normal_attrs ();
+    tty_setcolor (CORE_FRAME_COLOR);
     tty_draw_box (w->rect.y, w->rect.x, w->rect.lines, w->rect.cols, FALSE);
 
     // paint the mini info's separator line
@@ -1254,6 +1255,7 @@ show_dir (const WPanel *panel)
 
     g_free (tmp);
 
+    tty_setcolor (CORE_NORMAL_COLOR);
     widget_gotoyx (w, 0, 3);
 
     if (panel->is_panelized)
@@ -1572,14 +1574,14 @@ panel_print_header (const WPanel *panel)
             }
             else
             {
-                tty_setcolor (CORE_NORMAL_COLOR);
+                tty_setcolor (CORE_FRAME_COLOR);
                 tty_print_one_vline (TRUE);
             }
         }
 
         if (i < panel->list_cols - 1)
         {
-            tty_setcolor (CORE_NORMAL_COLOR);
+            tty_setcolor (CORE_FRAME_COLOR);
             tty_print_one_vline (TRUE);
         }
     }

--- a/src/filemanager/panelize.c
+++ b/src/filemanager/panelize.c
@@ -444,7 +444,7 @@ external_panelize_cmd (void)
     external_panelize_init ();
 
     // display file info
-    tty_setcolor (SELECTED_COLOR);
+    tty_setcolor (CORE_SELECTED_COLOR);
 
     switch (dlg_run (panelize_dlg))
     {

--- a/src/filemanager/tree.c
+++ b/src/filemanager/tree.c
@@ -1118,10 +1118,8 @@ tree_frame (WDialog *h, WTree *tree)
         const char *title = _ ("Directory tree");
         const int len = str_term_width1 (title);
 
+        tty_setcolor (CORE_FRAME_COLOR);
         tty_draw_box (w->rect.y, w->rect.x, w->rect.lines, w->rect.cols, FALSE);
-
-        widget_gotoyx (w, 0, (w->rect.cols - len - 2) / 2);
-        tty_printf (" %s ", title);
 
         if (panels_options.show_mini_info)
         {
@@ -1135,6 +1133,10 @@ tree_frame (WDialog *h, WTree *tree)
             tty_draw_hline (w->rect.y + y, w->rect.x + 1, mc_tty_frm[MC_TTY_FRM_HORIZ],
                             w->rect.cols - 2);
         }
+
+        tty_setcolor (CORE_NORMAL_COLOR);
+        widget_gotoyx (w, 0, (w->rect.cols - len - 2) / 2);
+        tty_printf (" %s ", title);
     }
 }
 

--- a/src/filemanager/tree.c
+++ b/src/filemanager/tree.c
@@ -239,7 +239,7 @@ tree_show_mini_info (WTree *tree, int tree_lines, int tree_cols)
     if (tree->searching)
     {
         // Show search string
-        tty_setcolor (INPUT_COLOR);
+        tty_setcolor (CORE_INPUT_COLOR);
         tty_draw_hline (w->rect.y + line, w->rect.x + 1, ' ', tree_cols);
         widget_gotoyx (w, line, 1);
         tty_print_char (PATH_SEP);
@@ -253,7 +253,7 @@ tree_show_mini_info (WTree *tree, int tree_lines, int tree_cols)
         const int *colors;
 
         colors = widget_get_colors (w);
-        tty_setcolor (tree->is_panel ? NORMAL_COLOR : colors[DLG_COLOR_NORMAL]);
+        tty_setcolor (tree->is_panel ? CORE_NORMAL_COLOR : colors[DLG_COLOR_NORMAL]);
         tty_draw_hline (w->rect.y + line, w->rect.x + 1, ' ', tree_cols);
         widget_gotoyx (w, line, 1);
         tty_print_string (
@@ -339,7 +339,7 @@ show_tree (WTree *tree)
         const int *colors;
 
         colors = widget_get_colors (w);
-        tty_setcolor (tree->is_panel ? NORMAL_COLOR : colors[DLG_COLOR_NORMAL]);
+        tty_setcolor (tree->is_panel ? CORE_NORMAL_COLOR : colors[DLG_COLOR_NORMAL]);
 
         // Move to the beginning of the line
         tty_draw_hline (w->rect.y + y + i, w->rect.x + x, ' ', tree_cols);
@@ -352,7 +352,7 @@ show_tree (WTree *tree)
             gboolean selected;
 
             selected = widget_get_state (w, WST_FOCUSED) && current == tree->selected_ptr;
-            tty_setcolor (selected ? SELECTED_COLOR : NORMAL_COLOR);
+            tty_setcolor (selected ? CORE_SELECTED_COLOR : CORE_NORMAL_COLOR);
         }
         else
         {
@@ -1111,7 +1111,7 @@ tree_frame (WDialog *h, WTree *tree)
 
     (void) h;
 
-    tty_setcolor (NORMAL_COLOR);
+    tty_setcolor (CORE_NORMAL_COLOR);
     widget_erase (w);
     if (tree->is_panel)
     {

--- a/src/viewer/ascii.c
+++ b/src/viewer/ascii.c
@@ -360,7 +360,7 @@ mcview_get_next_maybe_nroff_char (WView *view, mcview_state_machine_t *state, in
     int c2, c3;
 
     if (color != NULL)
-        *color = VIEW_NORMAL_COLOR;
+        *color = VIEWER_NORMAL_COLOR;
 
     if (!view->mode_flags.nroff)
         return mcview_get_next_char (view, state, c);
@@ -388,14 +388,14 @@ mcview_get_next_maybe_nroff_char (WView *view, mcview_state_machine_t *state, in
         *state = state_after_nroff;
         if (color != NULL)
             *color =
-                state->nroff_underscore_is_underlined ? VIEW_UNDERLINED_COLOR : VIEW_BOLD_COLOR;
+                state->nroff_underscore_is_underlined ? VIEWER_UNDERLINED_COLOR : VIEWER_BOLD_COLOR;
     }
     else if (*c == c3)
     {
         *state = state_after_nroff;
         state->nroff_underscore_is_underlined = FALSE;
         if (color != NULL)
-            *color = VIEW_BOLD_COLOR;
+            *color = VIEWER_BOLD_COLOR;
     }
     else if (*c == '_')
     {
@@ -403,7 +403,7 @@ mcview_get_next_maybe_nroff_char (WView *view, mcview_state_machine_t *state, in
         *state = state_after_nroff;
         state->nroff_underscore_is_underlined = TRUE;
         if (color != NULL)
-            *color = VIEW_UNDERLINED_COLOR;
+            *color = VIEWER_UNDERLINED_COLOR;
     }
 
     return TRUE;
@@ -580,7 +580,7 @@ mcview_display_line (WView *view, mcview_state_machine_t *state, int row, gboole
         }
 
         if (view->search_start <= state->offset && state->offset < view->search_end)
-            color = VIEW_SELECTED_COLOR;
+            color = VIEWER_SELECTED_COLOR;
 
         if (cs[0] == '\n')
         {
@@ -857,7 +857,7 @@ mcview_display_text (WView *view)
     view->dpy_end = state.offset;
     view->dpy_state_bottom = state;
 
-    tty_setcolor (VIEW_NORMAL_COLOR);
+    tty_setcolor (VIEWER_NORMAL_COLOR);
     if (mcview_show_eof != NULL && mcview_show_eof[0] != '\0')
         while (row < r->lines)
         {

--- a/src/viewer/display.c
+++ b/src/viewer/display.c
@@ -340,7 +340,7 @@ mcview_display_clean (WView *view)
 {
     Widget *w = WIDGET (view);
 
-    tty_setcolor (VIEW_NORMAL_COLOR);
+    tty_setcolor (VIEWER_NORMAL_COLOR);
     widget_erase (w);
     if (view->dpy_frame_size != 0)
         tty_draw_box (w->rect.y, w->rect.x, w->rect.lines, w->rect.cols, FALSE);
@@ -363,7 +363,7 @@ mcview_display_ruler (WView *view)
     if (ruler == RULER_NONE || r->lines < 1)
         return;
 
-    tty_setcolor (VIEW_BOLD_COLOR);
+    tty_setcolor (VIEWER_BOLD_COLOR);
     for (c = 0; c < r->cols; c++)
     {
         cl = view->dpy_text_column + c;
@@ -383,7 +383,7 @@ mcview_display_ruler (WView *view)
             }
         }
     }
-    tty_setcolor (VIEW_NORMAL_COLOR);
+    tty_setcolor (VIEWER_NORMAL_COLOR);
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/src/viewer/display.c
+++ b/src/viewer/display.c
@@ -342,6 +342,7 @@ mcview_display_clean (WView *view)
 
     tty_setcolor (VIEWER_NORMAL_COLOR);
     widget_erase (w);
+    tty_setcolor (VIEWER_FRAME_COLOR);
     if (view->dpy_frame_size != 0)
         tty_draw_box (w->rect.y, w->rect.x, w->rect.lines, w->rect.cols, FALSE);
 }

--- a/src/viewer/hex.c
+++ b/src/viewer/hex.c
@@ -297,7 +297,9 @@ mcview_display_hex (WView *view)
                 {
                     if (view->data_area.cols >= 80 && col < r->cols)
                     {
+                        tty_setcolor (VIEWER_FRAME_COLOR);
                         tty_print_one_vline (TRUE);
+                        tty_setcolor (VIEWER_NORMAL_COLOR);
                         col++;
                     }
                     if (col < r->cols)

--- a/src/viewer/hex.c
+++ b/src/viewer/hex.c
@@ -157,10 +157,10 @@ mcview_display_hex (WView *view)
 
             g_snprintf (hex_buff, sizeof (hex_buff), "%08" PRIXMAX " ", (uintmax_t) from);
             widget_gotoyx (view, r->y + row, r->x);
-            tty_setcolor (VIEW_BOLD_COLOR);
+            tty_setcolor (VIEWER_BOLD_COLOR);
             for (i = 0; col < r->cols && hex_buff[i] != '\0'; col++, i++)
                 tty_print_char (hex_buff[i]);
-            tty_setcolor (VIEW_NORMAL_COLOR);
+            tty_setcolor (VIEWER_NORMAL_COLOR);
         }
 
         for (bytes = 0; bytes < view->bytes_per_line; bytes++, from++)
@@ -261,13 +261,13 @@ mcview_display_hex (WView *view)
             }
 
             // Select the color for the hex number
-            tty_setcolor (boldflag_byte == MARK_NORMAL         ? VIEW_NORMAL_COLOR
-                              : boldflag_byte == MARK_SELECTED ? VIEW_BOLD_COLOR
-                              : boldflag_byte == MARK_CHANGED  ? VIEW_UNDERLINED_COLOR
+            tty_setcolor (boldflag_byte == MARK_NORMAL         ? VIEWER_NORMAL_COLOR
+                              : boldflag_byte == MARK_SELECTED ? VIEWER_BOLD_COLOR
+                              : boldflag_byte == MARK_CHANGED  ? VIEWER_UNDERLINED_COLOR
                                                                :
                                                               // boldflag_byte == MARK_CURSOR
-                              view->hexview_in_text ? VIEW_SELECTED_COLOR
-                                                    : VIEW_UNDERLINED_COLOR);
+                              view->hexview_in_text ? VIEWER_SELECTED_COLOR
+                                                    : VIEWER_UNDERLINED_COLOR);
 
             // Print the hex number
             widget_gotoyx (view, r->y + row, r->x + col);
@@ -283,7 +283,7 @@ mcview_display_hex (WView *view)
             }
 
             // Print the separator
-            tty_setcolor (VIEW_NORMAL_COLOR);
+            tty_setcolor (VIEWER_NORMAL_COLOR);
             if (bytes != view->bytes_per_line - 1)
             {
                 if (col < r->cols)
@@ -310,13 +310,13 @@ mcview_display_hex (WView *view)
 
             /* Select the color for the character; this differs from the
              * hex color when boldflag == MARK_CURSOR */
-            tty_setcolor (boldflag_char == MARK_NORMAL         ? VIEW_NORMAL_COLOR
-                              : boldflag_char == MARK_SELECTED ? VIEW_BOLD_COLOR
-                              : boldflag_char == MARK_CHANGED  ? VIEW_UNDERLINED_COLOR
+            tty_setcolor (boldflag_char == MARK_NORMAL         ? VIEWER_NORMAL_COLOR
+                              : boldflag_char == MARK_SELECTED ? VIEWER_BOLD_COLOR
+                              : boldflag_char == MARK_CHANGED  ? VIEWER_UNDERLINED_COLOR
                                                                :
                                                               // boldflag_char == MARK_CURSOR
-                              view->hexview_in_text ? VIEW_SELECTED_COLOR
-                                                    : MARKED_SELECTED_COLOR);
+                              view->hexview_in_text ? VIEWER_SELECTED_COLOR
+                                                    : CORE_MARKED_SELECTED_COLOR);
 
             if (mc_global.utf8_display)
             {
@@ -355,7 +355,7 @@ mcview_display_hex (WView *view)
     }
 
     // Be polite to the other functions
-    tty_setcolor (VIEW_NORMAL_COLOR);
+    tty_setcolor (VIEWER_NORMAL_COLOR);
 
     mcview_place_cursor (view);
     view->dpy_end = from;


### PR DESCRIPTION
## Proposed changes

- Use more consistent internal constant names for colors
- New skin colors for frames
- sand256 skin: Use non-italic frame characters

* Resolves: #4931

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
