### PR TITLE
Ticket #4959: editor: Use skin's double frame char for subwindow's corner

### DIFF
--- a/src/editor/editdraw.c
+++ b/src/editor/editdraw.c
@@ -343,7 +343,7 @@ edit_draw_frame (const WEdit *edit, int color, gboolean active)
     {
         tty_setcolor (EDITOR_FRAME_DRAG_COLOR);
         widget_gotoyx (w, w->rect.lines - 1, w->rect.cols - 1);
-        tty_print_char (mc_tty_frm[MC_TTY_FRM_RIGHTBOTTOM]);
+        tty_print_char (mc_tty_frm[MC_TTY_FRM_DRIGHTBOTTOM]);
     }
 }
 


### PR DESCRIPTION
## Proposed changes

editor: Use skin's double frame char for subwindow's corner

* Resolves: #4959

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
