### PR TITLE
Ticket #4963: Use OSC 8 hyperlinks in manual pages

### DIFF
--- a/doc/man/es/mc.1.in
+++ b/doc/man/es/mc.1.in
@@ -4141,7 +4141,7 @@ carencia de garantía.
 .\"NODE "AVAILABILITY"
 .SH "DISPONIBILIDAD"
 La última versión de este programa se puede encontrar en
-https://ftp.osuosl.org/pub/midnightcommander/ .
+\X'tty: link https://ftp.osuosl.org/pub/midnightcommander/'https://ftp.osuosl.org/pub/midnightcommander/\X'tty: link' .
 .\"NODE "SEE ALSO"
 .SH "VÉASE TAMBIÉN"
 mcedit(1), sh(1), bash(1), tcsh(1), zsh(1), ed(1), view(1),
@@ -4149,7 +4149,7 @@ terminfo(1), gpm(1).
 .PP
 .nf
 La página web de Midnight Commander está en:
-	https://midnight\-commander.org
+	\X'tty: link https://midnight\-commander.org'https://midnight\-commander.org\X'tty: link'
 .fi
 .PP
 La presente documentación recoge información relativa a la versión 4.8
@@ -4169,8 +4169,8 @@ distribución.
 .SH "ERRORES"
 Véase el archivo "TODO" en la distribución para saber qué falta por hacer.
 .PP
-Para informar de problemas con el programa, introducir una nueva incidencia
-en https://github.com/MidnightCommander/mc/issues .
+Para informar de problemas con el programa, introducir una nueva incidencia en
+\X'tty: link https://github.com/MidnightCommander/mc/issues'https://github.com/MidnightCommander/mc/issues\X'tty: link' .
 .PP
 Se debe proporcionar una descripción detallada del problema, la
 versión del programa (que se obtiene con

--- a/doc/man/hu/mc.1.in
+++ b/doc/man/hu/mc.1.in
@@ -3156,7 +3156,7 @@ zsh(1).
 .nf
 A Midnight Commander World Wide Web oldalának címe a
 következő:
-	https://midnight\-commander.org
+	\X'tty: link https://midnight\-commander.org'https://midnight\-commander.org\X'tty: link'
 .fi
 .\"NODE "AUTHORS"
 .SH "Szerzők"

--- a/doc/man/it/mc.1.in
+++ b/doc/man/it/mc.1.in
@@ -3144,7 +3144,7 @@ per i dettagli sulla licenza e sulla mancanza di garanzie.
 .\"NODE "AVAILABILITY"
 .SH "REPERIBILITA'"
 L'ultima versione di questo programma si trova su
-https://ftp.osuosl.org/pub/midnightcommander/ .
+\X'tty: link https://ftp.osuosl.org/pub/midnightcommander/'https://ftp.osuosl.org/pub/midnightcommander/\X'tty: link' .
 .\"NODE "SEE ALSO"
 .SH "VEDERE ANCHE"
 ed(1), gpm(1), terminfo(1), view(1), sh(1), bash(1),
@@ -3152,7 +3152,7 @@ tcsh(1), zsh(1).
 .PP
 .nf
 La pagina Web del Midnight Commander:
-	https://midnight\-commander.org
+	\X'tty: link https://midnight\-commander.org'https://midnight\-commander.org\X'tty: link'
 .fi
 .\"NODE "AUTHORS"
 .SH "AUTORI"

--- a/doc/man/mc.1.in
+++ b/doc/man/mc.1.in
@@ -4068,7 +4068,7 @@ help for details on the License and the lack of warranty.
 .\"NODE "AVAILABILITY"
 .SH "AVAILABILITY"
 The latest version of this program can be found at
-https://ftp.osuosl.org/pub/midnightcommander/ .
+\X'tty: link https://ftp.osuosl.org/pub/midnightcommander/'https://ftp.osuosl.org/pub/midnightcommander/\X'tty: link' .
 .\"NODE "SEE ALSO"
 .SH "SEE ALSO"
 ed(1), gpm(1), terminfo(1), view(1), sh(1), bash(1),
@@ -4076,7 +4076,7 @@ tcsh(1), zsh(1).
 .PP
 .nf
 Midnight Commander's page on the World Wide Web:
-	https://midnight\-commander.org
+	\X'tty: link https://midnight\-commander.org'https://midnight\-commander.org\X'tty: link'
 .fi
 .\"NODE "AUTHORS"
 .SH "AUTHORS"
@@ -4087,8 +4087,8 @@ distribution.
 See the file TODO in the distribution for information on what remains to
 be done.
 .PP
-If you want to report a problem with the program, please create bugreport
-at https://github.com/MidnightCommander/mc/issues .
+If you want to report a problem with the program, please create bugreport at
+\X'tty: link https://github.com/MidnightCommander/mc/issues'https://github.com/MidnightCommander/mc/issues\X'tty: link' .
 .PP
 Provide a detailed description of the bug, the version of the program
 you are running

--- a/doc/man/mcdiff.1.in
+++ b/doc/man/mcdiff.1.in
@@ -89,9 +89,10 @@ help of the Midnight Commander for details on the License and the lack
 of warranty.
 .SH AVAILABILITY
 The latest version of this program can be found at
-https://ftp.osuosl.org/pub/midnightcommander/ .
+\X'tty: link https://ftp.osuosl.org/pub/midnightcommander/'https://ftp.osuosl.org/pub/midnightcommander/\X'tty: link' .
 .SH SEE ALSO
 mc(1), mcedit(1), mcview(1)
 .PP
 .SH BUGS
-Bugs should be reported to https://github.com/MidnightCommander/mc/issues .
+Bugs should be reported to
+\X'tty: link https://github.com/MidnightCommander/mc/issues'https://github.com/MidnightCommander/mc/issues\X'tty: link' .

--- a/doc/man/mcedit.1.in
+++ b/doc/man/mcedit.1.in
@@ -652,11 +652,12 @@ help of Midnight Commander for details on the License and the lack
 of warranty.
 .SH AVAILABILITY
 The latest version of this program can be found at
-https://ftp.osuosl.org/pub/midnightcommander/ .
+\X'tty: link https://ftp.osuosl.org/pub/midnightcommander/'https://ftp.osuosl.org/pub/midnightcommander/\X'tty: link' .
 .SH SEE ALSO
 cooledit(1), mc(1), gpm(1), terminfo(1), scanf(3).
 .SH AUTHORS
 Paul Sheer (psheer@obsidian.co.za) is the original author of
 Midnight Commander's internal editor.
 .SH BUGS
-Bugs should be reported to https://github.com/MidnightCommander/mc/issues .
+Bugs should be reported to
+\X'tty: link https://github.com/MidnightCommander/mc/issues'https://github.com/MidnightCommander/mc/issues\X'tty: link' .

--- a/doc/man/mcview.1.in
+++ b/doc/man/mcview.1.in
@@ -87,9 +87,10 @@ help of Midnight Commander for details on the License and the lack
 of warranty.
 .SH AVAILABILITY
 The latest version of this program can be found at
-https://ftp.osuosl.org/pub/midnightcommander/ .
+\X'tty: link https://ftp.osuosl.org/pub/midnightcommander/'https://ftp.osuosl.org/pub/midnightcommander/\X'tty: link' .
 .SH SEE ALSO
 mc(1), mcedit(1)
 .PP
 .SH BUGS
-Bugs should be reported to https://github.com/MidnightCommander/mc/issues .
+Bugs should be reported to
+\X'tty: link https://github.com/MidnightCommander/mc/issues'https://github.com/MidnightCommander/mc/issues\X'tty: link' .

--- a/doc/man/pl/mc.1.in
+++ b/doc/man/pl/mc.1.in
@@ -2837,7 +2837,7 @@ tcsh(1), zsh(1).
 .PP
 .nf
 Strona Midnight Commander w sieci World Wide Web:
-	https://midnight\-commander.org
+	\X'tty: link https://midnight\-commander.org'https://midnight\-commander.org\X'tty: link'
 .fi
 .PP
 .\"NODE "AUTHORS"

--- a/doc/man/ru/mc.1.in
+++ b/doc/man/ru/mc.1.in
@@ -4853,7 +4853,7 @@ insert=\ee[Op
 .\"NODE "AVAILABILITY"
 .SH "Обновление версий"
 Последние версии программы Midnight Commander можно найти на сайте
-https://ftp.osuosl.org/pub/midnightcommander/ .
+\X'tty: link https://ftp.osuosl.org/pub/midnightcommander/'https://ftp.osuosl.org/pub/midnightcommander/\X'tty: link' .
 .\"NODE "SEE ALSO"
 .SH "Другие источники"
 ed(1), gpm(1), terminfo(1), view(1), sh(1), bash(1), tcsh(1),
@@ -4861,7 +4861,7 @@ zsh(1), mcedit(1).
 .PP
 .nf
 Страница, посвященная Midnight Commander, в World Wide Web:
-	https://midnight\-commander.org
+	\X'tty: link https://midnight\-commander.org'https://midnight\-commander.org\X'tty: link'
 .fi
 .PP
 Данная страница оперативного руководства содержит информацию, актуальную
@@ -4914,7 +4914,7 @@ and Wim Osterholt (wim@djo.wtm.tudelft.nl).
 .PP
 Если вы обнаружили в программе какие\-то недостатки или недоработки,
 оформите, пожалуйста, ваши замечания по адресу
-.IR https://github.com/MidnightCommander/mc/issues .
+\X'tty: link https://github.com/MidnightCommander/mc/issues'https://github.com/MidnightCommander/mc/issues\X'tty: link' .
 .PP
 Дайте подробное описание обнаруженных недостатков (и/или ваших
 предложений по усовершенствованию программы), сообщите версию программы

--- a/doc/man/sr/mc.1.in
+++ b/doc/man/sr/mc.1.in
@@ -4211,7 +4211,7 @@ insert=\ee[Op
 .\"NODE "AVAILABILITY"
 .SH "ДОСТУПНОСТ"
 Најновија верзија овог програма се може наћи на адреси
-https://ftp.osuosl.org/pub/midnightcommander/ .
+\X'tty: link https://ftp.osuosl.org/pub/midnightcommander/'https://ftp.osuosl.org/pub/midnightcommander/\X'tty: link' .
 .\"NODE "SEE ALSO"
 .SH "ВИДЕТИ И"
 ed(1), gpm(1), terminfo(1), view(1), sh(1), bash(1),
@@ -4219,7 +4219,7 @@ tcsh(1), zsh(1).
 .PP
 .nf
 Страница Поноћног наредника на Међународној мрежи:
-	https://midnight\-commander.org
+	\X'tty: link https://midnight\-commander.org'https://midnight\-commander.org\X'tty: link'
 .fi
 .\"NODE "AUTHORS"
 .SH "АУТОРИ"
@@ -4230,7 +4230,7 @@ tcsh(1), zsh(1).
 уради.
 .PP
 Ако желите да пријавите проблем у вези са програмом, пошаљите пријаву грешке на:
-https://github.com/MidnightCommander/mc/issues .
+\X'tty: link https://github.com/MidnightCommander/mc/issues'https://github.com/MidnightCommander/mc/issues\X'tty: link' .
 .PP
 Доставите детаљан опис грешке, верзију програма коју користите
 .RI ( "mc \-V"

--- a/doc/man/sr/mcdiff.1.in
+++ b/doc/man/sr/mcdiff.1.in
@@ -86,9 +86,9 @@ selected=black,green"
 Лиценци и одсуству гаранције.
 .SH ДОСТУПНОСТ
 Најновија верзија овог програма се може наћи на
-https://ftp.osuosl.org/pub/midnightcommander/ .
+\X'tty: link https://ftp.osuosl.org/pub/midnightcommander/'https://ftp.osuosl.org/pub/midnightcommander/\X'tty: link' .
 .SH ВИДЕТИ И
 mc(1), mcedit(1), mcview(1)
 .PP
 .SH ГРЕШКЕ
-Грешке пријавите на https://github.com/MidnightCommander/mc/issues .
+Грешке пријавите на \X'tty: link https://github.com/MidnightCommander/mc/issues'https://github.com/MidnightCommander/mc/issues\X'tty: link' .

--- a/doc/man/sr/mcedit.1.in
+++ b/doc/man/sr/mcedit.1.in
@@ -625,11 +625,12 @@ M\-n смењује ову опцију.
 наредника за детаље о Лиценци и одсуству гаранције.
 .SH ДОСТУПНОСТ
 Најновија верзија овог програма се може наћи на адреси
-https://ftp.osuosl.org/pub/midnightcommander/ .
+\X'tty: link https://ftp.osuosl.org/pub/midnightcommander/'https://ftp.osuosl.org/pub/midnightcommander/\X'tty: link' .
 .SH ВИДЕТИ И
 cooledit(1), mc(1), gpm(1), terminfo(1), scanf(3).
 .SH АУТОРИ
 Пол Шир (Paul Sheer, psheer@obsidian.co.za) је првобитни аутор уграђеног
 уређивача Поноћног наредника.
 .SH ГРЕШКЕ
-Грешке пријављивати на https://github.com/MidnightCommander/mc/issues .
+Грешке пријављивати на
+\X'tty: link https://github.com/MidnightCommander/mc/issues'https://github.com/MidnightCommander/mc/issues\X'tty: link' .


### PR DESCRIPTION
## Proposed changes

Use OSC 8 hyperlinks in manual pages

* Resolves: #4963

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
