### PR TITLE
Fix shadow color in ncurses build

### DIFF
--- a/lib/tty/tty-ncurses.c
+++ b/lib/tty/tty-ncurses.c
@@ -603,6 +603,7 @@ tty_colorize_area (int y, int x, int rows, int cols, int color)
     if (!use_colors || !tty_clip (&y, &x, &rows, &cols))
         return;
 
+    color = tty_maybe_map_color (color);
     tty_setcolor (color);
     ctext = g_malloc (sizeof (cchar_t) * (cols + 1));
 


### PR DESCRIPTION
This accidentally broke in commit a101d98bb.

## Checklist

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
