### PR TITLE
Prevent mcedit from hanging on macro

### DIFF
--- a/src/subshell/common.c
+++ b/src/subshell/common.c
@@ -1901,7 +1901,7 @@ invoke_subshell (const char *command, int how, vfs_path_t **new_dir_vpath)
         // some sort of error.
         if (use_persistent_buffer)
             clear_cwd_pipe ();
-        else
+        else if (mc_global.mc_run_mode == MC_RUN_FULL)
         {
             /* We don't need to call feed_subshell here if we are using fish, because of a
              * quirk in the behavior of that particular shell. */


### PR DESCRIPTION
## Summary

Fixes editor hang when executing macro scripts via `mc -e`.

## Problem

Running MC in editor-only mode (`mc -e file`) and executing a macro script (e.g., via `edit_block_process_cmd`) causes the editor to hang indefinitely.

The hang occurs in `invoke_subshell()` in `src/subshell/common.c`. Before sending a command to the subshell, the code sends Ctrl-C to clear any leftover input and calls `feed_subshell(QUIETLY, FALSE)` to wait for the shell to reach a prompt. This wait relies on the shell's prompt hook writing its CWD to a pipe - but in editor-only mode (`MC_RUN_EDITOR`), `use_persistent_buffer` is `FALSE` and the shell's CWD-reporting hook is not active, so `feed_subshell` blocks forever on `select()`.

## Fix

Skip the Ctrl-C + `feed_subshell` pre-clearing when not in full MC mode. This code path exists to clear user-typed text from the subshell prompt before injecting a command - but in editor mode, the subshell has not been interacted with by the user, so there is nothing to clear.

## Test plan

- [ ] `mc -e somefile` - select a text block, run a macro script - should execute without hanging
- [ ] Full MC mode - run `mc`, edit a file (F4) and run a macro script - should work as before