### PR TITLE
Ticket #1808: replace `hiddenfiles-show-char` in featured skins with middot

### DIFF
--- a/misc/skins/featured-plus.ini
+++ b/misc/skins/featured-plus.ini
@@ -143,7 +143,7 @@
 [widget-panel]
     sort-up-char = ↑
     sort-down-char = ↓
-    hiddenfiles-show-char = ⋅
+    hiddenfiles-show-char = ·
     hiddenfiles-hide-char = •
     history-prev-item-char = «
     history-next-item-char = »

--- a/misc/skins/featured.ini
+++ b/misc/skins/featured.ini
@@ -143,7 +143,7 @@
 [widget-panel]
     sort-up-char = ↑
     sort-down-char = ↓
-    hiddenfiles-show-char = ⋅
+    hiddenfiles-show-char = ·
     hiddenfiles-hide-char = •
     history-prev-item-char = «
     history-next-item-char = »


### PR DESCRIPTION
The center dot (U+22C5) seems to be missing from quite some fonts, including Courier New till this day. The much more common middot (U+00B7) looks almost the same and is supported by virtually any font.

## Proposed changes

* Resolves: #1808
