### PR TITLE
Ticket #5016: Remove OSC 8 markers when generating Help pages

### DIFF
--- a/src/man2hlp/man2hlp.in
+++ b/src/man2hlp/man2hlp.in
@@ -774,6 +774,7 @@ sub main
         }
 
         $in_row++;
+        $input_line =~ s/\X'tty:.*?'//g;  # Eliminate OSC 8 hyperlink targets
         $len = length($input_line);
 
         if ($verbatim_flag)


### PR DESCRIPTION
This fixes a regression introduced by commit fdbb1c0e1.

* Resolves: #5016

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
