### PR TITLE
skins: Use rgb000 instead of black in gray-* skins

### DIFF
--- a/misc/skins/gray-green-purple256.ini
+++ b/misc/skins/gray-green-purple256.ini
@@ -33,7 +33,7 @@
     main2 = rgb303
 
 [core]
-    _default_ = black;bgmain
+    _default_ = rgb000;bgmain
     selected = ;main1
     marked = main2;;bold
     markselect = main2;main1;bold
@@ -45,21 +45,20 @@
     reverse =
     commandlinemark = ;main1
     header = main2
-    shadow = black;gray12
-    frame = black;bgmain
+    shadow = rgb000;gray12
+    frame = rgb000;bgmain
 
 [dialog]
-    _default_ = black;bgdarker
+    _default_ = rgb000;bgdarker
     dfocus = ;main1
     dhotnormal = main2
     dhotfocus = main2;main1
     dselnormal = ;main1
     dselfocus = main2;main1
     dtitle = main2
-    dframe = black;bgdarker
+    dframe = rgb000;bgdarker
 
 [error]
-    # "white" might change color when going bold, so use "rgb555" instead
     _default_ = rgb555;rgb400;bold
     errdfocus = ;main2
     errdhotnormal = main1
@@ -85,58 +84,57 @@
     database = rgb421
 
 [menu]
-    _default_ = black;bgdarker
+    _default_ = rgb000;bgdarker
     menusel = ;main1
     menuhot = main2
     menuhotsel = main2;main1
     menuinactive =
-    menuframe = black;bgdarker
+    menuframe = rgb000;bgdarker
 
 [popupmenu]
-    _default_ = black;bgdarker
+    _default_ = rgb000;bgdarker
     menusel = ;main1
     menutitle = main2
-    menuframe = black;bgdarker
+    menuframe = rgb000;bgdarker
 
 [buttonbar]
-    hotkey = black;bgmain
-    button = black;bgdarker
+    hotkey = rgb000;bgmain
+    button = rgb000;bgdarker
 
 [statusbar]
-    _default_ = black;bgdarker
+    _default_ = rgb000;bgdarker
 
 [help]
-    _default_ = black;bgdarker
+    _default_ = rgb000;bgdarker
     helpitalic = rgb020
     helpbold = rgb300
     helplink = main2;;underline
     helpslink = bgdarker;main2
     helptitle = main2
-    helpframe = black;bgdarker
+    helpframe = rgb000;bgdarker
 
 [editor]
-    _default_ = black;bgmain
+    _default_ = rgb000;bgmain
     editbold = rgb400
     editmarked = ;main1
     editwhitespace = rgb400;bgdarker
-    editnonprintable = black;bgdarker
+    editnonprintable = rgb000;bgdarker
     editlinestate = ;bgdarker
     bookmark = ;main1
     bookmarkfound = ;main2
     editrightmargin = rgb400;bgdarker
 #    editbg =
     editframe = main2;
-    editframeactive = black;
+    editframeactive = rgb000;
     editframedrag = rgb400;
 
 [viewer]
-    _default_ = black;bgmain
-    # "black" might change color when going bold, so use "rgb000" instead
+    _default_ = rgb000;bgmain
     viewbold = rgb000;;bold
     viewunderline = ;;underline
     viewboldunderline = rgb000;;bold+underline
     viewselected = main2;main1;bold
-    viewframe = black;bgmain
+    viewframe = rgb000;bgmain
 
 [diffviewer]
     added = ;rgb340
@@ -144,7 +142,6 @@
     changednew = main2;bgdarker
     changed = ;bgbitdarker
     removed = ;rgb511
-    # "white" might change color when going bold, so use "rgb555" instead
     error = rgb555;rgb400;bold
 
 [widget-panel]

--- a/misc/skins/gray-orange-blue256.ini
+++ b/misc/skins/gray-orange-blue256.ini
@@ -33,7 +33,7 @@
     main2 = rgb004
 
 [core]
-    _default_ = black;bgmain
+    _default_ = rgb000;bgmain
     selected = ;main1
     marked = main2;;bold
     markselect = main2;main1;bold
@@ -45,21 +45,20 @@
     reverse =
     commandlinemark = ;main1
     header = main2
-    shadow = black;gray12
-    frame = black;bgmain
+    shadow = rgb000;gray12
+    frame = rgb000;bgmain
 
 [dialog]
-    _default_ = black;bgdarker
+    _default_ = rgb000;bgdarker
     dfocus = ;main1
     dhotnormal = main2
     dhotfocus = main2;main1
     dselnormal = ;main1
     dselfocus = main2;main1
     dtitle = main2
-    dframe = black;bgdarker
+    dframe = rgb000;bgdarker
 
 [error]
-    # "white" might change color when going bold, so use "rgb555" instead
     _default_ = rgb555;rgb400;bold
     errdfocus = ;main2
     errdhotnormal = main1
@@ -85,58 +84,57 @@
     database = rgb421
 
 [menu]
-    _default_ = black;bgdarker
+    _default_ = rgb000;bgdarker
     menusel = ;main1
     menuhot = main2
     menuhotsel = main2;main1
     menuinactive =
-    menuframe = black;bgdarker
+    menuframe = rgb000;bgdarker
 
 [popupmenu]
-    _default_ = black;bgdarker
+    _default_ = rgb000;bgdarker
     menusel = ;main1
     menutitle = main2
-    menuframe = black;bgdarker
+    menuframe = rgb000;bgdarker
 
 [buttonbar]
-    hotkey = black;bgmain
-    button = black;bgdarker
+    hotkey = rgb000;bgmain
+    button = rgb000;bgdarker
 
 [statusbar]
-    _default_ = black;bgdarker
+    _default_ = rgb000;bgdarker
 
 [help]
-    _default_ = black;bgdarker
+    _default_ = rgb000;bgdarker
     helpitalic = rgb020
     helpbold = rgb300
     helplink = main2;;underline
     helpslink = bgdarker;main2
     helptitle = main2
-    helpframe = black;bgdarker
+    helpframe = rgb000;bgdarker
 
 [editor]
-    _default_ = black;bgmain
+    _default_ = rgb000;bgmain
     editbold = rgb400
     editmarked = ;main1
     editwhitespace = rgb400;bgdarker
-    editnonprintable = black;bgdarker
+    editnonprintable = rgb000;bgdarker
     editlinestate = ;bgdarker
     bookmark = ;main1
     bookmarkfound = ;main2
     editrightmargin = rgb400;bgdarker
 #    editbg =
     editframe = main2;
-    editframeactive = black;
+    editframeactive = rgb000;
     editframedrag = rgb400;
 
 [viewer]
-    _default_ = black;bgmain
-    # "black" might change color when going bold, so use "rgb000" instead
+    _default_ = rgb000;bgmain
     viewbold = rgb000;;bold
     viewunderline = ;;underline
     viewboldunderline = rgb000;;bold+underline
     viewselected = main2;main1;bold
-    viewframe = black;bgmain
+    viewframe = rgb000;bgmain
 
 [diffviewer]
     added = ;rgb340
@@ -144,7 +142,6 @@
     changednew = main2;bgdarker
     changed = ;bgbitdarker
     removed = ;rgb511
-    # "white" might change color when going bold, so use "rgb555" instead
     error = rgb555;rgb400;bold
 
 [widget-panel]


### PR DESCRIPTION
This way it's always pitch black, even if the terminal has a different shade of black in its basic palette.

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [ ] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [ ] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
