### PR TITLE
doc: Remove a duplicated sentence from skins' README.txt

### DIFF
--- a/misc/skins/README.txt
+++ b/misc/skins/README.txt
@@ -420,8 +420,6 @@ Aliases section
             [core]
                 _default_ = myfavfg;myfavbg;myfavattr
 
-        Aliases can refer to other aliases as long as they don't form a loop.
-
 
 Color pair and attribute definitions
 ====================================


### PR DESCRIPTION
## Proposed changes

Remove a trivial editing mistake, a sentence duplicated a few lines apart.

(This change is so trivial that I'm merging right away if the system allows me to.)