### PR TITLE
Ticket #4834: suppress printing last `pwd` with `-P` only for `S-F10`

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -527,7 +527,7 @@ toggle_subshell (void)
     if ((quit & SUBSHELL_EXIT) != 0)
     {
         // User did 'exit' or 'logout': quit MC
-        if (quiet_quit_cmd ())
+        if (quiet_quit_cmd (FALSE))
             return;
 
         quit = 0;

--- a/src/filemanager/command.c
+++ b/src/filemanager/command.c
@@ -106,7 +106,7 @@ enter (WInput *lc_cmdline)
     else if (strcmp (cmd, "exit") == 0)
     {
         input_assign_text (lc_cmdline, "");
-        if (!quiet_quit_cmd ())
+        if (!quiet_quit_cmd (FALSE))
             return MSG_NOT_HANDLED;
     }
     else
@@ -154,7 +154,7 @@ enter (WInput *lc_cmdline)
 #ifdef ENABLE_SUBSHELL
         if ((quit & SUBSHELL_EXIT) != 0)
         {
-            if (quiet_quit_cmd ())
+            if (quiet_quit_cmd (FALSE))
                 return MSG_HANDLED;
 
             quit = 0;

--- a/src/filemanager/filemanager.c
+++ b/src/filemanager/filemanager.c
@@ -1292,7 +1292,7 @@ midnight_execute_cmd (Widget *sender, long command)
             quick_cmd_no_menu ();  // shortcut or buttonabr
         break;
     case CK_QuitQuiet:
-        quiet_quit_cmd ();
+        quiet_quit_cmd (TRUE);
         break;
     case CK_Quit:
         quit_cmd ();
@@ -1742,9 +1742,9 @@ save_cwds_stat (void)
 /* --------------------------------------------------------------------------------------------- */
 
 gboolean
-quiet_quit_cmd (void)
+quiet_quit_cmd (const gboolean suppress_last_pwd)
 {
-    print_last_revert = TRUE;
+    print_last_revert = suppress_last_pwd;
     return quit_cmd_internal (1);
 }
 

--- a/src/filemanager/filemanager.h
+++ b/src/filemanager/filemanager.h
@@ -45,7 +45,7 @@ char *get_random_hint (gboolean force);
 void load_hint (gboolean force);
 WPanel *change_panel (void);
 void save_cwds_stat (void);
-gboolean quiet_quit_cmd (void);
+gboolean quiet_quit_cmd (gboolean suppress_last_pwd);
 gboolean do_nc (void);
 
 /*** inline functions ****************************************************************************/


### PR DESCRIPTION
## Proposed changes

According to my research, this behavior existed since the beginning of days, but users seem to find it confusing.

* Resolves: #4834

/cc @sandman7920 @alexhk please test
