### PR TITLE
Ticket #5018: Color pairs beyond 256

### DIFF
--- a/lib/tty/color-ncurses.c
+++ b/lib/tty/color-ncurses.c
@@ -192,7 +192,7 @@ tty_color_try_alloc_lib_pair (tty_color_lib_pair_t *mc_color_pair)
 void
 tty_setcolor (int color)
 {
-    attrset (COLOR_PAIR (color) | color_get_attr (color));
+    attr_set (color_get_attr (color), color, NULL);
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/tty/color-slang.c
+++ b/lib/tty/color-slang.c
@@ -168,7 +168,7 @@ tty_setcolor (int color)
 void
 tty_lowlevel_setcolor (int color)
 {
-    SLsmg_set_color (color & 0x7F);
+    SLsmg_set_color (color);
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/src/editor/editwidget.h
+++ b/src/editor/editwidget.h
@@ -35,8 +35,8 @@ struct edit_syntax_rule_t
 {
     unsigned short keyword;
     off_t end;
-    unsigned char context;
-    unsigned char _context;
+    unsigned short context;
+    unsigned short _context;
     unsigned char border;
 };
 


### PR DESCRIPTION
## Proposed changes

editor: Allow more contexts per syntax highlighting rule
tty: Allow more than 128 / 256 color pairs

* Resolves: #5018

## Checklist

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
