### PR TITLE
Ticket #4995: color handling refactoring

### DIFF
--- a/lib/filehighlight/get-color.c
+++ b/lib/filehighlight/get-color.c
@@ -293,14 +293,14 @@ mc_fhl_get_color (const mc_fhl_t *fhl, const file_entry_t *fe)
         {
         case MC_FLHGH_T_FTYPE:
             ret = mc_fhl_get_color_filetype (mc_filter, fhl, fe);
-            if (ret > 0)
-                return -ret;
+            if (ret >= 0)
+                return ret;
             break;
         case MC_FLHGH_T_EXT:
         case MC_FLHGH_T_FREGEXP:
             ret = mc_fhl_get_color_regexp (mc_filter, fhl, fe);
-            if (ret > 0)
-                return -ret;
+            if (ret >= 0)
+                return ret;
             break;
         default:
             break;

--- a/lib/skin.h
+++ b/lib/skin.h
@@ -9,120 +9,123 @@
 
 /*** typedefs(not structures) and defined constants **********************************************/
 
-/* Beware! When using Slang with color, not all the indexes are free.
-   See color-slang.h (A_*) */
-
-/* cache often used colors */
-#define CORE_DEFAULT_COLOR         mc_skin_color__cache[0]
-#define CORE_NORMAL_COLOR          mc_skin_color__cache[1]
-#define CORE_MARKED_COLOR          mc_skin_color__cache[2]
-#define CORE_SELECTED_COLOR        mc_skin_color__cache[3]
-#define CORE_MARKED_SELECTED_COLOR mc_skin_color__cache[4]
-#define CORE_DISABLED_COLOR        mc_skin_color__cache[5]
-#define CORE_REVERSE_COLOR         mc_skin_color__cache[6]
-#define CORE_COMMAND_MARK_COLOR    mc_skin_color__cache[7]
-#define CORE_HEADER_COLOR          mc_skin_color__cache[8]
-#define CORE_SHADOW_COLOR          mc_skin_color__cache[9]
-#define CORE_FRAME_COLOR           mc_skin_color__cache[10]
-
-/* Dialog colors */
-#define DIALOG_NORMAL_COLOR          mc_skin_color__cache[11]
-#define DIALOG_FOCUS_COLOR           mc_skin_color__cache[12]
-#define DIALOG_HOT_NORMAL_COLOR      mc_skin_color__cache[13]
-#define DIALOG_HOT_FOCUS_COLOR       mc_skin_color__cache[14]
-#define DIALOG_SELECTED_NORMAL_COLOR mc_skin_color__cache[15]
-#define DIALOG_SELECTED_FOCUS_COLOR  mc_skin_color__cache[16]
-#define DIALOG_TITLE_COLOR           mc_skin_color__cache[17]
-#define DIALOG_FRAME_COLOR           mc_skin_color__cache[18]
-
-/* Error dialog colors */
-#define ERROR_NORMAL_COLOR     mc_skin_color__cache[19]
-#define ERROR_FOCUS_COLOR      mc_skin_color__cache[20]
-#define ERROR_HOT_NORMAL_COLOR mc_skin_color__cache[21]
-#define ERROR_HOT_FOCUS_COLOR  mc_skin_color__cache[22]
-#define ERROR_TITLE_COLOR      mc_skin_color__cache[23]
-#define ERROR_FRAME_COLOR      mc_skin_color__cache[24]
-
-/* Menu colors */
-#define MENU_ENTRY_COLOR    mc_skin_color__cache[25]
-#define MENU_SELECTED_COLOR mc_skin_color__cache[26]
-#define MENU_HOT_COLOR      mc_skin_color__cache[27]
-#define MENU_HOTSEL_COLOR   mc_skin_color__cache[28]
-#define MENU_INACTIVE_COLOR mc_skin_color__cache[29]
-#define MENU_FRAME_COLOR    mc_skin_color__cache[30]
-
-/* Popup menu colors */
-#define PMENU_ENTRY_COLOR      mc_skin_color__cache[31]
-#define PMENU_SELECTED_COLOR   mc_skin_color__cache[32]
-#define PMENU_HOT_COLOR        mc_skin_color__cache[33]  // unused: not implemented yet
-#define PMENU_HOTSEL_COLOR     mc_skin_color__cache[34]  // unused: not implemented yet
-#define PMENU_TITLE_COLOR      mc_skin_color__cache[35]
-#define PMENU_FRAME_COLOR      mc_skin_color__cache[36]
-
-#define BUTTONBAR_HOTKEY_COLOR mc_skin_color__cache[37]
-#define BUTTONBAR_BUTTON_COLOR mc_skin_color__cache[38]
-
-#define STATUSBAR_COLOR        mc_skin_color__cache[39]
-
-/*
- * This should be selectable independently. Default has to be black background
- * foreground does not matter at all.
- */
-#define CORE_GAUGE_COLOR             mc_skin_color__cache[40]
-#define CORE_INPUT_COLOR             mc_skin_color__cache[41]
-#define CORE_INPUT_UNCHANGED_COLOR   mc_skin_color__cache[42]
-#define CORE_INPUT_MARK_COLOR        mc_skin_color__cache[43]
-#define CORE_INPUT_HISTORY_COLOR     mc_skin_color__cache[44]
-#define CORE_COMMAND_HISTORY_COLOR   mc_skin_color__cache[45]
-
-#define HELP_NORMAL_COLOR            mc_skin_color__cache[46]
-#define HELP_ITALIC_COLOR            mc_skin_color__cache[47]
-#define HELP_BOLD_COLOR              mc_skin_color__cache[48]
-#define HELP_LINK_COLOR              mc_skin_color__cache[49]
-#define HELP_SLINK_COLOR             mc_skin_color__cache[50]
-#define HELP_TITLE_COLOR             mc_skin_color__cache[51]
-#define HELP_FRAME_COLOR             mc_skin_color__cache[52]
-
-#define VIEWER_NORMAL_COLOR          mc_skin_color__cache[53]
-#define VIEWER_BOLD_COLOR            mc_skin_color__cache[54]
-#define VIEWER_UNDERLINED_COLOR      mc_skin_color__cache[55]
-#define VIEWER_BOLD_UNDERLINED_COLOR mc_skin_color__cache[56]
-#define VIEWER_SELECTED_COLOR        mc_skin_color__cache[57]
-#define VIEWER_FRAME_COLOR           mc_skin_color__cache[58]
-
-/*
- * editor colors - only 4 for normal, search->found, select, and whitespace
- * respectively
- * Last is defined to view color.
- */
-#define EDITOR_NORMAL_COLOR       mc_skin_color__cache[59]
-#define EDITOR_NONPRINTABLE_COLOR mc_skin_color__cache[60]
-#define EDITOR_BOLD_COLOR         mc_skin_color__cache[61]
-#define EDITOR_MARKED_COLOR       mc_skin_color__cache[62]
-#define EDITOR_WHITESPACE_COLOR   mc_skin_color__cache[63]
-#define EDITOR_RIGHT_MARGIN_COLOR mc_skin_color__cache[64]
-#define EDITOR_BACKGROUND_COLOR   mc_skin_color__cache[65]
-#define EDITOR_FRAME_COLOR        mc_skin_color__cache[66]
-#define EDITOR_FRAME_ACTIVE_COLOR mc_skin_color__cache[67]
-#define EDITOR_FRAME_DRAG_COLOR   mc_skin_color__cache[68]
-/* color of left 8 char status per line */
-#define EDITOR_LINE_STATE_COLOR     mc_skin_color__cache[69]
-#define EDITOR_BOOKMARK_COLOR       mc_skin_color__cache[70]
-#define EDITOR_BOOKMARK_FOUND_COLOR mc_skin_color__cache[71]
-
-/* Diff colors */
-#define DIFFVIEWER_ADDED_COLOR       mc_skin_color__cache[72]
-#define DIFFVIEWER_CHANGEDLINE_COLOR mc_skin_color__cache[73]
-#define DIFFVIEWER_CHANGEDNEW_COLOR  mc_skin_color__cache[74]
-#define DIFFVIEWER_CHANGED_COLOR     mc_skin_color__cache[75]
-#define DIFFVIEWER_REMOVED_COLOR     mc_skin_color__cache[76]
-#define DIFFVIEWER_ERROR_COLOR       mc_skin_color__cache[77]
-
-#define FILEHIGHLIGHT_DEFAULT_COLOR  mc_skin_color__cache[78]
-
-#define MC_SKIN_COLOR_CACHE_COUNT    79
-
 /*** enums ***************************************************************************************/
+
+enum
+{
+    /* Basic colors */
+    CORE_DEFAULT_COLOR = TTY_COLOR_MAP_OFFSET,
+    CORE_NORMAL_COLOR,
+    CORE_MARKED_COLOR,
+    CORE_SELECTED_COLOR,
+    CORE_MARKED_SELECTED_COLOR,
+    CORE_DISABLED_COLOR,
+    CORE_REVERSE_COLOR,
+    CORE_COMMAND_MARK_COLOR,
+    CORE_HEADER_COLOR,
+    CORE_SHADOW_COLOR,
+    CORE_FRAME_COLOR,
+
+    /* Dialog colors */
+    DIALOG_NORMAL_COLOR,
+    DIALOG_FOCUS_COLOR,
+    DIALOG_HOT_NORMAL_COLOR,
+    DIALOG_HOT_FOCUS_COLOR,
+    DIALOG_SELECTED_NORMAL_COLOR,
+    DIALOG_SELECTED_FOCUS_COLOR,
+    DIALOG_TITLE_COLOR,
+    DIALOG_FRAME_COLOR,
+
+    /* Error dialog colors */
+    ERROR_NORMAL_COLOR,
+    ERROR_FOCUS_COLOR,
+    ERROR_HOT_NORMAL_COLOR,
+    ERROR_HOT_FOCUS_COLOR,
+    ERROR_TITLE_COLOR,
+    ERROR_FRAME_COLOR,
+
+    /* File highlight default color, the rest are constructed dynamically */
+    FILEHIGHLIGHT_DEFAULT_COLOR,
+
+    /* Menu colors */
+    MENU_ENTRY_COLOR,
+    MENU_SELECTED_COLOR,
+    MENU_HOT_COLOR,
+    MENU_HOTSEL_COLOR,
+    MENU_INACTIVE_COLOR,
+    MENU_FRAME_COLOR,
+
+    /* Popup menu colors */
+    PMENU_ENTRY_COLOR,
+    PMENU_SELECTED_COLOR,
+    PMENU_HOT_COLOR,     // unused: not implemented yet
+    PMENU_HOTSEL_COLOR,  // unused: not implemented yet
+    PMENU_TITLE_COLOR,
+    PMENU_FRAME_COLOR,
+
+    BUTTONBAR_HOTKEY_COLOR,
+    BUTTONBAR_BUTTON_COLOR,
+
+    STATUSBAR_COLOR,
+
+    /*
+     * This should be selectable independently. Default has to be black background
+     * foreground does not matter at all.
+     */
+    CORE_GAUGE_COLOR,
+    CORE_INPUT_COLOR,
+    CORE_INPUT_UNCHANGED_COLOR,
+    CORE_INPUT_MARK_COLOR,
+    CORE_INPUT_HISTORY_COLOR,
+    CORE_COMMAND_HISTORY_COLOR,
+
+    HELP_NORMAL_COLOR,
+    HELP_ITALIC_COLOR,
+    HELP_BOLD_COLOR,
+    HELP_LINK_COLOR,
+    HELP_SLINK_COLOR,
+    HELP_TITLE_COLOR,
+    HELP_FRAME_COLOR,
+
+    VIEWER_NORMAL_COLOR,
+    VIEWER_BOLD_COLOR,
+    VIEWER_UNDERLINED_COLOR,
+    VIEWER_BOLD_UNDERLINED_COLOR,
+    VIEWER_SELECTED_COLOR,
+    VIEWER_FRAME_COLOR,
+
+    /*
+     * editor colors - only 4 for normal, search->found, select, and whitespace
+     * respectively
+     * Last is defined to view color.
+     */
+    EDITOR_NORMAL_COLOR,
+    EDITOR_NONPRINTABLE_COLOR,
+    EDITOR_BOLD_COLOR,
+    EDITOR_MARKED_COLOR,
+    EDITOR_WHITESPACE_COLOR,
+    EDITOR_RIGHT_MARGIN_COLOR,
+    EDITOR_BACKGROUND_COLOR,
+    EDITOR_FRAME_COLOR,
+    EDITOR_FRAME_ACTIVE_COLOR,
+    EDITOR_FRAME_DRAG_COLOR,
+    /* color of left 8 char status per line */
+    EDITOR_LINE_STATE_COLOR,
+    EDITOR_BOOKMARK_COLOR,
+    EDITOR_BOOKMARK_FOUND_COLOR,
+
+    /* Diff colors */
+    DIFFVIEWER_ADDED_COLOR,
+    DIFFVIEWER_CHANGEDLINE_COLOR,
+    DIFFVIEWER_CHANGEDNEW_COLOR,
+    DIFFVIEWER_CHANGED_COLOR,
+    DIFFVIEWER_REMOVED_COLOR,
+    DIFFVIEWER_ERROR_COLOR,
+
+    COLOR_MAP_NEXT
+};
+
+#define COLOR_MAP_SIZE (COLOR_MAP_NEXT - TTY_COLOR_MAP_OFFSET)
 
 /*** structures declarations (and typedefs of structures)*****************************************/
 
@@ -138,7 +141,6 @@ typedef struct mc_skin_struct
 
 /*** global variables defined in .c file *********************************************************/
 
-extern int mc_skin_color__cache[];
 extern mc_skin_t mc_skin__default;
 
 /*** declarations of public functions ************************************************************/

--- a/lib/skin/colors.c
+++ b/lib/skin/colors.c
@@ -35,15 +35,113 @@
 
 /*** global variables ****************************************************************************/
 
-int mc_skin_color__cache[MC_SKIN_COLOR_CACHE_COUNT];
-
 /*** file scope macro definitions ****************************************************************/
 
 /*** file scope type declarations ****************************************************************/
 
+typedef struct
+{
+    int role;
+    const char *group;
+    const char *key;
+} color_keyword_t;
+
 /*** forward declarations (file scope functions) *************************************************/
 
 /*** file scope variables ************************************************************************/
+
+static const color_keyword_t color_keywords[] = {
+    { CORE_DEFAULT_COLOR, "skin", "terminal_default_color" },
+    { CORE_NORMAL_COLOR, "core", "_default_" },
+    { CORE_MARKED_COLOR, "core", "marked" },
+    { CORE_SELECTED_COLOR, "core", "selected" },
+    { CORE_MARKED_SELECTED_COLOR, "core", "markselect" },
+    { CORE_DISABLED_COLOR, "core", "disabled" },
+    { CORE_REVERSE_COLOR, "core", "reverse" },
+    { CORE_HEADER_COLOR, "core", "header" },
+    { CORE_COMMAND_MARK_COLOR, "core", "commandlinemark" },
+    { CORE_SHADOW_COLOR, "core", "shadow" },
+    { CORE_FRAME_COLOR, "core", "frame" },
+
+    { DIALOG_NORMAL_COLOR, "dialog", "_default_" },
+    { DIALOG_FOCUS_COLOR, "dialog", "dfocus" },
+    { DIALOG_HOT_NORMAL_COLOR, "dialog", "dhotnormal" },
+    { DIALOG_HOT_FOCUS_COLOR, "dialog", "dhotfocus" },
+    { DIALOG_SELECTED_NORMAL_COLOR, "dialog", "dselnormal" },
+    { DIALOG_SELECTED_FOCUS_COLOR, "dialog", "dselfocus" },
+    { DIALOG_TITLE_COLOR, "dialog", "dtitle" },
+    { DIALOG_FRAME_COLOR, "dialog", "dframe" },
+
+    { ERROR_NORMAL_COLOR, "error", "_default_" },
+    { ERROR_FOCUS_COLOR, "error", "errdfocus" },
+    { ERROR_HOT_NORMAL_COLOR, "error", "errdhotnormal" },
+    { ERROR_HOT_FOCUS_COLOR, "error", "errdhotfocus" },
+    { ERROR_TITLE_COLOR, "error", "errdtitle" },
+    { ERROR_FRAME_COLOR, "error", "errdframe" },
+
+    { FILEHIGHLIGHT_DEFAULT_COLOR, "filehighlight", "_default_" },
+
+    { MENU_ENTRY_COLOR, "menu", "_default_" },
+    { MENU_SELECTED_COLOR, "menu", "menusel" },
+    { MENU_HOT_COLOR, "menu", "menuhot" },
+    { MENU_HOTSEL_COLOR, "menu", "menuhotsel" },
+    { MENU_INACTIVE_COLOR, "menu", "menuinactive" },
+    { MENU_FRAME_COLOR, "menu", "menuframe" },
+
+    { PMENU_ENTRY_COLOR, "popupmenu", "_default_" },
+    { PMENU_SELECTED_COLOR, "popupmenu", "menusel" },
+    { PMENU_TITLE_COLOR, "popupmenu", "menutitle" },
+    { PMENU_FRAME_COLOR, "popupmenu", "menuframe" },
+
+    { BUTTONBAR_HOTKEY_COLOR, "buttonbar", "hotkey" },
+    { BUTTONBAR_BUTTON_COLOR, "buttonbar", "button" },
+
+    { STATUSBAR_COLOR, "statusbar", "_default_" },
+
+    { CORE_GAUGE_COLOR, "core", "gauge" },
+    { CORE_INPUT_COLOR, "core", "input" },
+    { CORE_INPUT_HISTORY_COLOR, "core", "inputhistory" },
+    { CORE_COMMAND_HISTORY_COLOR, "core", "commandhistory" },
+    { CORE_INPUT_MARK_COLOR, "core", "inputmark" },
+    { CORE_INPUT_UNCHANGED_COLOR, "core", "inputunchanged" },
+
+    { HELP_NORMAL_COLOR, "help", "_default_" },
+    { HELP_ITALIC_COLOR, "help", "helpitalic" },
+    { HELP_BOLD_COLOR, "help", "helpbold" },
+    { HELP_LINK_COLOR, "help", "helplink" },
+    { HELP_SLINK_COLOR, "help", "helpslink" },
+    { HELP_TITLE_COLOR, "help", "helptitle" },
+    { HELP_FRAME_COLOR, "help", "helpframe" },
+
+    { VIEWER_NORMAL_COLOR, "viewer", "_default_" },
+    { VIEWER_BOLD_COLOR, "viewer", "viewbold" },
+    { VIEWER_UNDERLINED_COLOR, "viewer", "viewunderline" },
+    { VIEWER_BOLD_UNDERLINED_COLOR, "viewer", "viewboldunderline" },
+    { VIEWER_SELECTED_COLOR, "viewer", "viewselected" },
+    { VIEWER_FRAME_COLOR, "viewer", "viewframe" },
+
+    { EDITOR_NORMAL_COLOR, "editor", "_default_" },
+    { EDITOR_BOLD_COLOR, "editor", "editbold" },
+    { EDITOR_MARKED_COLOR, "editor", "editmarked" },
+    { EDITOR_WHITESPACE_COLOR, "editor", "editwhitespace" },
+    { EDITOR_NONPRINTABLE_COLOR, "editor", "editnonprintable" },
+    { EDITOR_RIGHT_MARGIN_COLOR, "editor", "editrightmargin" },
+    { EDITOR_LINE_STATE_COLOR, "editor", "editlinestate" },
+    { EDITOR_BACKGROUND_COLOR, "editor", "editbg" },
+    { EDITOR_FRAME_COLOR, "editor", "editframe" },
+    { EDITOR_FRAME_ACTIVE_COLOR, "editor", "editframeactive" },
+    { EDITOR_FRAME_DRAG_COLOR, "editor", "editframedrag" },
+
+    { EDITOR_BOOKMARK_COLOR, "editor", "bookmark" },
+    { EDITOR_BOOKMARK_FOUND_COLOR, "editor", "bookmarkfound" },
+
+    { DIFFVIEWER_ADDED_COLOR, "diffviewer", "added" },
+    { DIFFVIEWER_CHANGEDLINE_COLOR, "diffviewer", "changedline" },
+    { DIFFVIEWER_CHANGEDNEW_COLOR, "diffviewer", "changednew" },
+    { DIFFVIEWER_CHANGED_COLOR, "diffviewer", "changed" },
+    { DIFFVIEWER_REMOVED_COLOR, "diffviewer", "removed" },
+    { DIFFVIEWER_ERROR_COLOR, "diffviewer", "error" },
+};
 
 /* --------------------------------------------------------------------------------------------- */
 /*** file scope functions ************************************************************************/
@@ -244,96 +342,11 @@ mc_skin_color_set_default_for_terminal (mc_skin_t *mc_skin)
 static void
 mc_skin_color_cache_init (void)
 {
-    CORE_DEFAULT_COLOR = mc_skin_color_get ("skin", "terminal_default_color");
-    CORE_NORMAL_COLOR = mc_skin_color_get ("core", "_default_");
-    CORE_MARKED_COLOR = mc_skin_color_get ("core", "marked");
-    CORE_SELECTED_COLOR = mc_skin_color_get ("core", "selected");
-    CORE_MARKED_SELECTED_COLOR = mc_skin_color_get ("core", "markselect");
-    CORE_DISABLED_COLOR = mc_skin_color_get ("core", "disabled");
-    CORE_REVERSE_COLOR = mc_skin_color_get ("core", "reverse");
-    CORE_HEADER_COLOR = mc_skin_color_get ("core", "header");
-    CORE_COMMAND_MARK_COLOR = mc_skin_color_get ("core", "commandlinemark");
-    CORE_SHADOW_COLOR = mc_skin_color_get ("core", "shadow");
-    CORE_FRAME_COLOR = mc_skin_color_get ("core", "frame");
-
-    DIALOG_NORMAL_COLOR = mc_skin_color_get ("dialog", "_default_");
-    DIALOG_FOCUS_COLOR = mc_skin_color_get ("dialog", "dfocus");
-    DIALOG_HOT_NORMAL_COLOR = mc_skin_color_get ("dialog", "dhotnormal");
-    DIALOG_HOT_FOCUS_COLOR = mc_skin_color_get ("dialog", "dhotfocus");
-    DIALOG_SELECTED_NORMAL_COLOR = mc_skin_color_get ("dialog", "dselnormal");
-    DIALOG_SELECTED_FOCUS_COLOR = mc_skin_color_get ("dialog", "dselfocus");
-    DIALOG_TITLE_COLOR = mc_skin_color_get ("dialog", "dtitle");
-    DIALOG_FRAME_COLOR = mc_skin_color_get ("dialog", "dframe");
-
-    ERROR_NORMAL_COLOR = mc_skin_color_get ("error", "_default_");
-    ERROR_FOCUS_COLOR = mc_skin_color_get ("error", "errdfocus");
-    ERROR_HOT_NORMAL_COLOR = mc_skin_color_get ("error", "errdhotnormal");
-    ERROR_HOT_FOCUS_COLOR = mc_skin_color_get ("error", "errdhotfocus");
-    ERROR_TITLE_COLOR = mc_skin_color_get ("error", "errdtitle");
-    ERROR_FRAME_COLOR = mc_skin_color_get ("error", "errdframe");
-
-    MENU_ENTRY_COLOR = mc_skin_color_get ("menu", "_default_");
-    MENU_SELECTED_COLOR = mc_skin_color_get ("menu", "menusel");
-    MENU_HOT_COLOR = mc_skin_color_get ("menu", "menuhot");
-    MENU_HOTSEL_COLOR = mc_skin_color_get ("menu", "menuhotsel");
-    MENU_INACTIVE_COLOR = mc_skin_color_get ("menu", "menuinactive");
-    MENU_FRAME_COLOR = mc_skin_color_get ("menu", "menuframe");
-
-    PMENU_ENTRY_COLOR = mc_skin_color_get ("popupmenu", "_default_");
-    PMENU_SELECTED_COLOR = mc_skin_color_get ("popupmenu", "menusel");
-    PMENU_TITLE_COLOR = mc_skin_color_get ("popupmenu", "menutitle");
-    PMENU_FRAME_COLOR = mc_skin_color_get ("popupmenu", "menuframe");
-
-    BUTTONBAR_HOTKEY_COLOR = mc_skin_color_get ("buttonbar", "hotkey");
-    BUTTONBAR_BUTTON_COLOR = mc_skin_color_get ("buttonbar", "button");
-
-    STATUSBAR_COLOR = mc_skin_color_get ("statusbar", "_default_");
-
-    CORE_GAUGE_COLOR = mc_skin_color_get ("core", "gauge");
-    CORE_INPUT_COLOR = mc_skin_color_get ("core", "input");
-    CORE_INPUT_HISTORY_COLOR = mc_skin_color_get ("core", "inputhistory");
-    CORE_COMMAND_HISTORY_COLOR = mc_skin_color_get ("core", "commandhistory");
-    CORE_INPUT_MARK_COLOR = mc_skin_color_get ("core", "inputmark");
-    CORE_INPUT_UNCHANGED_COLOR = mc_skin_color_get ("core", "inputunchanged");
-
-    HELP_NORMAL_COLOR = mc_skin_color_get ("help", "_default_");
-    HELP_ITALIC_COLOR = mc_skin_color_get ("help", "helpitalic");
-    HELP_BOLD_COLOR = mc_skin_color_get ("help", "helpbold");
-    HELP_LINK_COLOR = mc_skin_color_get ("help", "helplink");
-    HELP_SLINK_COLOR = mc_skin_color_get ("help", "helpslink");
-    HELP_TITLE_COLOR = mc_skin_color_get ("help", "helptitle");
-    HELP_FRAME_COLOR = mc_skin_color_get ("help", "helpframe");
-
-    VIEWER_NORMAL_COLOR = mc_skin_color_get ("viewer", "_default_");
-    VIEWER_BOLD_COLOR = mc_skin_color_get ("viewer", "viewbold");
-    VIEWER_UNDERLINED_COLOR = mc_skin_color_get ("viewer", "viewunderline");
-    VIEWER_BOLD_UNDERLINED_COLOR = mc_skin_color_get ("viewer", "viewboldunderline");
-    VIEWER_SELECTED_COLOR = mc_skin_color_get ("viewer", "viewselected");
-    VIEWER_FRAME_COLOR = mc_skin_color_get ("viewer", "viewframe");
-
-    EDITOR_NORMAL_COLOR = mc_skin_color_get ("editor", "_default_");
-    EDITOR_BOLD_COLOR = mc_skin_color_get ("editor", "editbold");
-    EDITOR_MARKED_COLOR = mc_skin_color_get ("editor", "editmarked");
-    EDITOR_WHITESPACE_COLOR = mc_skin_color_get ("editor", "editwhitespace");
-    EDITOR_NONPRINTABLE_COLOR = mc_skin_color_get ("editor", "editnonprintable");
-    EDITOR_RIGHT_MARGIN_COLOR = mc_skin_color_get ("editor", "editrightmargin");
-    EDITOR_LINE_STATE_COLOR = mc_skin_color_get ("editor", "editlinestate");
-    EDITOR_BACKGROUND_COLOR = mc_skin_color_get ("editor", "editbg");
-    EDITOR_FRAME_COLOR = mc_skin_color_get ("editor", "editframe");
-    EDITOR_FRAME_ACTIVE_COLOR = mc_skin_color_get ("editor", "editframeactive");
-    EDITOR_FRAME_DRAG_COLOR = mc_skin_color_get ("editor", "editframedrag");
-
-    EDITOR_BOOKMARK_COLOR = mc_skin_color_get ("editor", "bookmark");
-    EDITOR_BOOKMARK_FOUND_COLOR = mc_skin_color_get ("editor", "bookmarkfound");
-
-    DIFFVIEWER_ADDED_COLOR = mc_skin_color_get ("diffviewer", "added");
-    DIFFVIEWER_CHANGEDLINE_COLOR = mc_skin_color_get ("diffviewer", "changedline");
-    DIFFVIEWER_CHANGEDNEW_COLOR = mc_skin_color_get ("diffviewer", "changednew");
-    DIFFVIEWER_CHANGED_COLOR = mc_skin_color_get ("diffviewer", "changed");
-    DIFFVIEWER_REMOVED_COLOR = mc_skin_color_get ("diffviewer", "removed");
-    DIFFVIEWER_ERROR_COLOR = mc_skin_color_get ("diffviewer", "error");
-
-    FILEHIGHLIGHT_DEFAULT_COLOR = mc_skin_color_get ("filehighlight", "_default_");
+    for (size_t i = 0; i < G_N_ELEMENTS (color_keywords); i++)
+    {
+        tty_color_role_to_pair[color_keywords[i].role - TTY_COLOR_MAP_OFFSET] =
+            mc_skin_color_get (color_keywords[i].group, color_keywords[i].key);
+    }
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/tty/color-internal.c
+++ b/lib/tty/color-internal.c
@@ -270,3 +270,13 @@ convert_256color_to_truecolor (int color)
 }
 
 /* --------------------------------------------------------------------------------------------- */
+
+int
+tty_maybe_map_color (int color)
+{
+    if (color >= TTY_COLOR_MAP_OFFSET)
+        return tty_color_role_to_pair[color - TTY_COLOR_MAP_OFFSET];
+    return color;
+}
+
+/* --------------------------------------------------------------------------------------------- */

--- a/lib/tty/color-internal.h
+++ b/lib/tty/color-internal.h
@@ -53,6 +53,8 @@ void tty_color_deinit_lib (void);
 
 void tty_color_try_alloc_lib_pair (tty_color_lib_pair_t *mc_color_pair);
 
+int tty_maybe_map_color (int color);
+
 /*** inline functions ****************************************************************************/
 
 #endif

--- a/lib/tty/color-ncurses.c
+++ b/lib/tty/color-ncurses.c
@@ -192,15 +192,8 @@ tty_color_try_alloc_lib_pair (tty_color_lib_pair_t *mc_color_pair)
 void
 tty_setcolor (int color)
 {
+    color = tty_maybe_map_color (color);
     attr_set (color_get_attr (color), color, NULL);
-}
-
-/* --------------------------------------------------------------------------------------------- */
-
-void
-tty_lowlevel_setcolor (int color)
-{
-    tty_setcolor (color);
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/tty/color-slang.c
+++ b/lib/tty/color-slang.c
@@ -157,17 +157,7 @@ tty_color_try_alloc_lib_pair (tty_color_lib_pair_t *mc_color_pair)
 void
 tty_setcolor (int color)
 {
-    SLsmg_set_color (color);
-}
-
-/* --------------------------------------------------------------------------------------------- */
-/**
- * Set colorpair by index, don't interpret S-Lang "emulated attributes"
- */
-
-void
-tty_lowlevel_setcolor (int color)
-{
+    color = tty_maybe_map_color (color);
     SLsmg_set_color (color);
 }
 

--- a/lib/tty/color.c
+++ b/lib/tty/color.c
@@ -38,6 +38,7 @@
 #include <sys/types.h>  // size_t
 
 #include "lib/global.h"
+#include "lib/util.h"  // MC_PTR_FREE
 
 #include "tty.h"
 #include "color.h"
@@ -49,6 +50,8 @@
 static tty_color_pair_t tty_color_defaults = {
     .fg = NULL, .bg = NULL, .attrs = NULL, .pair_index = 0
 };
+
+int *tty_color_role_to_pair = NULL;
 
 /* Set if we are actually using colors */
 gboolean use_colors = FALSE;
@@ -123,8 +126,9 @@ tty_color_get_next__color_pair_number (void)
 /* --------------------------------------------------------------------------------------------- */
 
 void
-tty_init_colors (gboolean disable, gboolean force)
+tty_init_colors (gboolean disable, gboolean force, int color_map_size)
 {
+    tty_color_role_to_pair = g_new (int, color_map_size);
     tty_color_init_lib (disable, force);
     mc_tty_color__hashtable = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 }
@@ -137,6 +141,7 @@ tty_colors_done (void)
     tty_color_deinit_lib ();
     mc_color__deinit (&tty_color_defaults);
     g_hash_table_destroy (mc_tty_color__hashtable);
+    MC_PTR_FREE (tty_color_role_to_pair);
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/tty/color.h
+++ b/lib/tty/color.h
@@ -29,15 +29,35 @@ typedef struct
     size_t pair_index;
 } tty_color_pair_t;
 
+/*
+ * Color values below this number refer directly to the ncurses/slang color pair id.
+ *
+ * Color values beginning with this number represent a role, for which the ncurses/slang color pair
+ * id is looked up runtime from tty_color_role_to_pair which is initialized when loading the skin.
+ *
+ * This way the numbers representing skinnable colors remain the same across skin changes.
+ *
+ * (Note: Another approach could be to allocate a new ncurses/slang color pair id for every role,
+ * even if they use the same colors in the skin. The problem with this is that for 8-color terminal
+ * descriptors (like TERM=linux and TERM=xterm) ncurses only allows 64 color pairs, so we can't
+ * afford to allocate new ids for duplicates.)
+ *
+ * In src/editor/editdraw.c these values are shifted by 16 bits to the left and stored in an int.
+ * Keep this number safely below 65536 to avoid overflow.
+ */
+#define TTY_COLOR_MAP_OFFSET 4096
+
 /*** enums ***************************************************************************************/
 
 /*** structures declarations (and typedefs of structures)*****************************************/
 
 /*** global variables defined in .c file *********************************************************/
 
+extern int *tty_color_role_to_pair;
+
 /*** declarations of public functions ************************************************************/
 
-void tty_init_colors (gboolean disable, gboolean force);
+void tty_init_colors (gboolean disable, gboolean force, int color_map_size);
 void tty_colors_done (void);
 
 gboolean tty_use_colors (void);
@@ -47,7 +67,6 @@ void tty_color_free_temp (void);
 void tty_color_free_all (void);
 
 void tty_setcolor (int color);
-void tty_lowlevel_setcolor (int color);
 void tty_set_normal_attrs (void);
 
 void tty_color_set_defaults (const tty_color_pair_t *color);

--- a/lib/tty/tty-slang.c
+++ b/lib/tty/tty-slang.c
@@ -566,7 +566,10 @@ void
 tty_colorize_area (int y, int x, int rows, int cols, int color)
 {
     if (use_colors)
+    {
+        color = tty_maybe_map_color (color);
         SLsmg_set_color_in_region (color, y, x, rows, cols);
+    }
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/widget/dialog.c
+++ b/lib/widget/dialog.c
@@ -43,10 +43,26 @@
 /*** global variables ****************************************************************************/
 
 /* Color styles for normal and error dialogs */
-dlg_colors_t dialog_colors;
-dlg_colors_t alarm_colors;
-dlg_colors_t listbox_colors;
-dlg_colors_t help_colors;
+const dlg_colors_t dialog_colors = {
+    [DLG_COLOR_NORMAL] = DIALOG_NORMAL_COLOR,
+    [DLG_COLOR_FOCUS] = DIALOG_FOCUS_COLOR,
+    [DLG_COLOR_HOT_NORMAL] = DIALOG_HOT_NORMAL_COLOR,
+    [DLG_COLOR_HOT_FOCUS] = DIALOG_HOT_FOCUS_COLOR,
+    [DLG_COLOR_SELECTED_NORMAL] = DIALOG_SELECTED_NORMAL_COLOR,
+    [DLG_COLOR_SELECTED_FOCUS] = DIALOG_SELECTED_FOCUS_COLOR,
+    [DLG_COLOR_TITLE] = DIALOG_TITLE_COLOR,
+    [DLG_COLOR_FRAME] = DIALOG_FRAME_COLOR,
+};
+const dlg_colors_t alarm_colors = {
+    [DLG_COLOR_NORMAL] = ERROR_NORMAL_COLOR,
+    [DLG_COLOR_FOCUS] = ERROR_FOCUS_COLOR,
+    [DLG_COLOR_HOT_NORMAL] = ERROR_HOT_NORMAL_COLOR,
+    [DLG_COLOR_HOT_FOCUS] = ERROR_HOT_FOCUS_COLOR,
+    [DLG_COLOR_SELECTED_NORMAL] = ERROR_HOT_FOCUS_COLOR,  // unused
+    [DLG_COLOR_SELECTED_FOCUS] = ERROR_FOCUS_COLOR,       // unused
+    [DLG_COLOR_TITLE] = ERROR_TITLE_COLOR,
+    [DLG_COLOR_FRAME] = ERROR_FRAME_COLOR,
+};
 
 /* A hook list for idle events */
 hook_t *idle_hook = NULL;
@@ -414,48 +430,6 @@ dlg_create (gboolean modal, int y1, int x1, int lines, int cols, widget_pos_flag
     new_d->event_group = g_strdup_printf ("%s_%p", MCEVENT_GROUP_DIALOG, (void *) new_d);
 
     return new_d;
-}
-
-/* --------------------------------------------------------------------------------------------- */
-
-void
-dlg_set_default_colors (void)
-{
-    dialog_colors[DLG_COLOR_NORMAL] = DIALOG_NORMAL_COLOR;
-    dialog_colors[DLG_COLOR_FOCUS] = DIALOG_FOCUS_COLOR;
-    dialog_colors[DLG_COLOR_HOT_NORMAL] = DIALOG_HOT_NORMAL_COLOR;
-    dialog_colors[DLG_COLOR_HOT_FOCUS] = DIALOG_HOT_FOCUS_COLOR;
-    dialog_colors[DLG_COLOR_SELECTED_NORMAL] = DIALOG_SELECTED_NORMAL_COLOR;
-    dialog_colors[DLG_COLOR_SELECTED_FOCUS] = DIALOG_SELECTED_FOCUS_COLOR;
-    dialog_colors[DLG_COLOR_TITLE] = DIALOG_TITLE_COLOR;
-    dialog_colors[DLG_COLOR_FRAME] = DIALOG_FRAME_COLOR;
-
-    alarm_colors[DLG_COLOR_NORMAL] = ERROR_NORMAL_COLOR;
-    alarm_colors[DLG_COLOR_FOCUS] = ERROR_FOCUS_COLOR;
-    alarm_colors[DLG_COLOR_HOT_NORMAL] = ERROR_HOT_NORMAL_COLOR;
-    alarm_colors[DLG_COLOR_HOT_FOCUS] = ERROR_HOT_FOCUS_COLOR;
-    alarm_colors[DLG_COLOR_SELECTED_NORMAL] = ERROR_HOT_FOCUS_COLOR;  // unused
-    alarm_colors[DLG_COLOR_SELECTED_FOCUS] = ERROR_FOCUS_COLOR;       // unused
-    alarm_colors[DLG_COLOR_TITLE] = ERROR_TITLE_COLOR;
-    alarm_colors[DLG_COLOR_FRAME] = ERROR_FRAME_COLOR;
-
-    listbox_colors[DLG_COLOR_NORMAL] = PMENU_ENTRY_COLOR;
-    listbox_colors[DLG_COLOR_FOCUS] = PMENU_SELECTED_COLOR;
-    listbox_colors[DLG_COLOR_HOT_NORMAL] = PMENU_ENTRY_COLOR;
-    listbox_colors[DLG_COLOR_HOT_FOCUS] = PMENU_SELECTED_COLOR;
-    listbox_colors[DLG_COLOR_SELECTED_NORMAL] = PMENU_SELECTED_COLOR;  // unused
-    listbox_colors[DLG_COLOR_SELECTED_FOCUS] = PMENU_SELECTED_COLOR;   // unused
-    listbox_colors[DLG_COLOR_TITLE] = PMENU_TITLE_COLOR;
-    listbox_colors[DLG_COLOR_FRAME] = PMENU_FRAME_COLOR;
-
-    help_colors[DLG_COLOR_NORMAL] = HELP_NORMAL_COLOR;
-    help_colors[DLG_COLOR_FOCUS] = 0;  // unused
-    help_colors[DLG_COLOR_HOT_NORMAL] = HELP_BOLD_COLOR;
-    help_colors[DLG_COLOR_HOT_FOCUS] = 0;        // unused
-    help_colors[DLG_COLOR_SELECTED_NORMAL] = 0;  // unused
-    help_colors[DLG_COLOR_SELECTED_FOCUS] = 0;   // unused
-    help_colors[DLG_COLOR_TITLE] = HELP_TITLE_COLOR;
-    help_colors[DLG_COLOR_FRAME] = HELP_FRAME_COLOR;
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/widget/dialog.h
+++ b/lib/widget/dialog.h
@@ -89,10 +89,8 @@ struct WDialog
 /*** global variables defined in .c file *********************************************************/
 
 /* Color styles for normal and error dialogs */
-extern dlg_colors_t dialog_colors;
-extern dlg_colors_t alarm_colors;
-extern dlg_colors_t listbox_colors;
-extern dlg_colors_t help_colors;
+extern const dlg_colors_t dialog_colors;
+extern const dlg_colors_t alarm_colors;
 
 /* A hook list for idle events */
 extern hook_t *idle_hook;
@@ -108,8 +106,6 @@ WDialog *dlg_create (gboolean modal, int y1, int x1, int lines, int cols,
                      widget_pos_flags_t pos_flags, gboolean compact, const int *colors,
                      widget_cb_fn callback, widget_mouse_cb_fn mouse_callback, const char *help_ctx,
                      const char *title);
-
-void dlg_set_default_colors (void);
 
 void dlg_init (WDialog *h);
 int dlg_run (WDialog *d);

--- a/lib/widget/input.c
+++ b/lib/widget/input.c
@@ -57,7 +57,12 @@ gboolean quote = FALSE;
 const global_keymap_t *input_map = NULL;
 
 /* Color styles for input widgets */
-input_colors_t input_colors;
+const input_colors_t input_colors = {
+    [INPUT_COLOR_MAIN] = CORE_INPUT_COLOR,
+    [INPUT_COLOR_MARK] = CORE_INPUT_MARK_COLOR,
+    [INPUT_COLOR_UNCHANGED] = CORE_INPUT_UNCHANGED_COLOR,
+    [INPUT_COLOR_HISTORY] = CORE_INPUT_HISTORY_COLOR,
+};
 
 /*** file scope macro definitions ****************************************************************/
 
@@ -1074,17 +1079,6 @@ input_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void *dat
     default:
         return widget_default_callback (w, sender, msg, parm, data);
     }
-}
-
-/* --------------------------------------------------------------------------------------------- */
-
-void
-input_set_default_colors (void)
-{
-    input_colors[INPUT_COLOR_MAIN] = CORE_INPUT_COLOR;
-    input_colors[INPUT_COLOR_MARK] = CORE_INPUT_MARK_COLOR;
-    input_colors[INPUT_COLOR_UNCHANGED] = CORE_INPUT_UNCHANGED_COLOR;
-    input_colors[INPUT_COLOR_HISTORY] = CORE_INPUT_HISTORY_COLOR;
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/widget/input.c
+++ b/lib/widget/input.c
@@ -115,7 +115,7 @@ draw_history_button (WInput *in)
 
     widget_gotoyx (in, 0, WIDGET (in)->rect.cols - HISTORY_BUTTON_WIDTH);
     disabled = widget_get_state (WIDGET (in), WST_DISABLED);
-    tty_setcolor (disabled ? CORE_DISABLED_COLOR : in->color[WINPUTC_HISTORY]);
+    tty_setcolor (disabled ? CORE_DISABLED_COLOR : in->color[INPUT_COLOR_HISTORY]);
 
 #ifdef LARGE_HISTORY_BUTTON
     tty_print_string ("[ ]");
@@ -1081,10 +1081,10 @@ input_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void *dat
 void
 input_set_default_colors (void)
 {
-    input_colors[WINPUTC_MAIN] = CORE_INPUT_COLOR;
-    input_colors[WINPUTC_MARK] = CORE_INPUT_MARK_COLOR;
-    input_colors[WINPUTC_UNCHANGED] = CORE_INPUT_UNCHANGED_COLOR;
-    input_colors[WINPUTC_HISTORY] = CORE_INPUT_HISTORY_COLOR;
+    input_colors[INPUT_COLOR_MAIN] = CORE_INPUT_COLOR;
+    input_colors[INPUT_COLOR_MARK] = CORE_INPUT_MARK_COLOR;
+    input_colors[INPUT_COLOR_UNCHANGED] = CORE_INPUT_UNCHANGED_COLOR;
+    input_colors[INPUT_COLOR_HISTORY] = CORE_INPUT_HISTORY_COLOR;
 }
 
 /* --------------------------------------------------------------------------------------------- */
@@ -1226,9 +1226,9 @@ input_update (WInput *in, gboolean clear_first)
     if (widget_get_state (wi, WST_DISABLED))
         tty_setcolor (CORE_DISABLED_COLOR);
     else if (in->first)
-        tty_setcolor (in->color[WINPUTC_UNCHANGED]);
+        tty_setcolor (in->color[INPUT_COLOR_UNCHANGED]);
     else
-        tty_setcolor (in->color[WINPUTC_MAIN]);
+        tty_setcolor (in->color[INPUT_COLOR_MAIN]);
 
     widget_gotoyx (in, 0, 0);
 
@@ -1243,11 +1243,11 @@ input_update (WInput *in, gboolean clear_first)
 
             if (input_eval_marks (in, &m1, &m2))
             {
-                tty_setcolor (in->color[WINPUTC_MAIN]);
+                tty_setcolor (in->color[INPUT_COLOR_MAIN]);
                 cp = str_term_substring (in->buffer->str, in->term_first_shown,
                                          w->cols - has_history);
                 tty_print_string (cp);
-                tty_setcolor (in->color[WINPUTC_MARK]);
+                tty_setcolor (in->color[INPUT_COLOR_MARK]);
                 if (m1 < in->term_first_shown)
                 {
                     widget_gotoyx (in, 0, 0);
@@ -1273,7 +1273,7 @@ input_update (WInput *in, gboolean clear_first)
         int i;
 
         cp = str_term_substring (in->buffer->str, in->term_first_shown, w->cols - has_history);
-        tty_setcolor (in->color[WINPUTC_MAIN]);
+        tty_setcolor (in->color[INPUT_COLOR_MAIN]);
         for (i = 0; i < w->cols - has_history; i++)
         {
             if (i < (buf_len - in->term_first_shown) && cp[0] != '\0')

--- a/lib/widget/input.h
+++ b/lib/widget/input.h
@@ -79,7 +79,7 @@ extern int quote;
 extern const global_keymap_t *input_map;
 
 /* Color styles for normal and command line input widgets */
-extern input_colors_t input_colors;
+extern const input_colors_t input_colors;
 
 /*** declarations of public functions ************************************************************/
 
@@ -87,7 +87,6 @@ WInput *input_new (int y, int x, const int *colors, int len, const char *text, c
                    input_complete_t completion_flags);
 /* callback is public; needed for command line */
 cb_ret_t input_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void *data);
-void input_set_default_colors (void);
 cb_ret_t input_handle_char (WInput *in, int key);
 void input_assign_text (WInput *in, const char *text);
 void input_insert (WInput *in, const char *text, gboolean insert_extra_space);

--- a/lib/widget/input.h
+++ b/lib/widget/input.h
@@ -19,11 +19,11 @@
 
 typedef enum
 {
-    WINPUTC_MAIN,         // color used
-    WINPUTC_MARK,         // color for marked text
-    WINPUTC_UNCHANGED,    // color for inactive text (Is first keystroke)
-    WINPUTC_HISTORY,      // color for history list
-    WINPUTC_COUNT_COLORS  // count of used colors
+    INPUT_COLOR_MAIN,       // color used
+    INPUT_COLOR_MARK,       // color for marked text
+    INPUT_COLOR_UNCHANGED,  // color for inactive text (Is first keystroke)
+    INPUT_COLOR_HISTORY,    // color for history list
+    INPUT_COLOR_COUNT       // count of used colors
 } input_colors_enum_t;
 
 /* completion flags */
@@ -41,7 +41,7 @@ typedef enum
 
 /*** structures declarations (and typedefs of structures)*****************************************/
 
-typedef int input_colors_t[WINPUTC_COUNT_COLORS];
+typedef int input_colors_t[INPUT_COLOR_COUNT];
 
 typedef struct
 {

--- a/lib/widget/listbox-window.c
+++ b/lib/widget/listbox-window.c
@@ -49,6 +49,17 @@
 
 /*** file scope variables ************************************************************************/
 
+static const dlg_colors_t listbox_colors = {
+    [DLG_COLOR_NORMAL] = PMENU_ENTRY_COLOR,
+    [DLG_COLOR_FOCUS] = PMENU_SELECTED_COLOR,
+    [DLG_COLOR_HOT_NORMAL] = PMENU_ENTRY_COLOR,
+    [DLG_COLOR_HOT_FOCUS] = PMENU_SELECTED_COLOR,
+    [DLG_COLOR_SELECTED_NORMAL] = PMENU_SELECTED_COLOR,  // unused
+    [DLG_COLOR_SELECTED_FOCUS] = PMENU_SELECTED_COLOR,   // unused
+    [DLG_COLOR_TITLE] = PMENU_TITLE_COLOR,
+    [DLG_COLOR_FRAME] = PMENU_FRAME_COLOR,
+};
+
 /*** file scope functions ************************************************************************/
 
 /* --------------------------------------------------------------------------------------------- */

--- a/src/editor/editdraw.c
+++ b/src/editor/editdraw.c
@@ -471,7 +471,7 @@ print_to_widget (WEdit *edit, long row, int start_col, int start_col_real, long 
         else if ((style & MOD_ABNORMAL) != 0)
             tty_setcolor (EDITOR_NONPRINTABLE_COLOR);
         else
-            tty_lowlevel_setcolor (p->style >> 16);
+            tty_setcolor (p->style >> 16);
 
         if (edit_options.show_right_margin)
         {

--- a/src/filemanager/boxes.c
+++ b/src/filemanager/boxes.c
@@ -155,10 +155,6 @@ skin_apply (const gchar *skin_override)
     mc_skin_init (skin_override, &mcerror);
     mc_fhl_free (&mc_filehighlight);
     mc_filehighlight = mc_fhl_new (TRUE);
-    dlg_set_default_colors ();
-    input_set_default_colors ();
-    if (mc_global.mc_run_mode == MC_RUN_FULL)
-        command_set_default_colors ();
     panel_deinit ();
     panel_init ();
     repaint_screen ();

--- a/src/filemanager/command.c
+++ b/src/filemanager/command.c
@@ -68,7 +68,12 @@ WInput *cmdline;
 /*** file scope variables ************************************************************************/
 
 /* Color styles command line */
-static input_colors_t command_colors;
+static const input_colors_t command_colors = {
+    [INPUT_COLOR_MAIN] = CORE_DEFAULT_COLOR,
+    [INPUT_COLOR_MARK] = CORE_COMMAND_MARK_COLOR,
+    [INPUT_COLOR_UNCHANGED] = CORE_DEFAULT_COLOR,
+    [INPUT_COLOR_HISTORY] = CORE_COMMAND_HISTORY_COLOR,
+};
 
 /* --------------------------------------------------------------------------------------------- */
 /*** file scope functions ************************************************************************/
@@ -219,20 +224,6 @@ command_new (int y, int x, int cols)
     w->callback = command_callback;
 
     return cmd;
-}
-
-/* --------------------------------------------------------------------------------------------- */
-/**
- * Set colors for the command line.
- */
-
-void
-command_set_default_colors (void)
-{
-    command_colors[INPUT_COLOR_MAIN] = CORE_DEFAULT_COLOR;
-    command_colors[INPUT_COLOR_MARK] = CORE_COMMAND_MARK_COLOR;
-    command_colors[INPUT_COLOR_UNCHANGED] = CORE_DEFAULT_COLOR;
-    command_colors[INPUT_COLOR_HISTORY] = CORE_COMMAND_HISTORY_COLOR;
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/src/filemanager/command.c
+++ b/src/filemanager/command.c
@@ -229,10 +229,10 @@ command_new (int y, int x, int cols)
 void
 command_set_default_colors (void)
 {
-    command_colors[WINPUTC_MAIN] = CORE_DEFAULT_COLOR;
-    command_colors[WINPUTC_MARK] = CORE_COMMAND_MARK_COLOR;
-    command_colors[WINPUTC_UNCHANGED] = CORE_DEFAULT_COLOR;
-    command_colors[WINPUTC_HISTORY] = CORE_COMMAND_HISTORY_COLOR;
+    command_colors[INPUT_COLOR_MAIN] = CORE_DEFAULT_COLOR;
+    command_colors[INPUT_COLOR_MARK] = CORE_COMMAND_MARK_COLOR;
+    command_colors[INPUT_COLOR_UNCHANGED] = CORE_DEFAULT_COLOR;
+    command_colors[INPUT_COLOR_HISTORY] = CORE_COMMAND_HISTORY_COLOR;
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/src/filemanager/command.h
+++ b/src/filemanager/command.h
@@ -20,7 +20,6 @@ extern WInput *cmdline;
 /*** declarations of public functions ************************************************************/
 
 WInput *command_new (int y, int x, int len);
-void command_set_default_colors (void);
 void command_insert (WInput *in, const char *text, gboolean insert_extra_space);
 
 /*** inline functions ****************************************************************************/

--- a/src/filemanager/panel.c
+++ b/src/filemanager/panel.c
@@ -333,10 +333,8 @@ add_permission_string (const char *dest, int width, file_entry_t *fe, file_attr_
             else
                 tty_setcolor (CORE_MARKED_COLOR);
         }
-        else if (color >= 0)
-            tty_setcolor (color);
         else
-            tty_lowlevel_setcolor (-color);
+            tty_setcolor (color);
 
         tty_print_char (dest[i]);
     }
@@ -654,17 +652,17 @@ file_compute_color (const file_attr_t attr, file_entry_t *fe)
     switch (attr)
     {
     case FATTR_CURRENT:
-        return (CORE_SELECTED_COLOR);
+        return CORE_SELECTED_COLOR;
     case FATTR_MARKED:
-        return (CORE_MARKED_COLOR);
+        return CORE_MARKED_COLOR;
     case FATTR_MARKED_CURRENT:
-        return (CORE_MARKED_SELECTED_COLOR);
+        return CORE_MARKED_SELECTED_COLOR;
     case FATTR_STATUS:
-        return (CORE_NORMAL_COLOR);
+        return CORE_NORMAL_COLOR;
     case FATTR_NORMAL:
     default:
         if (!panels_options.filetype_mode)
-            return (CORE_NORMAL_COLOR);
+            return CORE_NORMAL_COLOR;
     }
 
     return mc_fhl_get_color (mc_filehighlight, fe);
@@ -752,10 +750,7 @@ format_file (WPanel *panel, int file_index, int width, file_attr_t attr, gboolea
                     perm = 2;
             }
 
-            if (color >= 0)
-                tty_setcolor (color);
-            else
-                tty_lowlevel_setcolor (-color);
+            tty_setcolor (color);
 
             if (!isstatus)
                 prepared_text = str_fit_to_term (txt + name_offset, len, HIDE_FIT (fi->just_mode));

--- a/src/help.c
+++ b/src/help.c
@@ -113,6 +113,17 @@ static struct
 static GSList *link_area = NULL;
 static gboolean inside_link_area = FALSE;
 
+static const dlg_colors_t help_colors = {
+    [DLG_COLOR_NORMAL] = HELP_NORMAL_COLOR,
+    [DLG_COLOR_FOCUS] = 0,  // unused
+    [DLG_COLOR_HOT_NORMAL] = HELP_BOLD_COLOR,
+    [DLG_COLOR_HOT_FOCUS] = 0,        // unused
+    [DLG_COLOR_SELECTED_NORMAL] = 0,  // unused
+    [DLG_COLOR_SELECTED_FOCUS] = 0,   // unused
+    [DLG_COLOR_TITLE] = HELP_TITLE_COLOR,
+    [DLG_COLOR_FRAME] = HELP_FRAME_COLOR,
+};
+
 /* --------------------------------------------------------------------------------------------- */
 /*** file scope functions ************************************************************************/
 /* --------------------------------------------------------------------------------------------- */

--- a/src/main.c
+++ b/src/main.c
@@ -364,13 +364,9 @@ main (int argc, char *argv[])
     macros_list = g_array_new (TRUE, FALSE, sizeof (macros_t));
 #endif
 
-    tty_init_colors (mc_global.tty.disable_colors, mc_args__force_colors);
+    tty_init_colors (mc_global.tty.disable_colors, mc_args__force_colors, COLOR_MAP_SIZE);
 
     mc_skin_init (NULL, &mcerror);
-    dlg_set_default_colors ();
-    input_set_default_colors ();
-    if (mc_global.mc_run_mode == MC_RUN_FULL)
-        command_set_default_colors ();
 
     mc_error_message (&mcerror, NULL);
 


### PR DESCRIPTION
What would you guys think of a color handling refactoring along these lines?

The current code does the resolution from the _role_ (e.g. "dialog's title color") to the ncurses/slang color pair id as soon as possible.

A significant drawback of this design is that initializing some color constant (e.g. the ones used for normal, error, listbox and help dialogs), or later adjusting these values upon a runtime skin change are pretty cumbersome. Either some locally used colors need to be defined in a much more global context (pointed out as unfortunate design twice during code review: https://github.com/MidnightCommander/mc/pull/4916#issuecomment-3591709937 and https://github.com/MidnightCommander/mc/pull/4976#discussion_r2736867667), or the code that switches the skin needs to dig deep down into the territory of individual widgets to change the color they use.

My idea is to instead carry the color role identifier for as long as possible, and only resolve to the actual color when it comes to painting. This way only the color cache needs to be updated from the new skin; widget's idea on which color (i.e. color role) to use remains the same.

We have those 80-ish uppercase variables like `CORE_NORMAL_COLOR` etc. Currently it's pretty counterintuitive that despite the uppercase naming, these are variables and do change at a skin change. Yet, for some reason, they aren't declared as individual variables but as members of an array, so we have to maintain their indexing and manually renumber every time a new item is added.

With my suggestion, these become constants (actually enum values) as their name suggests, and we no longer have to manually index them.

Now, due to having two places in mc that bypass these variables, namely file highligthing and editor syntax highlighting, the story becomes a bit more complex. Sometimes we know the color role id, yet to be resolved to an ncurses/slang color pair id, but sometimes the latter one is the only thing we have.

Might not be the cleanest design per se, but I just distinguish these two based on how large the value is: if the value is low then it refers directly to the ncurses/slang color pair id; if the value is large (above the arbitrarily picked 4096) then it's a color role id which still needs a hop to resolve. This sort of pattern already exists in mc's file highlighting code where negative vs. positive values have different roles, although it looks to me it's legacy leftover because both are just color pair id, the negative ones will simply be flipped to positive (and, by the way, due to two faulty `ret > 0` checks rather than `ret >= 0`, color pair id 0 (i.e. the terminal's default colors) can't be used for file highlighting; something that probably nobody cares about). I've ported this negative vs. positive split to the new ranges.

No more conceptual `tty_setcolor()` vs. `tty_lowlevel_setcolor()` separation (although it was probably a legacy anyway, they were identical, except for a `& 0x7F` mask in slang that I don't understand), now by design there's a single method only which decides based on the value (small vs. large) how to handle it.

As you can see, the initialization of `command_colors` etc. becomes compile-time rather than runtime, no need to reinitialize at skin change, and easy to move all of them where they really belong.

I've moved `CORE_NORMAL_COLOR` etc. from the upper level skin layer to the lower level tty layer because `tty_setcolor()` now needs to know about them, and I didn't want tty to know about skin. This is debatable where it should really go, what the new variables / types / etc. should be named, and so on, suggestions welcome.

Let me know please how you like the overall direction.
