### PR TITLE
Ticket #5090: add eTS and JSON5 syntax highlighting

### DIFF
--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -162,10 +162,10 @@ include cs.syntax
 file ..\*\\.(?i:m?js)$ JavaScript\sProgram ^#!.\*[\s/](node|nodejs)\\b
 include js.syntax
 
-file ..\*\\.(?i:json)$ JSON\sFile
+file ..\*\\.(?i:json5?)$ JSON\sFile
 include json.syntax
 
-file ..\*\\.(?i:ts)$ TypeScript\sProgram
+file ..\*\\.(?i:e?ts)$ TypeScript\sProgram
 include ts.syntax
 
 file ..\*\\.(?i:as)$ ActionScript\sProgram


### PR DESCRIPTION
## Proposed changes

* .ets is 'extended typescript' used in ArkTS (https://en.wikipedia.org/wiki/ArkTS) - one can treat these files as ts at the first glance

* json5 is a json extension

## Checklist

- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)

