### PR TITLE
syntax: fix TOML / add Kconfig syntax highlighting

### DIFF
--- a/misc/syntax/Makefile.am
+++ b/misc/syntax/Makefile.am
@@ -50,6 +50,7 @@ SYNTAXFILES =			\
 	java.syntax		\
 	js.syntax		\
 	json.syntax		\
+	kconfig.syntax		\
 	kotlin.syntax		\
 	latex.syntax		\
 	lisp.syntax		\

--- a/misc/syntax/Makefile.am
+++ b/misc/syntax/Makefile.am
@@ -51,6 +51,7 @@ SYNTAXFILES =			\
 	java.syntax		\
 	js.syntax		\
 	json.syntax		\
+	kconfig.syntax		\
 	kotlin.syntax		\
 	latex.syntax		\
 	lisp.syntax		\

--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -369,5 +369,8 @@ include dockerfile.syntax
 file (/Kconfig(\\.[A-z0-9-]\+)\*|/Config\\.(in|src)(\\.[A-z0-9-]\+)\*|.\*\\.kconf(ig)?)$ Kconfig
 include kconfig.syntax
 
+file ..\*(\\.config(\\.[A-z0-9-]\+)\*|defconfig)$ Kconfig\soutput
+include properties.syntax
+
 file .\* unknown
 include unknown.syntax

--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -366,5 +366,8 @@ include caddyfile.syntax
 file Dockerfile.\*$ Dockerfile
 include dockerfile.syntax
 
+file (/Kconfig(\\.[A-z0-9-]\+)\*|/Config\\.(in|src)(\\.[A-z0-9-]\+)\*|.\*\\.kconf(ig)?)$ Kconfig
+include kconfig.syntax
+
 file .\* unknown
 include unknown.syntax

--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -378,5 +378,8 @@ include tree-meta.syntax
 file (/Kconfig(\\.[A-z0-9-]\+)?|/Config\\.(in|src)(\\.[A-z0-9-]\+)?|.\*\\.kconf(ig)?)$ Kconfig
 include kconfig.syntax
 
+file ..\*(\\.config(\\.[A-z0-9-]\+)?|defconfig)$ Kconfig\soutput
+include properties.syntax
+
 file .\* unknown
 include unknown.syntax

--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -375,5 +375,8 @@ include meta-ii.syntax
 file ..\*\\.(?i:tmo?)$ TREE-META\sMetasyntax
 include tree-meta.syntax
 
+file (/Kconfig(\\.[A-z0-9-]\+)?|/Config\\.(in|src)(\\.[A-z0-9-]\+)?|.\*\\.kconf(ig)?)$ Kconfig
+include kconfig.syntax
+
 file .\* unknown
 include unknown.syntax

--- a/misc/syntax/kconfig.syntax
+++ b/misc/syntax/kconfig.syntax
@@ -1,0 +1,83 @@
+# Kconfig syntax
+#
+# Specifications:
+# https://docs.kernel.org/kbuild/kconfig-language.html
+# https://github.com/ulfalizer/Kconfiglib?tab=readme-ov-file#kconfig-extensions
+
+define kword     yellow
+define type      brightmagenta
+define property  brightmagenta
+define condition yellow
+define operator  brightcyan
+define brace     brightcyan
+define number    cyan
+define string    green
+define escape    brightgreen
+define comment   brown
+
+context default
+    keyword whole linestart \[\t\s\]config kword
+    keyword whole linestart \[\t\s\]menuconfig kword
+    keyword whole linestart \[\t\s\]menu kword
+    keyword whole linestart \[\t\s\]endmenu kword
+    keyword whole linestart \[\t\s\]mainmenu kword
+    keyword whole linestart \[\t\s\]choice kword
+    keyword whole linestart \[\t\s\]endchoice kword
+    keyword whole linestart \[\t\s\]comment kword
+    keyword whole linestart \[\t\s\]source kword
+    keyword whole linestart \[\t\s\]osource kword
+    keyword whole linestart \[\t\s\]rsource kword
+    keyword whole linestart \[\t\s\]orsource kword
+
+    keyword whole if condition
+    keyword whole linestart \[\t\s\]endif condition
+
+    keyword whole linestart \[\t\s\]bool type
+    keyword whole linestart \[\t\s\]tristate type
+    keyword whole linestart \[\t\s\]string type
+    keyword whole linestart \[\t\s\]hex type
+    keyword whole linestart \[\t\s\]int type
+
+    keyword whole linestart \[\t\s\]def_bool type
+    keyword whole linestart \[\t\s\]def_tristate type
+    keyword whole linestart \[\t\s\]def_string type
+    keyword whole linestart \[\t\s\]def_hex type
+    keyword whole linestart \[\t\s\]def_int type
+
+    keyword whole linestart \[\t\s\]prompt property
+    keyword whole linestart \[\t\s\]default property
+    keyword whole linestart \[\t\s\]depends\son property
+    keyword whole linestart \[\t\s\]select property
+    keyword whole linestart \[\t\s\]imply property
+    keyword whole linestart \[\t\s\]transitional property
+    keyword whole linestart \[\t\s\]visible\sif property
+    keyword whole linestart \[\t\s\]range property
+    keyword whole linestart \[\t\s\]option property
+    keyword whole linestart \[\t\s\]optional property
+    keyword whole linestart \[\t\s\]help property
+    keyword whole linestart \[\t\s\]---help--- property
+
+    keyword = operator
+    keyword > operator
+    keyword < operator
+    keyword >= operator
+    keyword <= operator
+    keyword || operator
+    keyword && operator
+    keyword ! operator
+
+    keyword ( brace
+    keyword ) brace
+
+    keyword whole 0x\{0123456789ABCDEFabcdef\}\[0123456789ABCDEFabcdef\] number
+    keyword whole \{0123456789\}\[0123456789\] number
+
+    # sometimes quotes are escaped in help like \"foo\" => do not start string context
+    keyword \\"
+
+context # \n comment
+    spellcheck
+
+context " " string
+    keyword \\" escape
+    keyword \\\\ escape

--- a/misc/syntax/toml.syntax
+++ b/misc/syntax/toml.syntax
@@ -1,22 +1,54 @@
 # TOML: Tom's Obvious Minimal Language
+#
+# Specification: https://toml.io/en/v1.1.0
 
-context default white
+define table   yellow
+define key     cyan
+define equal   white
+define brace   brightcyan
+define bool    cyan
+define number  cyan
+define string  green
+define escape  brightgreen
+define comment brown
 
-# groups
-context [ \n brown
-    keyword [ yellow
-    keyword ] yellow
+context default
+    keyword linestart \[\t\s\][[*]] table
+    keyword linestart \[\t\s\][*] table
 
-# assignment
-context exclusive = \n write
-    keyword "*" brightgreen
-    keyword whole false brightcyan
-    keyword whole true brightcyan
-    keyword \{0123456789\} brightcyan
+    keyword = equal
+    keyword [ brace
+    keyword ] brace
+    keyword { brace
+    keyword } brace
 
-# comments
-context # \n brown
+    keyword linestart \[\t\s\]\{0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_-\}\[0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_-.\] key
+
+    keyword whole true bool
+    keyword whole false bool
+
+    keyword whole inf number
+    keyword whole nan number
+
+    keyword whole 0\{box\}\{0123456789ABCDEFabcdef\}\[0123456789ABCDEFabcdef_\] number
+    keyword whole \{0123456789\}\[0123456789_\]\{eE\}\[0123456789_\] number
+    keyword whole \{0123456789\}\[0123456789_\] number
+
+context # \n comment
     spellcheck
 
-# other strings
-context " " brightgreen
+context """ """ string
+    keyword \\" escape
+    keyword \\\\ escape
+    keyword \\\{uU\}\[0123456789\] escape
+    keyword \\\{bfnrt\} escape
+
+context ''' ''' string
+
+context " " string
+    keyword \\" escape
+    keyword \\\\ escape
+    keyword \\\{uU\}\[0123456789\] escape
+    keyword \\\{bfnrt\} escape
+
+context ' ' string


### PR DESCRIPTION
## Proposed changes

Improve syntax highlighting:

- Resolves: #4933
- Resolves: #5003

Highlight Kconfig output files.

## Checklist

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [ ] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)

I've not tried to build / install mc - I tested my changes on existing installation by modifying `/usr/share/mc/syntax/*` files.