### PR TITLE
man2hlp: remove escaping from dashes in section titles

### DIFF
--- a/src/man2hlp/man2hlp.in
+++ b/src/man2hlp/man2hlp.in
@@ -355,8 +355,8 @@ sub handle_node($$)
     }
     else
     {
-        # Remove quotes
-        $buffer =~ s/^"// and $buffer =~ s/"$//;
+        # Remove quotes and escaping from dashes
+        $buffer =~ s/^"// and $buffer =~ s/"$// and $buffer =~ s/\\-/-/;
         # Calculate heading level
         $heading_level = 0;
         $heading_level++ while substr($buffer, $heading_level, 1) eq ' ';


### PR DESCRIPTION
## Proposed changes

Some 15 years ago, I did a mass-fixing of unescaped dashes in the manual pages, including section titles (8a692f96). Unfortunately, our man2hlp converter wasn't able to remove escaped dashes form the section titles. Now it can.

<img width="701" height="658" alt="Screenshot 2026-03-05 at 19 56 55" src="https://github.com/user-attachments/assets/2a85abdc-22a7-40c6-986d-6bb313b9faec" />

```diff
hlp % diff -Naur mc.hlp.orig mc.hlp
--- mc.hlp.orig	2026-03-06 12:50:43.620959892 +0100
+++ mc.hlp	2026-03-06 12:52:50.133107091 +0100
@@ -55,7 +55,7 @@
   Internal Diff ViewerDiff Viewer
   Internal File ViewerInternal File Viewer
   Internal File EditorInternal File Editor
-  Options of editor in ini\-fileInternal File Editor / options
+  Options of editor in ini-fileInternal File Editor / options
   Screen selectorScreen selector
   CompletionCompletion
   Virtual File SystemVirtual File System
```
