### PR TITLE
Ticket #5087: fix incorrect disabling of widgets in the Configuration dialog

### DIFF
--- a/src/filemanager/boxes.c
+++ b/src/filemanager/boxes.c
@@ -623,7 +623,7 @@ configure_box (void)
 #endif
 
         if (!old_esc_mode)
-            quick_widgets[10].state = quick_widgets[11].state = WST_DISABLED;
+            quick_widgets[10].state = WST_DISABLED;
 
 #ifndef HAVE_POSIX_FALLOCATE
         mc_global.vfs.preallocate_space = FALSE;

--- a/src/filemanager/boxes.c
+++ b/src/filemanager/boxes.c
@@ -627,7 +627,7 @@ configure_box (void)
 
 #ifndef HAVE_POSIX_FALLOCATE
         mc_global.vfs.preallocate_space = FALSE;
-        quick_widgets[7].state = WST_DISABLED;
+        quick_widgets[6].state = WST_DISABLED;
 #endif
 
         if (quick_dialog (&qdlg) == B_ENTER)


### PR DESCRIPTION
## Proposed changes

These patches fix a couple of typos in https://github.com/MidnightCommander/mc/commit/dca06a678663db82e1993097563da1da2bbd30d6. One of the typos resulted in non-disabling the Preallocate option on platforms without HAVE_POSIX_FALLOCATE. The other was rather harmless, tried to disable two widgets instead of one while disabling the Esc Timeout input widget.

## Checklist

- [ ] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)