### PR TITLE
4625 slow zsh macos

### DIFF
--- a/src/subshell/common.c
+++ b/src/subshell/common.c
@@ -1236,9 +1236,17 @@ pty_open_slave (const char *pty_name)
 /**
  * Set up `precmd' or equivalent for reading the subshell's CWD.
  *
- * Attention! Never forget that these are *one-liners* even though the concatenated
- * substrings contain line breaks and indentation for better understanding of the
- * shell code. It is vital that each one-liner ends with a line feed character ("\n" ).
+ * Attention!
+ *
+ * Physical lines sent to the shell must not be longer than 256 characters, because above that size
+ * on some platforms the kernel's tty driver in cooked mode begins to lose characters (#4480).
+ *
+ * However, it's preferable to send one logical line to the shell, to prevent the pre-prompt
+ * function from getting executed and the prompt from getting printed multiple times. Especially
+ * executing mc's pre-prompt handler with its kill command multiple times can confuse mc.
+ *
+ * Therefore it's recommended to end lines in a physical newline, but include a logical line
+ * continuation, i.e. "\\\n" or "; \\\n" as appropriate.
  *
  * Also note that some shells support not remembering commands beginning with a space in their
  * history (HISTCONTROL=ignorespace or equivalent). Let's have leading spaces consistently
@@ -1266,11 +1274,11 @@ init_subshell_precmd (void)
      * A hop via $MC_PRECMD works because in the sub-subshell MC_PRECMD is undefined (assuming the
      * user did not export this one), thus evaluated to empty string - no damage done.
      */
-    static const char *precmd_fallback = " mc_precmd() {"
-                                         "   pwd >&%d;"
-                                         "   kill -STOP $$;"
-                                         " };"
-                                         " MC_PRECMD=mc_precmd;"
+    static const char *precmd_fallback = " mc_precmd() { \\\n"
+                                         "   pwd >&%d; \\\n"
+                                         "   kill -STOP $$; \\\n"
+                                         " }; \\\n"
+                                         " MC_PRECMD=mc_precmd; \\\n"
                                          " PS1='$($MC_PRECMD)'\"$PS1\"\n";
 
     switch (mc_global.shell->type)
@@ -1281,10 +1289,10 @@ init_subshell_precmd (void)
             "\"$READLINE_POINT\" \"$READLINE_LINE\" >&%d; }\n"
             " bind -x '\"\\e" SHELL_BUFFER_KEYBINDING "\":\"mc_print_command_buffer\"'\n"
             " if test $BASH_VERSINFO -ge 5 && [[ ${PROMPT_COMMAND@a} == *a* ]] 2> "
-            "/dev/null; then\n"
-            "   PROMPT_COMMAND+=( 'pwd >&%d; kill -STOP $$' )\n"
-            " else\n"
-            "   PROMPT_COMMAND=${PROMPT_COMMAND:+$PROMPT_COMMAND\n}'pwd >&%d; kill -STOP $$'\n"
+            "/dev/null; then \\\n"
+            "   PROMPT_COMMAND+=( 'pwd >&%d; kill -STOP $$' ); \\\n"
+            " else \\\n"
+            "   PROMPT_COMMAND=${PROMPT_COMMAND:+$PROMPT_COMMAND\n}'pwd >&%d; kill -STOP $$'; \\\n"
             " fi\n",
             command_buffer_pipe[WRITE], subshell_pipe[WRITE], subshell_pipe[WRITE]);
 
@@ -1305,10 +1313,10 @@ init_subshell_precmd (void)
     case SHELL_ZSH:
         return g_strdup_printf (
             " mc_print_command_buffer () { printf '%%s\\n%%s\\000' \"$CURSOR\" \"$BUFFER\" "
-            ">&%d; }\n"
-            " zle -N mc_print_command_buffer\n"
-            " bindkey '^[" SHELL_BUFFER_KEYBINDING "' mc_print_command_buffer\n"
-            " _mc_precmd() { pwd>&%d; kill -STOP $$; }\n"
+            ">&%d; }; \\\n"
+            " zle -N mc_print_command_buffer; \\\n"
+            " bindkey '^[" SHELL_BUFFER_KEYBINDING "' mc_print_command_buffer; \\\n"
+            " _mc_precmd() { pwd >&%d; kill -STOP $$; }; \\\n"
             " precmd_functions+=(_mc_precmd)\n",
             command_buffer_pipe[WRITE], subshell_pipe[WRITE]);
 
@@ -1319,16 +1327,17 @@ init_subshell_precmd (void)
                                 tcsh_fifo);
 
     case SHELL_FISH:
-        return g_strdup_printf (" bind \\e" SHELL_BUFFER_KEYBINDING
-                                " \"begin; commandline -C; commandline; printf '\\000'; end >&%d\";"
-                                " if not functions -q fish_prompt_mc;"
-                                " functions -e fish_right_prompt;"
-                                " functions -c fish_prompt fish_prompt_mc;"
-                                " end;"
-                                " function fish_prompt;"
-                                " echo \"$PWD\" >&%d; kill -STOP $fish_pid; fish_prompt_mc;"
-                                " end\n",
-                                command_buffer_pipe[WRITE], subshell_pipe[WRITE]);
+        return g_strdup_printf (
+            " bind \\e" SHELL_BUFFER_KEYBINDING
+            " \"begin; commandline -C; commandline; printf '\\000'; end >&%d\"; \\\n"
+            " if not functions -q fish_prompt_mc; \\\n"
+            " functions -e fish_right_prompt; \\\n"
+            " functions -c fish_prompt fish_prompt_mc; \\\n"
+            " end; \\\n"
+            " function fish_prompt; \\\n"
+            " echo \"$PWD\" >&%d; kill -STOP $fish_pid; fish_prompt_mc; \\\n"
+            " end\n",
+            command_buffer_pipe[WRITE], subshell_pipe[WRITE]);
     default:
         fprintf (stderr, "subshell: unknown shell type (%u), aborting!\r\n", mc_global.shell->type);
         exit (EXIT_FAILURE);

--- a/src/subshell/common.c
+++ b/src/subshell/common.c
@@ -227,6 +227,10 @@ static struct termios shell_mode;
 /* are delivered to the shell pty */
 static struct termios raw_mode;
 
+/* If the subshell is not yet initialized then we might be sending our initialization code.
+ * During this initialization don't flush the tty line and don't send the interrupt character. */
+static gboolean subshell_initialized = FALSE;
+
 /* --------------------------------------------------------------------------------------------- */
 /*** file scope functions ************************************************************************/
 /* --------------------------------------------------------------------------------------------- */
@@ -573,7 +577,7 @@ synchronize (void)
         pselect (0, NULL, NULL, NULL, NULL, &old_mask);
     }
 
-    if (subshell_state != ACTIVE)
+    if (subshell_state != ACTIVE && subshell_initialized)
     {
         // Discard all remaining data from stdin to the subshell
         tcflush (subshell_pty_slave, TCIFLUSH);
@@ -1020,7 +1024,7 @@ feed_subshell (int how, gboolean fail_on_error)
                         if (subshell_ready && !read_command_line_buffer (FALSE))
                         {
                             // If we got here, some unforeseen error must have occurred.
-                            if (mc_global.shell->type != SHELL_FISH)
+                            if (subshell_initialized && mc_global.shell->type != SHELL_FISH)
                             {
                                 write_all (mc_global.tty.subshell_pty, "\003", 1);
                                 subshell_state = RUNNING_COMMAND;
@@ -1536,7 +1540,7 @@ do_subshell_chdir (const vfs_path_t *vpath, gboolean force, gboolean update_prom
 
     /* If we are using a shell that doesn't support persistent command buffer, we need to clear
      * the command prompt before we send the cd command. */
-    if (!use_persistent_buffer)
+    if (!use_persistent_buffer && subshell_initialized)
     {
         write_all (mc_global.tty.subshell_pty, "\003", 1);
         subshell_state = RUNNING_COMMAND;
@@ -1805,6 +1809,8 @@ init_subshell (void)
     vfs_subshell_cwd = vfs_path_from_str (subshell_cwd);
     do_subshell_chdir (vfs_subshell_cwd, TRUE, FALSE);
     vfs_path_free (vfs_subshell_cwd, TRUE);
+
+    subshell_initialized = TRUE;
 }
 
 /* --------------------------------------------------------------------------------------------- */
@@ -1863,7 +1869,7 @@ invoke_subshell (const char *command, int how, vfs_path_t **new_dir_vpath)
         {
             /* We don't need to call feed_subshell here if we are using fish, because of a
              * quirk in the behavior of that particular shell. */
-            if (mc_global.shell->type != SHELL_FISH)
+            if (subshell_initialized && mc_global.shell->type != SHELL_FISH)
             {
                 write_all (mc_global.tty.subshell_pty, "\003", 1);
                 subshell_state = RUNNING_COMMAND;

--- a/src/subshell/proxyfunc.c
+++ b/src/subshell/proxyfunc.c
@@ -60,7 +60,8 @@
 const vfs_path_t *
 subshell_get_cwd (void)
 {
-    if (mc_global.mc_run_mode == MC_RUN_FULL)
+    // Note: current_panel is NULL during subshell startup
+    if (mc_global.mc_run_mode == MC_RUN_FULL && current_panel != NULL)
         return current_panel->cwd_vpath;
 
     return vfs_get_raw_current_dir ();


### PR DESCRIPTION
## Proposed changes

Fix slow startup on macOS with zsh, and other related problems also affecting other platforms and shells.

* Resolves: #4625
* Resolves: #4780
* Resolves: #4548
* Resolves: #4723

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)

---

This is a reincarnation of closed PR #4784. The patches are essentially unchanged (rebased and a few minor feedback addressed).

I really wanted to address #4253 / #4789 first, i.e. to inject our commands via shell startup files rather than "typing" them to those shells; and rebase this work on top of that. However, as discussed in 4789, I failed to figure out how to do this in `zsh`, it looks like it's not possible. This made me lose motivation and I've abandoned that work, at least for now.

The work in this PR is quite hackish, but so is the problem we're trying to deal with, and the current quite complex codebase. And, unfortunately, I still can't claim I perfectly understand everything, including the suspicious 2 or 3 different ways of handling of sending the Ctrl-C char. It's surely nowhere near the cleanest of my works I've ever made, but honestly I got tired of not seeing a clear solution. It's just not the kind of area I'm comfortable with.

So, IMO, let's land this -- along with remotely related pending PR #4804 --, both have already gotten approval a long time ago but then still the discussion and possible improvements went on. I'm afraid this very PR is not really going to get substantially better, and lack of progress for more than a month clearly shows that I've lost motivation. I suggest that we land these two after a last round of review, and then later (also depending on possible user feedback) iterate further.
