### PR TITLE
Fix GString API migration regressions: lack of NUL after strncpy and use after free

### DIFF
--- a/src/filemanager/ext.c
+++ b/src/filemanager/ext.c
@@ -80,12 +80,12 @@
 
 /*** forward declarations (file scope functions) *************************************************/
 
-// To prevent compiler warnings from being generated with --enable-tests
+#if defined(HAVE_TESTS)
 MC_TESTABLE
 GString *exec_make_shell_string (const char *lc_data, const vfs_path_t *filename_vpath);
 
-// To prevent compiler warnings from being generated without --enable-tests
-#if defined(HAVE_TESTS)
+MC_TESTABLE GString *exec_get_export_variables (const vfs_path_t *filename_vpath);
+
 extern char buffer[BUF_1K];
 #endif
 
@@ -185,7 +185,7 @@ exec_expand_format (char symbol, gboolean is_result_quoted)
 
 /* --------------------------------------------------------------------------------------------- */
 
-static GString *
+MC_TESTABLE GString *
 exec_get_export_variables (const vfs_path_t *filename_vpath)
 {
     GString *text;

--- a/src/filemanager/ext.c
+++ b/src/filemanager/ext.c
@@ -80,6 +80,15 @@
 
 /*** forward declarations (file scope functions) *************************************************/
 
+// To prevent compiler warnings from being generated with --enable-tests
+MC_TESTABLE
+GString *exec_make_shell_string (const char *lc_data, const vfs_path_t *filename_vpath);
+
+// To prevent compiler warnings from being generated without --enable-tests
+#if defined(HAVE_TESTS)
+extern char buffer[BUF_1K];
+#endif
+
 /*** file scope variables ************************************************************************/
 
 /* This variable points to a copy of the mc.ext file in memory
@@ -89,7 +98,7 @@
 static mc_config_t *ext_ini = NULL;
 static gchar **ext_ini_groups = NULL;
 static vfs_path_t *localfilecopy_vpath = NULL;
-static char buffer[BUF_1K];
+MC_TESTABLE char buffer[BUF_1K];
 
 static char *pbuffer = NULL;
 static time_t localmtime = 0;
@@ -226,7 +235,7 @@ exec_get_export_variables (const vfs_path_t *filename_vpath)
 
 /* --------------------------------------------------------------------------------------------- */
 
-static GString *
+MC_TESTABLE GString *
 exec_make_shell_string (const char *lc_data, const vfs_path_t *filename_vpath)
 {
     GString *shell_string;
@@ -328,7 +337,7 @@ exec_make_shell_string (const char *lc_data, const vfs_path_t *filename_vpath)
                                     mc_g_string_concat (shell_string, text);
                                 else
                                 {
-                                    strncpy (pbuffer, text->str, text->len);
+                                    strncpy (pbuffer, text->str, text->len + 1);
                                     pbuffer = strchr (pbuffer, '\0');
                                 }
 

--- a/src/vfs/extfs/extfs.c
+++ b/src/vfs/extfs/extfs.c
@@ -956,10 +956,6 @@ extfs_cmd (const char *str_extfs_cmd, const struct extfs_super_t *archive,
         return (-1);
     }
 
-    // Skip leading "./" (if present) added in name_quote()
-    file = extfs_skip_leading_dotslash (quoted_file->str);
-    g_string_free (quoted_file, TRUE);
-
     archive_name = extfs_get_archive_name (archive);
     quoted_archive_name = name_quote (archive_name, FALSE);
     g_free (archive_name);
@@ -967,10 +963,14 @@ extfs_cmd (const char *str_extfs_cmd, const struct extfs_super_t *archive,
     if (quoted_archive_name == NULL)
     {
         message (D_ERROR, MSG_ERROR, _ ("EXTFS virtual file system:\nwrong archive name"));
+        g_string_free (quoted_file, TRUE);
         return (-1);
     }
 
     info = &g_array_index (extfs_plugins, extfs_plugin_info_t, archive->fstype);
+
+    // Skip leading "./" (if present) added in name_quote()
+    file = extfs_skip_leading_dotslash (quoted_file->str);
 
     cmd = g_string_new (info->path);
     g_string_append (cmd, info->prefix);
@@ -979,6 +979,7 @@ extfs_cmd (const char *str_extfs_cmd, const struct extfs_super_t *archive,
     g_string_append_c (cmd, ' ');
     g_string_append (cmd, file);
 
+    g_string_free (quoted_file, TRUE);
     g_string_free (quoted_archive_name, TRUE);
 
     if (localname != NULL && *localname != '\0')

--- a/tests/src/filemanager/Makefile.am
+++ b/tests/src/filemanager/Makefile.am
@@ -19,6 +19,7 @@ TESTS = \
 	cd_to \
 	examine_cd \
 	exec_get_export_variables_ext \
+	ext__exec_make_shell_string \
 	filegui_is_wildcarded \
 	get_random_hint
 
@@ -32,6 +33,9 @@ examine_cd_SOURCES = \
 
 exec_get_export_variables_ext_SOURCES = \
 	exec_get_export_variables_ext.c
+
+ext__exec_make_shell_string_SOURCES = \
+	ext__exec_make_shell_string.c
 
 get_random_hint_SOURCES = \
 	get_random_hint.c

--- a/tests/src/filemanager/exec_get_export_variables_ext.c
+++ b/tests/src/filemanager/exec_get_export_variables_ext.c
@@ -28,14 +28,14 @@
 #include "tests/mctest.h"
 
 #include "lib/file-entry.h"
+#include "src/filemanager/filemanager.h"
 
 #include "src/vfs/local/local.c"
 
-#include "src/filemanager/ext.c"
+MC_TESTABLE GString *exec_get_export_variables (const vfs_path_t *filename_vpath);
 
 /* --------------------------------------------------------------------------------------------- */
 /* mocked functions */
-
 /* --------------------------------------------------------------------------------------------- */
 
 static void

--- a/tests/src/filemanager/ext__exec_make_shell_string.c
+++ b/tests/src/filemanager/ext__exec_make_shell_string.c
@@ -1,0 +1,102 @@
+/*
+   src/filemanager - exec_make_shell_string() function testing
+
+   Copyright (C) 2026
+   Free Software Foundation, Inc.
+
+   Written by:
+   Manuel Einfalt <einfalt1@proton.me>, 2026
+
+   This file is part of the Midnight Commander.
+
+   The Midnight Commander is free software: you can redistribute it
+   and/or modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation, either version 3 of the License,
+   or (at your option) any later version.
+
+   The Midnight Commander is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define TEST_SUITE_NAME "/lib"
+
+#include "tests/mctest.h"
+#include "lib/global.h"
+#include "lib/vfs/path.h"
+#include "src/vfs/local/local.h"
+#include "lib/strutil.h"
+#include "src/filemanager/panel.h"
+
+extern char buffer[BUF_1K];
+
+MC_TESTABLE GString *exec_make_shell_string (const char *lc_data, const vfs_path_t *filename_vpath);
+
+/* --------------------------------------------------------------------------------------------- */
+
+static struct test_paths
+{
+    const char *lc_data;
+    const char *path;
+    const char *expected_buffer;
+    const char *expected_ret;
+} test_paths[] = { { "/foo/bar/hello_world.c", "/does_not_appear", "", "/foo/bar/hello_world.c" },
+                   { "%cd /tmp/file/with/a/longer/path/name/xyz.sock", "/never/used",
+                     "/tmp/file/with/a/longer/path/name/xyz.sock", "" },
+                   { "%f/utar://", "/path/to/foo.tar", "", "/path/to/foo.tar/utar://" },
+                   { "%cd %f", "/path/to/directory", "/path/to/directory", "" },
+                   { "%f%cd /dev", "/etc/mc", "/dev", "/etc/mc" },
+                   { "%cd %f%view{ascii}/some/subdir", "/tmp", "/tmp/some/subdir", "" }
+
+};
+
+/* --------------------------------------------------------------------------------------------- */
+
+static void
+setup (void)
+{
+    str_init_strings (NULL);
+    vfs_init ();
+    vfs_init_localfs ();
+}
+
+/* --------------------------------------------------------------------------------------------- */
+
+START_PARAMETRIZED_TEST (shell_str_test, test_paths)
+{
+    vfs_path_t *vpath;
+    GString *gs;
+
+    vpath = vfs_path_from_str (data->path);
+    gs = exec_make_shell_string (data->lc_data, vpath);
+    vfs_path_free (vpath, FALSE);
+
+    mctest_assert_str_eq (buffer, data->expected_buffer);
+    mctest_assert_str_eq (gs->str, data->expected_ret);
+
+    g_string_free (gs, TRUE);
+}
+END_PARAMETRIZED_TEST
+
+/* --------------------------------------------------------------------------------------------- */
+
+int
+main (void)
+{
+    TCase *tc_core;
+
+    tc_core = tcase_create ("Core");
+    tcase_add_checked_fixture (tc_core, setup, NULL);
+
+    // Add new tests here: ***************
+    mctest_add_parameterized_test (tc_core, shell_str_test, test_paths);
+    // ***********************************
+
+    return mctest_run_all (tc_core);
+}
+
+/* --------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
strncpy() was called with text->len, which does not include the terminating NUL byte. As a result, when a shorter filename was copied after a longer one, the global buffer retained trailing characters from the previous value, producing an invalid path.

The fix copies text->len + 1 bytes to include the guaranteed NUL terminator provided by GString.