### PR TITLE
Ticket #3734: improve syntax documentation for mcedit

### DIFF
--- a/doc/man/mcedit.1.in
+++ b/doc/man/mcedit.1.in
@@ -468,7 +468,38 @@ can do rather than try to do things that this implementation cannot deal
 with.  Also remember that the aim of syntax highlighting is to make
 programming less prone to error, not to make code look pretty.
 .PP
+Special sequences interpreted by
+.B mcedit
+are listed below:
+.PP
+.nf
+mcedit    PCRE2 equivalent
+
+[a\-c]     \(rs[a\-c\(rs]        ([ ] has no special meaning)
+\(rs[a\-c\(rs]   (a|\-|c)*       ( \-  has no special meaning)
+{a\-c}     \(rs{a\-c\(rs}        ({ } has no special meaning)
+\(rs{a\-c\(rs}   [ac\-]          ( \-  has no special meaning)
+\&.         \(rs.
+(         \(rs(
+)         \(rs)
+*         .*
++         [^ \(rst]*
+?         \(rs?
+\(rs*        \(rs*
+\(rs+        \(rs+
+^         \(rs^
+$         \(rs$
+|         \(rs|
+\(rss        [ ]            (space only)
+\(rst        \(rst
+\(rsn        \(rsn
+.fi
+.PP
 The syntax highlighting can be toggled using Ctrl\-s shortcut.
+Pressing C\-s twice effectively reloads the syntax file, so you
+don't have to exit the editor, or
+.B mc
+itself, to test your syntax modifications.
 .SH OPTIONS
 Most options can be set from Options dialog box.  See the
 .B Options


### PR DESCRIPTION
Document text sequences interpreted by mcedit.

## Proposed changes

Put a table with patterns correspondence 'mcedit vs. pcre2' from MidnightCommander/mc#3734 into `doc/man/mcedit.1.in` file.

* Resolves: #3734

## Checklist

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [ ] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
