### PR TITLE
Ticket #4952: skin selector: Filter out skin files not ending in ".ini"

### DIFF
--- a/lib/skin/ini-file.c
+++ b/lib/skin/ini-file.c
@@ -69,10 +69,12 @@ mc_skin_get_list_from_dir (const gchar *base_dir, GPtrArray *list)
             unsigned int i;
 
             slen = strlen (cname);
-            sname = g_strndup (cname, slen);
 
-            if (slen > 4 && strcmp (sname + slen - 4, ".ini") == 0)
-                sname[slen - 4] = '\0';
+            if (slen <= 4 || strcmp (cname + slen - 4, ".ini") != 0)
+                continue;
+
+            sname = g_strndup (cname, slen);
+            sname[slen - 4] = '\0';
 
             for (i = 0; i < list->len; i++)
                 if (strcmp (sname, g_ptr_array_index (list, i)) == 0)


### PR DESCRIPTION
## Proposed changes

skin selector: Filter out skin files not ending in ".ini"

* Resolves: #4952

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
