### PR TITLE
Tickets #4872, #4873 and #4874: fix 'insert control code' function

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -51,6 +51,7 @@
 #include "lib/vfs/vfs.h"
 #include "lib/strutil.h"
 #include "lib/util.h"
+#include "lib/tty/key.h"  // KEY_M_CTRL
 
 /*** global variables ****************************************************************************/
 
@@ -64,11 +65,6 @@
 #endif
 
 #define TMP_SUFFIX ".tmp"
-
-#define ASCII_A    (0x40 + 1)
-#define ASCII_Z    (0x40 + 26)
-#define ASCII_a    (0x60 + 1)
-#define ASCII_z    (0x60 + 26)
 
 /*** file scope type declarations ****************************************************************/
 
@@ -1158,13 +1154,27 @@ early_error:
 
 /* --------------------------------------------------------------------------------------------- */
 
-extern int
-ascii_alpha_to_cntrl (int ch)
+int
+keycode_to_cntrl (int ch)
 {
-    if ((ch >= ASCII_A && ch <= ASCII_Z) || (ch >= ASCII_a && ch <= ASCII_z))
-        ch &= 0x1f;
+    // Extended keys such as F_KEY(n), Page Up and Page Down are not allowed.
+    if ((ch & ~(KEY_M_CTRL | 0x7f)) != 0)
+        return -1;
 
-    return ch;
+    // User pressed Ctrl+(ch) or '\t', '\'n
+    if ((ch & KEY_M_CTRL) != 0 || ch < 0x1b)
+        return ch & 0x1f;
+
+    if (ch >= '@' && ch <= '_')
+        return ch - '@';
+
+    if (ch >= 'a' && ch <= 'z')
+        return ch - '`';
+
+    if (ch == '?')
+        return 0x7f;
+
+    return -1;
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/util.h
+++ b/lib/util.h
@@ -262,9 +262,9 @@ void load_file_position (const vfs_path_t *filename_vpath, long *line, long *col
 void save_file_position (const vfs_path_t *filename_vpath, long line, long column, off_t offset,
                          GArray *bookmarks);
 
-/* if ch is in [A-Za-z], returns the corresponding control character,
- * else returns the argument. */
-extern int ascii_alpha_to_cntrl (int ch);
+/* Return the control character corresponding to key code ch,
+   or -1 if ch cannot be represented as a control character. */
+int keycode_to_cntrl (int ch);
 
 #undef Q_
 const char *Q_ (const char *s);

--- a/lib/widget/input.c
+++ b/lib/widget/input.c
@@ -1030,7 +1030,13 @@ input_callback (Widget *w, Widget *sender, widget_msg_t msg, int parm, void *dat
         if (parm == XCTRL ('q'))
         {
             quote = TRUE;
-            v = input_handle_char (in, ascii_alpha_to_cntrl (tty_getch ()));
+
+            const int control_code = keycode_to_cntrl (tty_getch ());
+
+            if (control_code != -1)
+                v = input_handle_char (in, control_code);
+            else
+                v = MSG_NOT_HANDLED;
             quote = FALSE;
             return v;
         }

--- a/src/editor/editcmd.c
+++ b/src/editor/editcmd.c
@@ -2006,11 +2006,13 @@ edit_select_codepage_cmd (WEdit *edit)
 void
 edit_insert_literal_cmd (WEdit *edit)
 {
-    int char_for_insertion;
-
-    char_for_insertion =
+    const int char_for_insertion =
         editcmd_dialog_raw_key_query (_ ("Insert literal"), _ ("Press any key:"), FALSE);
-    edit_execute_key_command (edit, -1, ascii_alpha_to_cntrl (char_for_insertion));
+
+    const int control_code = keycode_to_cntrl (char_for_insertion);
+
+    if (control_code != -1)
+        edit_execute_key_command (edit, -1, control_code);
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/tests/lib/Makefile.am
+++ b/tests/lib/Makefile.am
@@ -21,6 +21,7 @@ TESTS = \
 	serialize \
 	terminal \
 	tty \
+	util__keycode_to_cntrl \
 	utilunix__mc_pstream_get_string \
 	utilunix__my_system_fork_fail \
 	utilunix__my_system_fork_child_shell \
@@ -52,6 +53,9 @@ terminal_SOURCES = \
 tty_SOURCES = \
 	tty.c
 
+util__keycode_to_cntrl_SOURCES = \
+	util__keycode_to_cntrl.c
+
 utilunix__mc_pstream_get_string_SOURCES = \
 	utilunix__mc_pstream_get_string.c
 
@@ -66,4 +70,3 @@ utilunix__my_system_fork_child_SOURCES = \
 
 x_basename_SOURCES = \
 	x_basename.c
-

--- a/tests/lib/util__keycode_to_cntrl.c
+++ b/tests/lib/util__keycode_to_cntrl.c
@@ -1,0 +1,167 @@
+/*
+   lib - keycode_to_cntrl() function testing
+
+   Copyright (C) 2026
+   Free Software Foundation, Inc.
+
+   Written by:
+   Manuel Einfalt <einfalt1@proton.me>, 2026
+
+   This file is part of the Midnight Commander.
+
+   The Midnight Commander is free software: you can redistribute it
+   and/or modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation, either version 3 of the License,
+   or (at your option) any later version.
+
+   The Midnight Commander is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define TEST_SUITE_NAME "/lib"
+
+#include "tests/mctest.h"
+#include "lib/util.h"
+#include "lib/tty/key.h"
+
+/* --------------------------------------------------------------------------------------------- */
+
+static const struct test_keycodes
+{
+    int keycode;
+    int expected_return;
+} test_keycodes[] = { { '@', 0 },
+                      { '`', -1 },
+                      { KEY_M_CTRL | 0, 0 },
+                      { 'A', 1 },
+                      { 'a', 1 },
+                      { KEY_M_CTRL | 1, 1 },
+                      { 'B', 2 },
+                      { 'b', 2 },
+                      { KEY_M_CTRL | 2, 2 },
+                      { 'C', 3 },
+                      { 'c', 3 },
+                      { KEY_M_CTRL | 3, 3 },
+                      { 'D', 4 },
+                      { 'd', 4 },
+                      { KEY_M_CTRL | 4, 4 },
+                      { 'E', 5 },
+                      { 'e', 5 },
+                      { KEY_M_CTRL | 5, 5 },
+                      { 'F', 6 },
+                      { 'f', 6 },
+                      { KEY_M_CTRL | 6, 6 },
+                      { 'G', 7 },
+                      { 'g', 7 },
+                      { KEY_M_CTRL | 7, 7 },
+                      { 'H', 8 },
+                      { 'h', 8 },
+                      { KEY_M_CTRL | 8, 8 },
+                      { 'I', 9 },
+                      { 'i', 9 },
+                      { KEY_M_CTRL | 9, 9 },
+                      { 'J', 10 },
+                      { 'j', 10 },
+                      { KEY_M_CTRL | 10, 10 },
+                      { 'K', 11 },
+                      { 'k', 11 },
+                      { KEY_M_CTRL | 11, 11 },
+                      { 'L', 12 },
+                      { 'l', 12 },
+                      { KEY_M_CTRL | 12, 12 },
+                      { 'M', 13 },
+                      { 'm', 13 },
+                      { KEY_M_CTRL | 13, 13 },
+                      { 'N', 14 },
+                      { 'n', 14 },
+                      { KEY_M_CTRL | 14, 14 },
+                      { 'O', 15 },
+                      { 'o', 15 },
+                      { KEY_M_CTRL | 15, 15 },
+                      { 'P', 16 },
+                      { 'p', 16 },
+                      { KEY_M_CTRL | 16, 16 },
+                      { 'Q', 17 },
+                      { 'q', 17 },
+                      { KEY_M_CTRL | 17, 17 },
+                      { 'R', 18 },
+                      { 'r', 18 },
+                      { KEY_M_CTRL | 18, 18 },
+                      { 'S', 19 },
+                      { 's', 19 },
+                      { KEY_M_CTRL | 19, 19 },
+                      { 'T', 20 },
+                      { 't', 20 },
+                      { KEY_M_CTRL | 20, 20 },
+                      { 'U', 21 },
+                      { 'u', 21 },
+                      { KEY_M_CTRL | 21, 21 },
+                      { 'V', 22 },
+                      { 'v', 22 },
+                      { KEY_M_CTRL | 22, 22 },
+                      { 'W', 23 },
+                      { 'w', 23 },
+                      { KEY_M_CTRL | 23, 23 },
+                      { 'X', 24 },
+                      { 'x', 24 },
+                      { KEY_M_CTRL | 24, 24 },
+                      { 'Y', 25 },
+                      { 'y', 25 },
+                      { KEY_M_CTRL | 25, 25 },
+                      { 'Z', 26 },
+                      { 'z', 26 },
+                      { KEY_M_CTRL | 26, 26 },
+                      { '[', 27 },
+                      { KEY_M_CTRL | 27, 27 },
+                      { '\\', 28 },
+                      { KEY_M_CTRL | 28, 28 },
+                      { ']', 29 },
+                      { KEY_M_CTRL | 29, 29 },
+                      { '^', 30 },
+                      { KEY_M_CTRL | 30, 30 },
+                      { '_', 31 },
+                      { KEY_M_CTRL | 31, 31 },
+
+                      // Invalid ASCII-inputs:
+                      { '~', -1 },
+                      { '}', -1 },
+                      { '|', -1 },
+                      { '{', -1 },
+
+                      /*
+                       * Invalid inputs are non-ASCII or other special keys.
+                       * These have bits set outside of 0x7f and KEY_M_CTRL.
+                       */
+                      { 0x5000, -1 },
+                      { 128, -1 },
+                      { 0x0507, -1 } };
+
+START_PARAMETRIZED_TEST (keycode_test, test_keycodes)
+{
+    const int actual_result = keycode_to_cntrl (data->keycode);
+    mctest_assert_true (actual_result == data->expected_return);
+}
+END_PARAMETRIZED_TEST
+
+/* --------------------------------------------------------------------------------------------- */
+
+int
+main (void)
+{
+    TCase *tc_core;
+
+    tc_core = tcase_create ("Core");
+
+    // Add new tests here: ***************
+    mctest_add_parameterized_test (tc_core, keycode_test, test_keycodes);
+    // ***********************************
+
+    return mctest_run_all (tc_core);
+}
+
+/* --------------------------------------------------------------------------------------------- */

--- a/tests/mctest.h
+++ b/tests/mctest.h
@@ -35,24 +35,26 @@
 
 #define mctest_assert_null(actual_pointer)                                                         \
     {                                                                                              \
-        ck_assert_msg ((void *) actual_pointer == NULL, "%s(%p) variable should be NULL",          \
+        ck_assert_msg (((void *) actual_pointer) == NULL, "%s(%p) variable should be NULL",        \
                        #actual_pointer, actual_pointer);                                           \
     }
 
 #define mctest_assert_not_null(actual_pointer)                                                     \
     {                                                                                              \
-        ck_assert_msg ((void *) actual_pointer != NULL, "%s(nil) variable should not be NULL",     \
+        ck_assert_msg (((void *) actual_pointer) != NULL, "%s(nil) variable should not be NULL",   \
                        #actual_pointer);                                                           \
     }
 
 #define mctest_assert_true(actual_pointer)                                                         \
     {                                                                                              \
-        ck_assert_msg ((int) actual_pointer != 0, "%s variable should be TRUE", #actual_pointer);  \
+        ck_assert_msg (((int) actual_pointer) != 0, "%s variable should be TRUE",                  \
+                       #actual_pointer);                                                           \
     }
 
 #define mctest_assert_false(actual_pointer)                                                        \
     {                                                                                              \
-        ck_assert_msg ((int) actual_pointer == 0, "%s variable should be FALSE", #actual_pointer); \
+        ck_assert_msg (((int) actual_pointer) == 0, "%s variable should be FALSE",                 \
+                       #actual_pointer);                                                           \
     }
 
 /**


### PR DESCRIPTION
The previous implementation used `ascii_alpha_to_cntrl()`, which assumed
alphabetic input and did not properly validate key codes returned by the
terminal libraries. The function has been renamed to `keycode_to_cntrl()`
and extended to correctly validate and convert key codes.

Changes:

- correctly handle `KEY_M_CTRL` combinations (e.g. `Ctrl+J`).
  - Fixes #4872.

- ignore special keys returned by `get_key_code()` (e.g. function or cursor keys).
  - Fixes #4873.

- extend control mappings for `@ [ \ ] ^ _`.
  - Fixes #4874.

- return `-1` for invalid input and ignore it at the call sites


The function is used both in the *Insert literal* dialog in `mcedit` and in the `mc` command line.

## Checklist
- [X] I have referenced the issue(s) resolved by this PR (if any)
- [X] I have signed-off my contribution with `git commit --amend -s`
- [X] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)

