### PR TITLE
Ticket #5062: Ignore mouse click on a menu's separator line

### DIFF
--- a/lib/widget/menu.c
+++ b/lib/widget/menu.c
@@ -728,17 +728,25 @@ menubar_get_menu_by_x_coord (const WMenuBar *menubar, int x)
 
 /* --------------------------------------------------------------------------------------------- */
 
+/*
+ * Whether the mouse is over a dropped down menu entry (separators excluded).
+ */
 static gboolean
-menubar_mouse_on_menu (const WMenuBar *menubar, int y, int x)
+menubar_mouse_on_menu_entry (const WMenuBar *menubar, int y, int x)
 {
     const WRect *w = &CONST_WIDGET (menubar)->rect;
     menu_t *menu;
+    menu_entry_t *entry;
     int left_x, right_x, bottom_y;
 
     if (!menubar->is_dropped)
         return FALSE;
 
     menu = MENU (g_list_nth_data (menubar->menu, menubar->current));
+    entry = MENUENTRY (g_list_nth_data (menu->entries, y - 2));
+    if (entry == NULL)
+        return FALSE;  // separator line
+
     left_x = menu->start_x;
     right_x = left_x + menu->max_entry_len + 2;
     if (right_x > w->cols - 1)
@@ -782,7 +790,7 @@ menubar_mouse_callback (Widget *w, mouse_msg_t msg, mouse_event_t *event)
     WMenuBar *menubar = MENUBAR (w);
     gboolean mouse_on_drop;
 
-    mouse_on_drop = menubar_mouse_on_menu (menubar, event->y, event->x);
+    mouse_on_drop = menubar_mouse_on_menu_entry (menubar, event->y, event->x);
 
     switch (msg)
     {


### PR DESCRIPTION
## Proposed changes

Ignore mouse click on a menu's separator line

* Resolves: #5062

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
