### PR TITLE
Add MashDark skin

### DIFF
--- a/misc/skins/Makefile.am
+++ b/misc/skins/Makefile.am
@@ -12,6 +12,7 @@ SKINS = \
 	gray-orange-blue256.ini \
 	julia256.ini \
 	julia256root.ini \
+	mashdark256.ini \
 	mc46.ini \
 	modarcon16-defbg.ini \
 	modarcon16-defbg-thin.ini \

--- a/misc/skins/mashdark256.ini
+++ b/misc/skins/mashdark256.ini
@@ -1,0 +1,199 @@
+#
+# MashDark Midnight Commander skin
+#
+# See https://github.com/notnout/mashdark
+#
+
+[skin]
+    description = MashDark Skin
+    256colors = true
+
+[aliases]
+    # --- Backgrounds (Surface colors) ---
+    bg-main = color233
+    bg-menu = color235
+    bg-dialog = color238
+    bg-error = color52
+
+    # --- Foregrounds (Text colors) ---
+    fg-main = color231
+    fg-inactive = color246
+
+    # --- Accents (The "Pop" colors) ---
+    fg-accent = color214
+    bg-selection = color60
+    bg-secondary = color94
+
+    # --- Frames & Borders ---
+    fg-frame-main = color238
+    fg-frame-dialog = color243
+
+[lines]
+    horiz = ─
+    vert = │
+    lefttop = ╭
+    righttop = ╮
+    leftbottom = ╰
+    rightbottom = ╯
+    topmiddle = ┬
+    bottommiddle = ┴
+    leftmiddle = ├
+    rightmiddle = ┤
+    cross = ┼
+    dhoriz = ─
+    dvert = │
+    dlefttop = ╭
+    drighttop = ╮
+    dleftbottom = ╰
+    drightbottom = ╯
+    dtopmiddle = ─
+    dbottommiddle = ─
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[core]
+    _default_ = color246;bg-main
+    selected = fg-main;bg-selection
+    marked = fg-main;bg-secondary;bold
+    markselect = fg-main;color172;bold
+    gauge = color9;bg-secondary
+    input = color187;color235;bold
+    inputmark = color228;color88;bold
+    inputunchanged = color144;color235;bold
+    hintbar = fg-inactive;bg-main
+    shellprompt = fg-main;bg-main
+    commandline = fg-main;bg-main
+    commandlinemark = color228;color88;bold
+    reverse = color254;bg-secondary
+    header = color241;;bold
+    disabled = fg-inactive;color238
+    inputhistory = color187;color235
+    #commandhistory =
+    frame = fg-frame-main
+    shadow = color236;color232
+
+[dialog]
+    _default_ = color252;bg-dialog
+    dhotnormal = fg-accent
+    dfocus = fg-main;bg-secondary;bold
+    dhotfocus = color220;bg-secondary;bold
+    dselnormal = color228;color23;bold
+    dselfocus = fg-main;bg-selection
+    dtitle = color222;;bold
+    dframe = fg-frame-dialog
+
+[error]
+    _default_ = color230;bg-error
+    errdfocus = color254;color95;bold
+    errdhotnormal = color203
+    errdhotfocus = color203;color95;bold
+    errdtitle = color227;;bold
+    errdframe = color88
+
+[filehighlight]
+    _default_ = fg-main
+    directory = fg-main
+    executable = color114
+    symlink = color45
+    hardlink =
+    stalelink = color203
+    device = color170
+    special = color142
+    core = color197
+    temp = color245
+    archive = color172
+    doc = color153
+    source = color109
+    media = color141
+    graph = color216
+    database = color103
+
+[menu]
+    _default_ = color252;bg-menu
+    menusel = color254;bg-selection
+    menuhot = fg-accent
+    menuhotsel = fg-accent;bg-selection
+    menuinactive = fg-inactive
+    menuframe = fg-frame-main
+
+[popupmenu]
+    _default_ = color252;bg-menu
+    menusel = fg-main;bg-secondary;bold
+    menutitle = color222;;bold
+    menuframe = fg-frame-main
+
+[buttonbar]
+    button = color253;bg-menu
+    hotkey = fg-accent;color234;bold
+
+[statusbar]
+    _default_ = color254;bg-menu
+
+[help]
+    _default_ = color252;bg-menu
+    helpitalic = color114;;bold
+    helpbold = color180;;bold
+    helplink = color45
+    helpslink = color231;bg-secondary;bold
+    helptitle = color222;;bold
+    helpframe = fg-frame-main
+
+[editor]
+    _default_ = color252;bg-main
+    editbold = color228;;bold
+    editmarked = color231;bg-selection;bold
+    editwhitespace = color53;bg-main
+    # editnonprintable =
+    editrightmargin = ;bg-main
+    editlinestate = color240;color234
+    editbg = ;bg-main
+    bookmark = ;color237
+    bookmarkfound = ;color237;bold
+    editframe = fg-frame-main
+    editframeactive = color240
+    # editframedrag =
+
+[viewer]
+    _default_ = color252;bg-main
+    viewbold = ;;bold
+    viewunderline = ;;underline
+    viewboldunderline = ;;bold+underline
+    viewselected = fg-main;bg-selection;bold
+    viewframe = fg-frame-main
+
+[diffviewer]
+    _default_ = color252;color234
+    changedline = color231;color130
+    changednew = color232;color208
+    changed = color231;color64
+    added = color232;color106
+    removed = ;color235
+    error = color231;color160
+
+[widget-common]
+    sort-sign-up = ↑
+    sort-sign-down = ↓
+
+[widget-panel]
+    sort-up-char = ↑
+    sort-down-char = ↓
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ‹
+    history-next-item-char = ›
+    history-show-list-char = ʜ
+    filename-scroll-left-char = ❬
+    filename-scroll-right-char = ❭
+
+[widget-scrollbar]
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕
+


### PR DESCRIPTION
## Proposed changes

Adding new dark MashDark skin. This skin is using multiple new features, like styling borders separately and styling default files.

* Refs: #4553

## Checklist
- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)

<img width="1520" height="973" alt="Screenshot_2026-02-06_15-58-48" src="https://github.com/user-attachments/assets/8d9d350f-d333-4804-99bd-fcaaa23fffe4" />
