### PR TITLE
Learn keys: support Ctrl/Meta/Shift modifiers

### DIFF
--- a/tests/src/Makefile.am
+++ b/tests/src/Makefile.am
@@ -32,6 +32,7 @@ TESTS = \
 	execute__execute_external_editor_or_viewer \
 	execute__execute_get_external_cmd_opts_from_config \
 	file_history \
+	learn_modifiers \
 	usermenu__test_condition \
 	usermenu__test_expand_format
 
@@ -50,6 +51,9 @@ execute__execute_get_external_cmd_opts_from_config_SOURCES = \
 
 file_history_SOURCES = \
 	file_history.c
+
+learn_modifiers_SOURCES = \
+	learn_modifiers.c
 
 usermenu__test_condition_SOURCES = \
 	usermenu__test_condition.c

--- a/tests/src/learn_modifiers.c
+++ b/tests/src/learn_modifiers.c
@@ -1,0 +1,77 @@
+/*
+   src/learn - tests for modifier-aware key names
+
+   Copyright (C) 2026
+   Free Software Foundation, Inc.
+*/
+
+#define TEST_SUITE_NAME "/src/learn"
+
+#include "tests/mctest.h"
+
+#include "lib/tty/key.h"
+
+#include "src/learn.c"
+
+/* --------------------------------------------------------------------------------------------- */
+
+START_TEST (test_learn_build_key_name_without_modifiers)
+{
+    char *name;
+
+    name = learn_build_key_name ("up", 0);
+    mctest_assert_str_eq (name, "up");
+    g_free (name);
+}
+END_TEST
+
+/* --------------------------------------------------------------------------------------------- */
+
+START_TEST (test_learn_build_key_name_single_modifiers)
+{
+    char *name;
+
+    name = learn_build_key_name ("f9", KEY_M_CTRL);
+    mctest_assert_str_eq (name, "ctrl-f9");
+    g_free (name);
+
+    name = learn_build_key_name ("right", KEY_M_ALT);
+    mctest_assert_str_eq (name, "meta-right");
+    g_free (name);
+
+    name = learn_build_key_name ("left", KEY_M_SHIFT);
+    mctest_assert_str_eq (name, "shift-left");
+    g_free (name);
+}
+END_TEST
+
+/* --------------------------------------------------------------------------------------------- */
+
+START_TEST (test_learn_build_key_name_combined_modifiers)
+{
+    char *name;
+
+    name = learn_build_key_name ("up", KEY_M_CTRL | KEY_M_SHIFT);
+    mctest_assert_str_eq (name, "ctrl-shift-up");
+    g_free (name);
+
+    name = learn_build_key_name ("pgdn", KEY_M_CTRL | KEY_M_ALT | KEY_M_SHIFT);
+    mctest_assert_str_eq (name, "ctrl-meta-shift-pgdn");
+    g_free (name);
+}
+END_TEST
+
+/* --------------------------------------------------------------------------------------------- */
+
+int
+main (void)
+{
+    TCase *tc_core;
+
+    tc_core = tcase_create ("Core");
+    tcase_add_test (tc_core, test_learn_build_key_name_without_modifiers);
+    tcase_add_test (tc_core, test_learn_build_key_name_single_modifiers);
+    tcase_add_test (tc_core, test_learn_build_key_name_combined_modifiers);
+
+    return mctest_run_all (tc_core);
+}


### PR DESCRIPTION
Fixes #5027

## Summary
- Add Ctrl/Meta(Alt)/Shift modifier support to Learn Keys dialog.
- Save learned terminal key entries with modifier-aware key names.
- Keep existing learning flow, extending it with explicit modifier selection.

## Details
- Added modifier checkboxes in Learn Keys UI.
- Applied selected modifiers when building learned key definitions.
- Saved key names with prefixes like `ctrl-`, `meta-`, `shift-`.
- Updated key validation logic to account for selected modifiers.

## Testing
- Built in `../build` with `--enable-vfs-sftp=no` due local libssh2 link issue unrelated to this change.
- Ran `make -C tests/src learn_modifiers check-TESTS TESTS=learn_modifiers -j$(nproc)` (PASS).