### PR TITLE
Ticket: #5020: Allocate fewer ncurses color pairs

### DIFF
--- a/lib/tty/color-internal.h
+++ b/lib/tty/color-internal.h
@@ -55,6 +55,8 @@ void tty_color_try_alloc_lib_pair (tty_color_lib_pair_t *mc_color_pair);
 
 int tty_maybe_map_color (int color);
 
+void tty_colorize_area (int y, int x, int rows, int cols, int color);
+
 /*** inline functions ****************************************************************************/
 
 #endif

--- a/lib/tty/color-ncurses.c
+++ b/lib/tty/color-ncurses.c
@@ -49,57 +49,78 @@
 
 /*** file scope type declarations ****************************************************************/
 
+typedef struct
+{
+    int pair;   // ncurses color pair index
+    int attrs;  // attributes
+} mc_tty_ncurses_color_pair_and_attrs_t;
+
 /*** forward declarations (file scope functions) *************************************************/
 
 /*** file scope variables ************************************************************************/
 
-static GHashTable *mc_tty_color_color_pair_attrs = NULL;
+/*
+ * Our bookkeeping of the ncurses color pair indices, indexed by the "{fg}.{bg}" string.
+ */
+static GHashTable *mc_tty_ncurses_color_pairs = NULL;
+
+/*
+ * Indexed by mc's color index, points to the mc_tty_ncurses_color_pair_and_attrs_t object
+ * representing the ncurses color pair index and the attributes.
+ *
+ * mc's color index represents unique (fg, bg, attrs) tuples. Allocating an ncurses color pair
+ * for each of them might be too wasteful and might cause us to run out of available color pairs
+ * too soon (especially in 8-color terminals), if many combinations only differ in attrs.
+ * So we allocate a new ncurses color pair only if the (fg, bg) tuple is newly seen.
+ * See #5020 for details.
+ */
+static GArray *mc_tty_ncurses_color_pair_and_attrs = NULL;
+
+static int mc_tty_ncurses_next_color_pair = 0;
+
 static int overlay_colors = 0;
 
 /* --------------------------------------------------------------------------------------------- */
 /*** file scope functions ************************************************************************/
 /* --------------------------------------------------------------------------------------------- */
 
-static inline void
-mc_tty_color_attr_destroy_cb (gpointer data)
-{
-    g_free (data);
-}
-
-/* --------------------------------------------------------------------------------------------- */
-
-static void
-mc_tty_color_save_attr (int color_pair, int color_attr)
-{
-    int *attr, *key;
-
-    attr = g_try_new0 (int, 1);
-    if (attr == NULL)
-        return;
-
-    key = g_try_new (int, 1);
-    if (key == NULL)
-    {
-        g_free (attr);
-        return;
-    }
-
-    *key = color_pair;
-    *attr = color_attr;
-
-    g_hash_table_replace (mc_tty_color_color_pair_attrs, (gpointer) key, (gpointer) attr);
-}
-
-/* --------------------------------------------------------------------------------------------- */
-
 static int
-color_get_attr (int color_pair)
+get_ncurses_color_pair (int ifg, int ibg)
 {
-    int *fnd = NULL;
+    char *color_pair_str;
+    int *ncurses_color_pair;
+    int init_pair_ret;
 
-    if (mc_tty_color_color_pair_attrs != NULL)
-        fnd = (int *) g_hash_table_lookup (mc_tty_color_color_pair_attrs, (gpointer) &color_pair);
-    return (fnd != NULL) ? *fnd : 0;
+    color_pair_str = g_strdup_printf ("%d.%d", ifg, ibg);
+
+    ncurses_color_pair =
+        (int *) g_hash_table_lookup (mc_tty_ncurses_color_pairs, (gpointer) color_pair_str);
+
+    if (ncurses_color_pair == NULL)
+    {
+        ncurses_color_pair = g_try_new0 (int, 1);
+        *ncurses_color_pair = mc_tty_ncurses_next_color_pair;
+#if NCURSES_VERSION_PATCH >= 20170401 && defined(NCURSES_EXT_COLORS) && defined(NCURSES_EXT_FUNCS) \
+    && defined(HAVE_NCURSES_WIDECHAR)
+        init_pair_ret = init_extended_pair (*ncurses_color_pair, ifg, ibg);
+#else
+        init_pair_ret = init_pair (*ncurses_color_pair, ifg, ibg);
+#endif
+
+        if (init_pair_ret == ERR)
+        {
+            g_free (ncurses_color_pair);
+            g_free (color_pair_str);
+            return 0;
+        }
+
+        g_hash_table_insert (mc_tty_ncurses_color_pairs, color_pair_str, ncurses_color_pair);
+        mc_tty_ncurses_next_color_pair++;
+    }
+    else
+        g_free (color_pair_str);
+
+    return *ncurses_color_pair;
 }
 
 /* --------------------------------------------------------------------------------------------- */
@@ -109,6 +130,8 @@ color_get_attr (int color_pair)
 void
 tty_color_init_lib (gboolean disable, gboolean force)
 {
+    int default_color_pair_id;
+
     (void) force;
 
     if (has_colors () && !disable)
@@ -122,8 +145,18 @@ tty_color_init_lib (gboolean disable, gboolean force)
         tty_use_truecolors (NULL);
     }
 
-    mc_tty_color_color_pair_attrs = g_hash_table_new_full (
-        g_int_hash, g_int_equal, mc_tty_color_attr_destroy_cb, mc_tty_color_attr_destroy_cb);
+    // our tracking of ncurses's color pairs
+    mc_tty_ncurses_color_pairs = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+
+    // ncurses color pair 0 always refers to the default colors; add it to our hash
+    mc_tty_ncurses_next_color_pair = 0;
+    default_color_pair_id = get_ncurses_color_pair (-1, -1);
+    g_assert (default_color_pair_id == 0);
+    (void) default_color_pair_id;  // unused if g_assert is eliminated
+
+    // mapping from our index to ncurses's index and attributes
+    mc_tty_ncurses_color_pair_and_attrs =
+        g_array_new (FALSE, FALSE, sizeof (mc_tty_ncurses_color_pair_and_attrs_t));
 }
 
 /* --------------------------------------------------------------------------------------------- */
@@ -131,8 +164,13 @@ tty_color_init_lib (gboolean disable, gboolean force)
 void
 tty_color_deinit_lib (void)
 {
-    g_hash_table_destroy (mc_tty_color_color_pair_attrs);
-    mc_tty_color_color_pair_attrs = NULL;
+    g_hash_table_destroy (mc_tty_ncurses_color_pairs);
+    mc_tty_ncurses_color_pairs = NULL;
+
+    g_array_free (mc_tty_ncurses_color_pair_and_attrs, TRUE);
+    mc_tty_ncurses_color_pair_and_attrs = NULL;
+
+    mc_tty_ncurses_next_color_pair = 0;
 }
 
 /* --------------------------------------------------------------------------------------------- */
@@ -178,13 +216,12 @@ tty_color_try_alloc_lib_pair (tty_color_lib_pair_t *mc_color_pair)
             ibg += (1 << 16);
     }
 
-#if NCURSES_VERSION_PATCH >= 20170401 && defined(NCURSES_EXT_COLORS) && defined(NCURSES_EXT_FUNCS) \
-    && defined(HAVE_NCURSES_WIDECHAR)
-    init_extended_pair (mc_color_pair->pair_index, ifg, ibg);
-#else
-    init_pair (mc_color_pair->pair_index, ifg, ibg);
-#endif
-    mc_tty_color_save_attr (mc_color_pair->pair_index, attr);
+    const int ncurses_color_pair = get_ncurses_color_pair (ifg, ibg);
+    const mc_tty_ncurses_color_pair_and_attrs_t pair_and_attrs = { .pair = ncurses_color_pair,
+                                                                   .attrs = attr };
+
+    g_array_insert_val (mc_tty_ncurses_color_pair_and_attrs, mc_color_pair->pair_index,
+                        pair_and_attrs);
 }
 
 /* --------------------------------------------------------------------------------------------- */
@@ -192,8 +229,12 @@ tty_color_try_alloc_lib_pair (tty_color_lib_pair_t *mc_color_pair)
 void
 tty_setcolor (int color)
 {
+    mc_tty_ncurses_color_pair_and_attrs_t *pair_and_attrs;
+
     color = tty_maybe_map_color (color);
-    attr_set (color_get_attr (color), color, NULL);
+    pair_and_attrs = &g_array_index (mc_tty_ncurses_color_pair_and_attrs,
+                                     mc_tty_ncurses_color_pair_and_attrs_t, color);
+    attr_set (pair_and_attrs->attrs, pair_and_attrs->pair, NULL);
 }
 
 /* --------------------------------------------------------------------------------------------- */
@@ -278,6 +319,10 @@ tty_colorize_area (int y, int x, int rows, int cols, int color)
         return;
 
     color = tty_maybe_map_color (color);
+    color = g_array_index (mc_tty_ncurses_color_pair_and_attrs,
+                           mc_tty_ncurses_color_pair_and_attrs_t, color)
+                .pair;
+
     ctext = g_malloc (sizeof (cchar_t) * (cols + 1));
 
     for (int row = 0; row < rows; row++)

--- a/lib/tty/color-ncurses.c
+++ b/lib/tty/color-ncurses.c
@@ -264,3 +264,43 @@ tty_use_truecolors (GError **error)
 }
 
 /* --------------------------------------------------------------------------------------------- */
+
+void
+tty_colorize_area (int y, int x, int rows, int cols, int color)
+{
+#ifdef ENABLE_SHADOWS
+    cchar_t *ctext;
+    wchar_t wch[CCHARW_MAX + 1];
+    attr_t attrs;
+    short color_pair;
+
+    if (!use_colors || !tty_clip (&y, &x, &rows, &cols))
+        return;
+
+    color = tty_maybe_map_color (color);
+    ctext = g_malloc (sizeof (cchar_t) * (cols + 1));
+
+    for (int row = 0; row < rows; row++)
+    {
+        mvin_wchnstr (y + row, x, ctext, cols);
+
+        for (int col = 0; col < cols; col++)
+        {
+            getcchar (&ctext[col], wch, &attrs, &color_pair, NULL);
+            setcchar (&ctext[col], wch, attrs, color, NULL);
+        }
+
+        mvadd_wchnstr (y + row, x, ctext, cols);
+    }
+
+    g_free (ctext);
+#else
+    (void) y;
+    (void) x;
+    (void) rows;
+    (void) cols;
+    (void) color;
+#endif
+}
+
+/* --------------------------------------------------------------------------------------------- */

--- a/lib/tty/color-ncurses.c
+++ b/lib/tty/color-ncurses.c
@@ -164,17 +164,17 @@ tty_color_try_alloc_lib_pair (tty_color_lib_pair_t *mc_color_pair)
 
     // Shady trick: if we don't have the exact color, because it is overlaid by backwards
     // compatibility indexed values, just borrow one degree of red. The user won't notice :)
-    if ((ifg & FLAG_TRUECOLOR) != 0)
+    if (ifg >= 0 && (ifg & FLAG_TRUECOLOR) != 0)
     {
         ifg &= ~FLAG_TRUECOLOR;
-        if (ifg != 0 && ifg <= overlay_colors)
+        if (ifg <= overlay_colors)
             ifg += (1 << 16);
     }
 
-    if ((ibg & FLAG_TRUECOLOR) != 0)
+    if (ibg >= 0 && (ibg & FLAG_TRUECOLOR) != 0)
     {
         ibg &= ~FLAG_TRUECOLOR;
-        if (ibg != 0 && ibg <= overlay_colors)
+        if (ibg <= overlay_colors)
             ibg += (1 << 16);
     }
 

--- a/lib/tty/color-slang.c
+++ b/lib/tty/color-slang.c
@@ -233,3 +233,15 @@ tty_use_truecolors (GError **error)
 }
 
 /* --------------------------------------------------------------------------------------------- */
+
+void
+tty_colorize_area (int y, int x, int rows, int cols, int color)
+{
+    if (use_colors)
+    {
+        color = tty_maybe_map_color (color);
+        SLsmg_set_color_in_region (color, y, x, rows, cols);
+    }
+}
+
+/* --------------------------------------------------------------------------------------------- */

--- a/lib/tty/tty-internal.h
+++ b/lib/tty/tty-internal.h
@@ -42,8 +42,6 @@ char *mc_tty_normalize_from_utf8 (const char *str);
 void tty_init_xterm_support (gboolean is_xterm);
 int tty_lowlevel_getch (void);
 
-void tty_colorize_area (int y, int x, int rows, int cols, int color);
-
 /*** inline functions ****************************************************************************/
 
 #endif

--- a/lib/tty/tty-ncurses.c
+++ b/lib/tty/tty-ncurses.c
@@ -122,51 +122,6 @@ sigwinch_handler (int dummy)
 
 /* --------------------------------------------------------------------------------------------- */
 
-/**
- * Get visible part of area.
- *
- * @return TRUE if any part of area is in screen bounds, FALSE otherwise.
- */
-static gboolean
-tty_clip (int *y, int *x, int *rows, int *cols)
-{
-    if (*y < 0)
-    {
-        *rows += *y;
-
-        if (*rows <= 0)
-            return FALSE;
-
-        *y = 0;
-    }
-
-    if (*x < 0)
-    {
-        *cols += *x;
-
-        if (*cols <= 0)
-            return FALSE;
-
-        *x = 0;
-    }
-
-    if (*y + *rows > LINES)
-        *rows = LINES - *y;
-
-    if (*rows <= 0)
-        return FALSE;
-
-    if (*x + *cols > COLS)
-        *cols = COLS - *x;
-
-    if (*cols <= 0)
-        return FALSE;
-
-    return TRUE;
-}
-
-/* --------------------------------------------------------------------------------------------- */
-
 static chtype
 get_maybe_acs (mc_tty_char_t ch)
 {
@@ -570,6 +525,51 @@ tty_draw_vline (int y, int x, mc_tty_char_t ch, int len)
 
 /* --------------------------------------------------------------------------------------------- */
 
+/**
+ * Get visible part of area.
+ *
+ * @return TRUE if any part of area is in screen bounds, FALSE otherwise.
+ */
+gboolean
+tty_clip (int *y, int *x, int *rows, int *cols)
+{
+    if (*y < 0)
+    {
+        *rows += *y;
+
+        if (*rows <= 0)
+            return FALSE;
+
+        *y = 0;
+    }
+
+    if (*x < 0)
+    {
+        *cols += *x;
+
+        if (*cols <= 0)
+            return FALSE;
+
+        *x = 0;
+    }
+
+    if (*y + *rows > LINES)
+        *rows = LINES - *y;
+
+    if (*rows <= 0)
+        return FALSE;
+
+    if (*x + *cols > COLS)
+        *cols = COLS - *x;
+
+    if (*cols <= 0)
+        return FALSE;
+
+    return TRUE;
+}
+
+/* --------------------------------------------------------------------------------------------- */
+
 void
 tty_fill_region (int y, int x, int rows, int cols, unsigned char ch)
 {
@@ -588,46 +588,6 @@ tty_fill_region (int y, int x, int rows, int cols, unsigned char ch)
 
     mc_curs_row = y;
     mc_curs_col = x;
-}
-
-/* --------------------------------------------------------------------------------------------- */
-
-void
-tty_colorize_area (int y, int x, int rows, int cols, int color)
-{
-#ifdef ENABLE_SHADOWS
-    cchar_t *ctext;
-    wchar_t wch[CCHARW_MAX + 1];
-    attr_t attrs;
-    short color_pair;
-
-    if (!use_colors || !tty_clip (&y, &x, &rows, &cols))
-        return;
-
-    color = tty_maybe_map_color (color);
-    ctext = g_malloc (sizeof (cchar_t) * (cols + 1));
-
-    for (int row = 0; row < rows; row++)
-    {
-        mvin_wchnstr (y + row, x, ctext, cols);
-
-        for (int col = 0; col < cols; col++)
-        {
-            getcchar (&ctext[col], wch, &attrs, &color_pair, NULL);
-            setcchar (&ctext[col], wch, attrs, color, NULL);
-        }
-
-        mvadd_wchnstr (y + row, x, ctext, cols);
-    }
-
-    g_free (ctext);
-#else
-    (void) y;
-    (void) x;
-    (void) rows;
-    (void) cols;
-    (void) color;
-#endif
 }
 
 /* --------------------------------------------------------------------------------------------- */

--- a/lib/tty/tty-ncurses.c
+++ b/lib/tty/tty-ncurses.c
@@ -26,7 +26,7 @@
  */
 
 /** \file
- *  \brief Source: NCurses-based tty layer of Midnight-commander
+ *  \brief Source: NCurses-based tty layer of Midnight Commander
  */
 
 #include <config.h>
@@ -597,7 +597,7 @@ tty_colorize_area (int y, int x, int rows, int cols, int color)
 {
 #ifdef ENABLE_SHADOWS
     cchar_t *ctext;
-    wchar_t wch[10];  // TODO not sure if the length is correct
+    wchar_t wch[CCHARW_MAX + 1];
     attr_t attrs;
     short color_pair;
 
@@ -605,7 +605,6 @@ tty_colorize_area (int y, int x, int rows, int cols, int color)
         return;
 
     color = tty_maybe_map_color (color);
-    tty_setcolor (color);
     ctext = g_malloc (sizeof (cchar_t) * (cols + 1));
 
     for (int row = 0; row < rows; row++)

--- a/lib/tty/tty-ncurses.h
+++ b/lib/tty/tty-ncurses.h
@@ -43,6 +43,8 @@ extern gboolean ncurses_koi8r_double_line_bug;
 
 /*** declarations of public functions ************************************************************/
 
+gboolean tty_clip (int *y, int *x, int *rows, int *cols);
+
 /*** inline functions ****************************************************************************/
 
 #endif

--- a/lib/tty/tty-slang.c
+++ b/lib/tty/tty-slang.c
@@ -563,18 +563,6 @@ tty_fill_region (int y, int x, int rows, int cols, unsigned char ch)
 /* --------------------------------------------------------------------------------------------- */
 
 void
-tty_colorize_area (int y, int x, int rows, int cols, int color)
-{
-    if (use_colors)
-    {
-        color = tty_maybe_map_color (color);
-        SLsmg_set_color_in_region (color, y, x, rows, cols);
-    }
-}
-
-/* --------------------------------------------------------------------------------------------- */
-
-void
 tty_display_8bit (gboolean what)
 {
     SLsmg_Display_Eight_Bit = what ? 128 : 160;

--- a/lib/tty/tty.c
+++ b/lib/tty/tty.c
@@ -57,6 +57,7 @@
 
 #include "tty.h"
 #include "tty-internal.h"
+#include "color-internal.h"
 #include "color.h"  // tty_set_normal_attrs()
 #include "mouse.h"  // use_mouse_p
 #include "win.h"


### PR DESCRIPTION
## Proposed changes

Reuse ncurses color pairs if possible
    
Allocating a new ncurses color pair for every new (fg, bg, attrs) tuple might result in running out of available color pairs too soon.
    
Instead, allocate a new ncurses color pair only if really needed, i.e. if (fg, bg) is a new combination. Apply the attributes separately.

Plus some minor underlying changes.

* Resolves: #5020

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
