### PR TITLE
Add QML syntax to editor

### DIFF
--- a/misc/syntax/Makefile.am
+++ b/misc/syntax/Makefile.am
@@ -82,6 +82,7 @@ SYNTAXFILES =			\
 	protobuf.syntax		\
 	puppet.syntax		\
 	python.syntax		\
+	qml.syntax		\
 	r.syntax		\
 	ruby.syntax		\
 	rust.syntax		\

--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -366,5 +366,8 @@ include caddyfile.syntax
 file Dockerfile.\*$ Dockerfile
 include dockerfile.syntax
 
+file .\*\\.qml$ QML\sFile
+include qml.syntax
+
 file .\* unknown
 include unknown.syntax

--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -375,5 +375,8 @@ include meta-ii.syntax
 file ..\*\\.(?i:tmo?)$ TREE-META\sMetasyntax
 include tree-meta.syntax
 
+file ..\*\\.qml$ QML\sFile
+include qml.syntax
+
 file .\* unknown
 include unknown.syntax

--- a/misc/syntax/qml.syntax
+++ b/misc/syntax/qml.syntax
@@ -1,0 +1,380 @@
+#
+# QML/JavaScript syntax highlighting
+# for MC Editor/CoolEdit
+#
+# Authors:
+#    * Vlad Romanenko <VladRomanenko@ukr.net>
+#    * Timur Shemsedinov <timur.shemsedinov@gmail.com>
+#    * Pavel Roskin <proski@gnu.org>
+#    * Milian Wolff <mail@milianw.de>
+#    * Eugene Sanivsky <eugenesan@gmail.com>
+#
+# Based on c.syntax; includes js.syntax and borrows keywords from Kate's qml.xml
+#
+# 2026-02-20 - Eugene Sanivsky <eugenesan@gmail.com>
+#    * Initial public release
+#
+
+context default
+#=========================
+    # Elements (http://doc.trolltech.com/4.7-snapshot/qmlelements.html)
+    keyword whole State yellow
+    keyword whole PropertyChanges yellow
+    keyword whole StateGroup yellow
+    keyword whole ParentChange yellow
+    keyword whole StateChangeScript yellow
+    keyword whole AnchorChanges yellow
+    keyword whole PropertyAnimation yellow
+    keyword whole NumberAnimation yellow
+    keyword whole ColorAnimation yellow
+    keyword whole SequentialAnimation yellow
+    keyword whole ParallelAnimation yellow
+    keyword whole PauseAnimation yellow
+    keyword whole PropertyAction yellow
+    keyword whole ParentAction yellow
+    keyword whole ScriptAction yellow
+    keyword whole Transition yellow
+    keyword whole SpringFollow yellow
+    keyword whole EaseFollow yellow
+    keyword whole Behavior yellow
+    keyword whole Binding yellow
+    keyword whole ListModel yellow
+    keyword whole ListElement yellow
+    keyword whole VisualItemModel yellow
+    keyword whole XmlListModel yellow
+    keyword whole XmlRole yellow
+    keyword whole DateTimeFormatter yellow
+    keyword whole NumberFormatter yellow
+    keyword whole Script yellow
+    keyword whole Connections yellow
+    keyword whole Component yellow
+    keyword whole Timer yellow
+    keyword whole QtObject yellow
+    keyword whole Item yellow
+    keyword whole Rectangle yellow
+    keyword whole Image yellow
+    keyword whole BorderImage yellow
+    keyword whole Text yellow
+    keyword whole TextInput yellow
+    keyword whole TextEdit yellow
+    keyword whole MouseArea yellow
+    keyword whole FocusScope yellow
+    keyword whole Flickable yellow
+    keyword whole Flipable yellow
+    keyword whole WebView yellow
+    keyword whole Loader yellow
+    keyword whole Repeater yellow
+    keyword whole SystemPalette yellow
+    keyword whole GraphicsObjectContainer yellow
+    keyword whole LayoutItem yellow
+    keyword whole ListView yellow
+    keyword whole GridView yellow
+    keyword whole PathView yellow
+    keyword whole Path yellow
+    keyword whole PathLine yellow
+    keyword whole PathQuad yellow
+    keyword whole PathCubic yellow
+    keyword whole PathAttribute yellow
+    keyword whole PathPercent yellow
+    keyword whole Column yellow
+    keyword whole Row yellow
+    keyword whole Grid yellow
+    keyword whole Scale yellow
+    keyword whole Rotation yellow
+    keyword whole Blur yellow
+    keyword whole Colorize yellow
+    keyword whole DropShadow yellow
+    keyword whole Opacity yellow
+    keyword whole Particles yellow
+    keyword whole ParticleMotionLinear yellow
+    keyword whole ParticleMotionGravity yellow
+    keyword whole ParticleMotionWander yellow
+
+    # Some other items found in public code (need to be expanded)
+    keyword whole Gradient yellow
+    keyword whole GradientStop yellow
+    keyword whole MouseRegion yellow
+    keyword whole Enabled yellow
+
+    # keywords not part of JavaScript
+    # extra-keywords
+    keyword whole pragma yellow
+    keyword whole readonly yellow
+    keyword whole required yellow
+    keyword whole signal yellow
+    keyword whole alias yellow
+    keyword whole model yellow
+    keyword whole target yellow
+    keyword whole parent yellow
+    keyword whole value yellow
+    keyword whole anchors yellow
+    keyword whole when yellow
+    keyword whole enum yellow
+
+    # types (http://doc.trolltech.com/4.7-snapshot/qml-extending-types.html)
+    keyword whole string yellow
+    keyword whole int yellow
+    keyword whole bool yellow
+    keyword whole date yellow
+    keyword whole color yellow
+    keyword whole url yellow
+    keyword whole real yellow
+    keyword whole double yellow
+    keyword whole var yellow
+    keyword whole variant yellow
+
+    # Class keywords
+    keyword whole property brightcyan
+    keyword whole id brightcyan
+    keyword whole active brightcyan
+    keyword whole inactive brightcyan
+    keyword whole enabled brightcyan
+
+    #=========================
+    # Keywords
+    keyword whole arguments yellow
+    keyword whole async yellow
+    keyword whole await yellow
+    keyword whole break yellow
+    keyword whole caller yellow
+    keyword whole case yellow
+    keyword whole catch yellow
+    keyword whole class yellow
+    keyword whole const yellow
+    keyword whole constructor yellow
+    keyword whole continue yellow
+    keyword whole debugger yellow
+    keyword whole default yellow
+    keyword whole delete yellow
+    keyword whole do yellow
+    keyword whole else yellow
+    keyword whole export yellow
+    keyword whole extends yellow
+    keyword whole finally yellow
+    keyword whole for yellow
+    keyword whole function yellow
+    keyword whole if yellow
+    keyword whole import yellow
+    keyword whole in yellow
+    keyword whole instanceof yellow
+    keyword whole let yellow
+    keyword whole new yellow
+    keyword whole of yellow
+    keyword whole prototype yellow
+    keyword whole return yellow
+    keyword whole super yellow
+    keyword whole switch yellow
+    keyword whole this yellow
+    keyword whole throw yellow
+    keyword whole try yellow
+    keyword whole typeof yellow
+    keyword whole var yellow
+    keyword whole void yellow
+    keyword whole while yellow
+    keyword whole with yellow
+    keyword whole yield yellow
+
+    #=========================
+    # Objects
+    keyword whole AbortController yellow
+    keyword whole AbortSignal yellow
+    keyword whole AggregateError yellow
+    keyword whole Array yellow
+    keyword whole ArrayBuffer yellow
+    keyword whole AsyncFunction yellow
+    keyword whole AsyncGenerator yellow
+    keyword whole AsyncGeneratorFunction yellow
+    keyword whole Atomics yellow
+    keyword whole BigInt64Array yellow
+    keyword whole BigInt yellow
+    keyword whole BigUint64Array yellow
+    keyword whole Blob yellowOB
+    keyword whole Boolean yellow
+    keyword whole Buffer yellow
+    keyword whole DataView yellow
+    keyword whole Date yellow
+    keyword whole DOMException yellow
+    keyword whole Error yellow
+    keyword whole EvalError yellow
+    keyword whole Float32Array yellow
+    keyword whole Float64Array yellow
+    keyword whole Function yellow
+    keyword whole Generator yellow
+    keyword whole GeneratorFunction yellow
+    keyword whole global yellow
+    keyword whole globalThis yellow
+    keyword whole Image yellow
+    keyword whole Infinity yellow
+    keyword whole Int16Array yellow
+    keyword whole Int32Array yellow
+    keyword whole Int8Array yellow
+    keyword whole Intl yellow
+    keyword whole JSON yellow
+    keyword whole Map yellow
+    keyword whole Math yellow
+    keyword whole Number yellow
+    keyword whole Object yellow
+    keyword whole Promise yellow
+    keyword whole Promise yellow
+    keyword whole Proxy yellow
+    keyword whole RangeError yellow
+    keyword whole ReferenceError yellow
+    keyword whole Reflect yellow
+    keyword whole RegExp yellow
+    keyword whole Set yellow
+    keyword whole SharedArrayBuffer yellow
+    keyword whole Symbol yellow
+    keyword whole SyntaxError yellow
+    keyword whole TextDecoder yellow
+    keyword whole TypeError yellow
+    keyword whole Uint16Array yellow
+    keyword whole Uint32Array yellow
+    keyword whole Uint8Array yellow
+    keyword whole Uint8ClampedArray yellow
+    keyword whole URIError yellow
+    keyword whole URL yellow
+    keyword whole URLSearchParams yellow
+    keyword whole WeakMap yellow
+    keyword whole WeakSet yellow
+    keyword whole WebAssembly yellow
+    keyword whole window yellow
+
+    #=========================
+    # Most common functions
+    keyword whole alert yellow
+    keyword whole clearInterval yellow
+    keyword whole clearTimeout yellow
+    keyword whole console yellow
+    keyword whole decodeURIComponent yellow
+    keyword whole decodeURI yellow
+    keyword whole encodeURIComponent yellow
+    keyword whole escape yellow
+    keyword whole eval yellow
+    keyword whole fetch yellow
+    keyword whole isFinite yellow
+    keyword whole isNaN yellow
+    keyword whole module yellow
+    keyword whole parseFloat yellow
+    keyword whole parseInt yellow
+    keyword whole performance yellow
+    keyword whole process yellow
+    keyword whole queueMicrotask yellow
+    keyword whole require yellow
+    keyword whole setImmediate yellow
+    keyword whole setInterval yellow
+    keyword whole setTimeout yellow
+    keyword whole structuredClone yellow
+    keyword whole unescape yellow
+
+    #=========================
+    # Constants
+    keyword whole true brightgreen
+    keyword whole false brightgreen
+    keyword whole null brightgreen
+    keyword whole undefined yellow
+    keyword whole NaN yellow
+    keyword whole __dirname yellow
+    keyword whole __filename yellow
+
+    #=========================
+    # Comments
+    keyword /\* brown
+    keyword \*/ brown
+    keyword // brown
+
+    #=========================
+    # Numbers
+    wholechars abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.
+
+    keyword whole 0\{xX\}\{0123456789abcdefABCDEF\}\[0123456789abcdefABCDEF\] brightgreen
+    keyword whole \{0123456789\}\[0123456789\] brightgreen
+    keyword whole \[0123456789\]\.\{0123456789\}\[0123456789\] brightgreen
+    keyword whole \{0123456789\}\[0123456789\]\.\[0123456789\] brightgreen
+    keyword whole \{0123456789\}\[0123456789\]\{eE\}\{0123456789\}\[0123456789\] brightgreen
+    keyword whole \{0123456789\}\[0123456789\]\{eE\}\{\-\+\}\{0123456789\}\[0123456789\] brightgreen
+    keyword whole \{0123456789\}\[0123456789\]\.\{0123456789\}\[0123456789\]\{eE\}\{0123456789\}\[0123456789\] brightgreen
+    keyword whole \{0123456789\}\[0123456789\]\.\{0123456789\}\[0123456789\]\{eE\}\{\-\+\}\{0123456789\}\[0123456789\] brightgreen
+
+    #=========================
+    # Special symbols
+    keyword => brightcyan
+    keyword \. yellow
+    keyword \* yellow
+    keyword \+ yellow
+    keyword - yellow
+    keyword / yellow
+    keyword % yellow
+    keyword = yellow
+    keyword ! yellow
+    keyword & yellow
+    keyword | yellow
+    keyword ^ yellow
+    keyword ~ yellow
+    keyword > yellow
+    keyword < yellow
+
+    #=========================
+    # Separators
+    keyword { brightcyan
+    keyword } brightcyan
+    keyword ( brightcyan
+    keyword ) brightcyan
+    keyword [ brightcyan
+    keyword ] brightcyan
+    keyword , brightcyan
+    keyword ? brightcyan
+    keyword : brightcyan
+    keyword ; brightmagenta
+
+
+#=============================
+# Comments
+
+context exclusive /\* \*/ brown
+    spellcheck
+    keyword whole BUG brightred
+    keyword whole FixMe brightred
+    keyword whole FIXME brightred
+    keyword whole Note brightred
+    keyword whole NOTE brightred
+    keyword whole ToDo brightred
+    keyword whole TODO brightred
+    keyword !!\[!\] brightred
+    keyword ??\[?\] brightred
+
+
+context exclusive // \n brown
+    spellcheck
+    keyword whole BUG brightred
+    keyword whole FixMe brightred
+    keyword whole FIXME brightred
+    keyword whole Note brightred
+    keyword whole NOTE brightred
+    keyword whole ToDo brightred
+    keyword whole TODO brightred
+    keyword !!\[!\] brightred
+    keyword ??\[?\] brightred
+
+
+#=============================
+# Strings
+
+context " " green
+    spellcheck
+    keyword \\\{\\'"abtnvfr\} brightgreen
+    keyword \\\{0123\}\{01234567\}\{01234567\} brightgreen
+
+    keyword ' brightgreen
+
+context ' ' green
+    spellcheck
+    keyword \\\{\\'"abtnvfr\} brightgreen
+    keyword \\\{0123\}\{01234567\}\{01234567\} brightgreen
+
+    keyword " brightgreen
+
+context ` ` green
+    spellcheck
+    keyword \\\{\\'"abtnvfr\} brightgreen
+    keyword \\\{0123\}\{01234567\}\{01234567\} brightgreen
+    keyword ${*} yellow


### PR DESCRIPTION
## Proposed changes

* Adds support for QML  (Qt declarative meta lang)

## Checklist

- [N/A] I have referenced the issue(s) resolved by this PR (if any)
- [V] I have signed-off my contribution with `git commit --amend -s`
- [N/A] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A ] I have added the necessary documentation (if appropriate)

## Discussion
Currently QML was added as a standalone syntax file.
I'd like to hear opinions if instead it should be added to existing JavaScript syntax (`js.syntax`) as they share ~70% of syntax and QML can contains JavaScript code.