### PR TITLE
Disable colors if NO_COLOR env var is present and nonempty

### DIFF
--- a/doc/man/mc.1.in
+++ b/doc/man/mc.1.in
@@ -20,7 +20,9 @@ Unix\-like operating systems.
 Disable usage of graphic characters for line drawing.
 .TP
 .I \-b, \-\-nocolor
-Force black and white display.
+Force black and white display. Setting the
+.B NO_COLOR
+environment variable to a nonempty value has the same effect.
 .TP
 .I \-c, \-\-color
 Force color mode, please check the section

--- a/doc/man/mcdiff.1.in
+++ b/doc/man/mcdiff.1.in
@@ -18,7 +18,9 @@ specified on the command line.
 .SH OPTIONS
 .TP
 .I "\-b"
-Force black and white display.
+Force black and white display. Setting the
+.B NO_COLOR
+environment variable to a nonempty value has the same effect.
 .TP
 .I "\-c"
 Force color mode on terminals where

--- a/doc/man/mcedit.1.in
+++ b/doc/man/mcedit.1.in
@@ -25,7 +25,9 @@ sign and the number). Several line numbers are allowed but only the last one
 will be used, and it will be applied to the first file only.
 .TP
 .I "\-b"
-Force black and white display.
+Force black and white display. Setting the
+.B NO_COLOR
+environment variable to a nonempty value has the same effect.
 .TP
 .I "\-c"
 Force ANSI color mode on terminals that don't seem to have color

--- a/doc/man/mcview.1.in
+++ b/doc/man/mcview.1.in
@@ -16,7 +16,9 @@ specified on the command line.
 .SH OPTIONS
 .TP
 .I "\-b"
-Force black and white display.
+Force black and white display. Setting the
+.B NO_COLOR
+environment variable to a nonempty value has the same effect.
 .TP
 .I "\-c"
 Force color mode on terminals where

--- a/src/args.c
+++ b/src/args.c
@@ -612,10 +612,16 @@ mc_setup_run_mode (char **argv)
 gboolean
 mc_args_parse (int *argc, char ***argv, const char *translation_domain, GError **mcerror)
 {
+    const char *nocolor_env;
     const gchar *_system_codepage;
     gboolean ok = TRUE;
 
     mc_return_val_if_error (mcerror, FALSE);
+
+    // https://no-color.org/ - avoid colors if NO_COLOR is nonempty, unless overridden in cmdline
+    nocolor_env = getenv ("NO_COLOR");
+    if (nocolor_env != NULL && nocolor_env[0] != '\0')
+        mc_global.tty.disable_colors = TRUE;
 
     _system_codepage = str_detect_termencoding ();
 


### PR DESCRIPTION
## Proposed changes

Disable colors when environment variable `NO_COLOR` is present and nonempty, according to the "standard" described in http://no-color.org/

## Checklist

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)

---

This was already submitted a long time ago, at https://github.com/MidnightCommander/mc-old/pull/133. Then it was closed without mc devs expressing their opinions.

Since then, a couple of things have changed:
- The standard fixed the handling of the env var's empty value.
- They clarified that app-specific options should be able to override it.
- They sort of clarified a few things on their homepage (it's not super-duper obvious, but I have the strong impression that they're fine with attributes like reverse video, but ANSI colors (even grayscale) are not okay.
- mc's black and white mode was fixed recently, and it happens to match this previous requirement.
- mc's development has moved here to github.
- The number of supporting projects listed on the no-color homepage has grown from 3 to 257.

NO_COLOR is still a somewhat controversial initiative, several people have expressed that it should have been done differently, but it's definitely gaining traction. With about 4 lines of source code, why not join them?

@RauliL I've prepared the change in your name as the original author. I had to modify two things: the handling of the empty value, and moving the code elsewhere so that `--color` can override it. Neither were your fault: the standard changed since then.

It's signed-off-by me. Not sure how it should be done ideally, but I don't think I should add someone else's name _there_. Please let me know if you have any comment or preference; maybe the cleanest would be if you could take back full ownership and re-submit the PR fully under your name?
