### PR TITLE
Ticket #4961: Revert the look of the "seasons" skins

### DIFF
--- a/misc/skins/seasons-autumn16M.ini
+++ b/misc/skins/seasons-autumn16M.ini
@@ -34,8 +34,6 @@
     MainFg = #ffa
     MarkedFg = #ff5
     HeaderFg = MarkedFg
-    DirectoryFg = #ffc
-    SelectedFg = DirectoryFg
     Selected = #681400
     Dialog = #85a918
     DialogFocus = #69880c
@@ -73,7 +71,7 @@
 
 [core]
     _default_ = MainFg;Main
-    selected = SelectedFg;Selected
+    selected = ;Selected
     marked = MarkedFg;;bold
     markselect = MarkedFg;Selected;bold
     gauge = ;DialogFocus
@@ -106,7 +104,7 @@
     errdframe = #fff;Error
 
 [filehighlight]
-    directory = DirectoryFg
+    directory =
     executable = #84ea84
     symlink = #ff58fd
     hardlink =

--- a/misc/skins/seasons-spring16M.ini
+++ b/misc/skins/seasons-spring16M.ini
@@ -31,11 +31,9 @@
 
 [aliases]
     Main = #f3ffe7
-    MainFg = #303030
+    MainFg = #000
     MarkedFg = #d14576
     HeaderFg = MarkedFg
-    DirectoryFg = #000
-    SelectedFg = DirectoryFg
     Selected = #d5f1b7
     Dialog = Selected
     DialogFocus = #b3de85
@@ -73,7 +71,7 @@
 
 [core]
     _default_ = MainFg;Main
-    selected = SelectedFg;Selected
+    selected = ;Selected
     marked = MarkedFg;;bold
     markselect = MarkedFg;Selected;bold
     gauge = ;DialogFocus
@@ -106,7 +104,7 @@
     errdframe = #fff;Error
 
 [filehighlight]
-    directory = DirectoryFg
+    directory =
     executable = #00af00
     symlink = #870087
     hardlink =

--- a/misc/skins/seasons-summer16M.ini
+++ b/misc/skins/seasons-summer16M.ini
@@ -31,11 +31,9 @@
 
 [aliases]
     Main = #ffedb3
-    MainFg = #303030
+    MainFg = #000
     MarkedFg = #e311aa
     HeaderFg = MarkedFg
-    DirectoryFg = #000
-    SelectedFg = DirectoryFg
     Selected = #d9b64a
     Dialog = #a7f25a
     DialogFocus = #f864f6
@@ -73,7 +71,7 @@
 
 [core]
     _default_ = MainFg;Main
-    selected = SelectedFg;Selected
+    selected = ;Selected
     marked = MarkedFg;;bold
     markselect = MarkedFg;Selected;bold
     gauge = ;DialogFocus
@@ -106,7 +104,7 @@
     errdframe = #fff;Error
 
 [filehighlight]
-    directory = DirectoryFg
+    directory =
     executable = #00af00
     symlink = #870087
     hardlink =

--- a/misc/skins/seasons-winter16M.ini
+++ b/misc/skins/seasons-winter16M.ini
@@ -31,11 +31,9 @@
 
 [aliases]
     Main = #e4e3ed
-    MainFg = #303030
+    MainFg = #000
     MarkedFg = #3064a9
     HeaderFg = MarkedFg
-    DirectoryFg = #000
-    SelectedFg = DirectoryFg
     Selected = #cbd1e1
     Dialog = Selected
     DialogFocus = #afbad8
@@ -73,7 +71,7 @@
 
 [core]
     _default_ = MainFg;Main
-    selected = SelectedFg;Selected
+    selected = ;Selected
     marked = MarkedFg;;bold
     markselect = MarkedFg;Selected;bold
     gauge = ;DialogFocus
@@ -106,7 +104,7 @@
     errdframe = #fff;Error
 
 [filehighlight]
-    directory = DirectoryFg
+    directory =
     executable = #00af00
     symlink = #870087
     hardlink =


### PR DESCRIPTION
Revert "misc/skins: Differentiate directories and files in true color skins"

This reverts commit b524cc367094580bfc80e493d6dd553f0f23b371.

## Proposed changes

* Resolves: #4961

## Checklist

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
