### PR TITLE
Improving block file change detection

### DIFF
--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -1780,6 +1780,15 @@ edit_user_menu (WEdit *edit, const char *menu_file, int selected_entry)
     block_file = mc_config_get_full_path (EDIT_HOME_BLOCK_FILE);
     block_file_vpath = vfs_path_from_str (block_file);
 
+    /* Save the selected block to the block file before running the command.
+       This makes %b available to macro scripts that process the selection. */
+    {
+        off_t start_mark, end_mark;
+
+        if (eval_marks (edit, &start_mark, &end_mark))
+            edit_save_block (edit, block_file, start_mark, end_mark);
+    }
+
     const gboolean status_before_ok = mc_stat (block_file_vpath, &status_before) == 0;
 
     // run menu command. It can or can not create or modify block_file

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -1789,10 +1789,19 @@ edit_user_menu (WEdit *edit, const char *menu_file, int selected_entry)
         const gboolean status_after_ok = mc_stat (block_file_vpath, &status_after) == 0;
 
         // was block file created or modified by menu command?
+        // Use nanosecond-precision mtime when available, because scripts that only
+        // rearrange bytes (e.g. word-wrap replacing spaces with newlines) produce
+        // the same file size and may finish within the same second.
         modified = (!status_before_ok && status_after_ok)
             || (status_before_ok && status_after_ok && status_after.st_size != 0
                 && (status_after.st_size != status_before.st_size
-                    || status_after.st_mtime != status_before.st_mtime));
+#ifdef HAVE_STRUCT_STAT_ST_MTIM
+                    || status_after.st_mtim.tv_sec != status_before.st_mtim.tv_sec
+                    || status_after.st_mtim.tv_nsec != status_before.st_mtim.tv_nsec
+#else
+                    || status_after.st_mtime != status_before.st_mtime
+#endif
+                    ));
     }
 
     if (modified)

--- a/src/editor/editcmd.c
+++ b/src/editor/editcmd.c
@@ -1939,6 +1939,19 @@ edit_block_process_cmd (WEdit *edit, int macro_number)
 {
     char *fname;
     char *macros_fname = NULL;
+    off_t start_mark, end_mark;
+
+    // Save the selected block to the block file so that macro scripts
+    // referencing %b can read it. Without this, the block file does not
+    // exist when the script runs and %b points to a nonexistent file.
+    if (eval_marks (edit, &start_mark, &end_mark))
+    {
+        char *tmp;
+
+        tmp = mc_config_get_full_path (EDIT_HOME_BLOCK_FILE);
+        edit_save_block (edit, tmp, start_mark, end_mark);
+        g_free (tmp);
+    }
 
     fname = g_strdup_printf ("%s.%i.sh", EDIT_HOME_MACRO_FILE, macro_number);
     macros_fname = g_build_filename (mc_config_get_data_path (), fname, (char *) NULL);

--- a/src/editor/editcmd.c
+++ b/src/editor/editcmd.c
@@ -1939,19 +1939,6 @@ edit_block_process_cmd (WEdit *edit, int macro_number)
 {
     char *fname;
     char *macros_fname = NULL;
-    off_t start_mark, end_mark;
-
-    // Save the selected block to the block file so that macro scripts
-    // referencing %b can read it. Without this, the block file does not
-    // exist when the script runs and %b points to a nonexistent file.
-    if (eval_marks (edit, &start_mark, &end_mark))
-    {
-        char *tmp;
-
-        tmp = mc_config_get_full_path (EDIT_HOME_BLOCK_FILE);
-        edit_save_block (edit, tmp, start_mark, end_mark);
-        g_free (tmp);
-    }
 
     fname = g_strdup_printf ("%s.%i.sh", EDIT_HOME_MACRO_FILE, macro_number);
     macros_fname = g_build_filename (mc_config_get_data_path (), fname, (char *) NULL);


### PR DESCRIPTION
## Summary

Fixes two related issues with editor macro scripts and the block file.

## Problem 1: Block file not saved before macro execution

`edit_block_process_cmd()` runs a numbered macro script that may reference `%b` (the block file). However, the selected block is not written to the block file before the script runs, so `%b` points to a stale or nonexistent file.

The fix is to save the selected block to `EDIT_HOME_BLOCK_FILE` at the start of `edit_block_process_cmd()`, before calling `edit_user_menu()`.

## Problem 2: Block file modification missed due to second-precision timestamps

`edit_user_menu()` detects whether a macro script modified the block file by comparing `st_size` and `st_mtime` before and after execution. Scripts that rearrange bytes without changing file size (e.g., word-wrap replacing spaces with newlines) and complete within the same second produce identical `st_size` and `st_mtime`, causing a false negative - the editor does not reload the modified block.

The fix is to use nanosecond-precision `st_mtim` (via `HAVE_STRUCT_STAT_ST_MTIM`, already detected by configure) instead of second-precision `st_mtime`. Falls back to `st_mtime` on platforms without nanosecond support.

## Test plan

- [ ] Select a block, run a macro that transforms it (e.g., sort, word-wrap) - the result should be inserted back into the editor
- [ ] Run a macro that produces identical file size but different content - the change should be detected
- [ ] Build on a platform without `st_mtim` - should compile and fall back to second-precision comparison