### PR TITLE
Add BNF / META II / TREE-META and update J syntax

### DIFF
--- a/misc/filehighlight.ini
+++ b/misc/filehighlight.ini
@@ -33,7 +33,7 @@
     extensions=chm;css;ctl;diz;doc;docm;docx;dtd;fodg;fodp;fods;fodt;htm;html;json;letter;lsm;mail;man;markdown;md;me;mkd;msg;nroff;odg;odp;ods;odt;pdf;po;ppt;pptm;pptx;ps;rtf;sgml;shtml;tex;text;txt;xls;xlsm;xlsx;xml;xsd;xslt
 
 [source]
-    extensions=ada;asm;awk;bash;bnf;ebnf;c;c++;caml;cc;cgi;cpp;cxx;diff;erl;go;h;h++;hh;hi;hpp;hs;inc;jasm;jav;java;js;m4;mak;mjs;ml;mli;mll;mlp;mly;pas;patch;php;phps;pl;pm;prg;py;rb;s;sas;sh;sl;st;swift;tcl;tk;tsx;xq
+    extensions=ada;asm;awk;bash;bnf;ebnf;c;c++;caml;cc;cgi;cpp;cxx;diff;erl;go;h;h++;hh;hi;hpp;hs;inc;jasm;jav;java;js;m2;m2o;m4;mak;mjs;ml;mli;mll;mlp;mly;pas;patch;php;phps;pl;pm;prg;py;rb;s;sas;sh;sl;st;swift;tcl;tk;tsx;xq
 
 [media]
     extensions=3gp;aac;ac3;ape;asf;avi;awb;dts;flac;flv;it;m3u;m4a;m4v;med;mid;midi;mkv;mod;mol;mov;mp2;mp3;mp4;mpeg;mpg;mpl;ogg;ogv;opus;s3m;ts;umx;vob;wav;webm;wma;wmv;xm;y4m

--- a/misc/filehighlight.ini
+++ b/misc/filehighlight.ini
@@ -33,7 +33,7 @@
     extensions=chm;css;ctl;diz;doc;docm;docx;dtd;fodg;fodp;fods;fodt;htm;html;json;letter;lsm;mail;man;markdown;md;me;mkd;msg;nroff;odg;odp;ods;odt;pdf;po;ppt;pptm;pptx;ps;rtf;sgml;shtml;tex;text;txt;xls;xlsm;xlsx;xml;xsd;xslt
 
 [source]
-    extensions=ada;asm;awk;bash;bnf;ebnf;c;c++;caml;cc;cgi;cpp;cxx;diff;erl;go;h;h++;hh;hi;hpp;hs;inc;jasm;jav;java;js;m2;m2o;m4;mak;mjs;ml;mli;mll;mlp;mly;pas;patch;php;phps;pl;pm;prg;py;rb;s;sas;sh;sl;st;swift;tcl;tk;tsx;xq
+    extensions=ada;asm;awk;bash;bnf;ebnf;c;c++;caml;cc;cgi;cpp;cxx;diff;erl;go;h;h++;hh;hi;hpp;hs;inc;jasm;jav;java;js;m2;m2o;m4;mak;mjs;ml;mli;mll;mlp;mly;pas;patch;php;phps;pl;pm;prg;py;rb;s;sas;sh;sl;st;swift;tcl;tk;tm;tmo;tsx;xq
 
 [media]
     extensions=3gp;aac;ac3;ape;asf;avi;awb;dts;flac;flv;it;m3u;m4a;m4v;med;mid;midi;mkv;mod;mol;mov;mp2;mp3;mp4;mpeg;mpg;mpl;ogg;ogv;opus;s3m;ts;umx;vob;wav;webm;wma;wmv;xm;y4m

--- a/misc/filehighlight.ini
+++ b/misc/filehighlight.ini
@@ -33,7 +33,7 @@
     extensions=chm;css;ctl;diz;doc;docm;docx;dtd;fodg;fodp;fods;fodt;htm;html;json;letter;lsm;mail;man;markdown;md;me;mkd;msg;nroff;odg;odp;ods;odt;pdf;po;ppt;pptm;pptx;ps;rtf;sgml;shtml;tex;text;txt;xls;xlsm;xlsx;xml;xsd;xslt
 
 [source]
-    extensions=ada;asm;awk;bash;c;c++;caml;cc;cgi;cpp;cxx;diff;erl;go;h;h++;hh;hi;hpp;hs;inc;jasm;jav;java;js;m4;mak;mjs;ml;mli;mll;mlp;mly;pas;patch;php;phps;pl;pm;prg;py;rb;s;sas;sh;sl;st;swift;tcl;tk;tsx;xq
+    extensions=ada;asm;awk;bash;bnf;ebnf;c;c++;caml;cc;cgi;cpp;cxx;diff;erl;go;h;h++;hh;hi;hpp;hs;inc;jasm;jav;java;js;m4;mak;mjs;ml;mli;mll;mlp;mly;pas;patch;php;phps;pl;pm;prg;py;rb;s;sas;sh;sl;st;swift;tcl;tk;tsx;xq
 
 [media]
     extensions=3gp;aac;ac3;ape;asf;avi;awb;dts;flac;flv;it;m3u;m4a;m4v;med;mid;midi;mkv;mod;mol;mov;mp2;mp3;mp4;mpeg;mpg;mpl;ogg;ogv;opus;s3m;ts;umx;vob;wav;webm;wma;wmv;xm;y4m

--- a/misc/syntax/Makefile.am
+++ b/misc/syntax/Makefile.am
@@ -99,6 +99,7 @@ SYNTAXFILES =			\
 	tcl.syntax		\
 	texinfo.syntax		\
 	toml.syntax		\
+	tree-meta.syntax	\
 	ts.syntax		\
 	tt.syntax		\
 	unknown.syntax		\

--- a/misc/syntax/Makefile.am
+++ b/misc/syntax/Makefile.am
@@ -10,6 +10,7 @@ SYNTAXFILES =			\
 	assembler.syntax	\
 	awk.syntax		\
 	b.syntax		\
+	bnf.syntax		\
 	c.syntax		\
 	cabal.syntax		\
 	caddyfile.syntax	\

--- a/misc/syntax/Makefile.am
+++ b/misc/syntax/Makefile.am
@@ -61,6 +61,7 @@ SYNTAXFILES =			\
 	mail.syntax		\
 	makefile.syntax		\
 	markdown.syntax		\
+	meta-ii.syntax		\
 	ml.syntax		\
 	meson.syntax		\
 	muttrc.syntax		\

--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -372,5 +372,8 @@ include bnf.syntax
 file ..\*\\.(?i:m2o?)$ META\sII\sMetasyntax
 include meta-ii.syntax
 
+file ..\*\\.(?i:tmo?)$ TREE-META\sMetasyntax
+include tree-meta.syntax
+
 file .\* unknown
 include unknown.syntax

--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -369,5 +369,8 @@ include dockerfile.syntax
 file ..\*\\.(?i:e?bnf)$ BNF/EBNF/ABNF/WBNF\sMetasyntax
 include bnf.syntax
 
+file ..\*\\.(?i:m2o?)$ META\sII\sMetasyntax
+include meta-ii.syntax
+
 file .\* unknown
 include unknown.syntax

--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -366,5 +366,8 @@ include caddyfile.syntax
 file Dockerfile.\*$ Dockerfile
 include dockerfile.syntax
 
+file ..\*\\.(?i:e?bnf)$ BNF/EBNF/ABNF/WBNF\sMetasyntax
+include bnf.syntax
+
 file .\* unknown
 include unknown.syntax

--- a/misc/syntax/bnf.syntax
+++ b/misc/syntax/bnf.syntax
@@ -1,0 +1,128 @@
+# BNF family (BNF, EBNF, ABNF, WBNF etc.) Syntax Highlighting Definition
+# Version 3.0.0 2026-03-23
+# See updates and changelog at https://github.com/jip/syntax-highlighting
+#
+# Backus-Naur form (BNF) is a notation technique for context-free grammars
+#
+# This file is part of GNU Midnight Commander
+# https://midnight-commander.org/
+#
+# SPDX-FileCopyrightText: 2026 Igor Zhuravlov <zhuravlov.ip@ya.ru>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# for the default (lightgray on blue)
+define _alerthi lightgray red
+define _alertmi gray yellow
+define _alertlo gray cyan
+define _assign  white
+define _comb    yellow
+define _comment brown
+define _esc     brightgreen
+define _group   brightcyan
+define _lbl     lightgray blue underline
+define _num     brightgreen
+define _oper    yellow
+define _sep     brightmagenta
+define _special lightgray black
+define _str     green
+define _var     lightgray
+
+context default
+    # labels
+    keyword \{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._\]: _lbl
+    # nonterminals
+    keyword <\{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._\]> _var
+    keyword \{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._\] _var
+    # decimal integer numbers
+    keyword wholeleft 0 _num
+    keyword wholeleft \{123456789_\}\[0123456789_\] _num
+    keyword wholeleft -\{123456789_\}\[0123456789_\] _num
+    # repeaters (EBNF)
+    keyword (/ _group
+    keyword /) _group
+    keyword (: _group
+    keyword :) _group
+    # exclude from highlighting
+    keyword ::== lightgray blue
+    # assignments
+    keyword :≡ _assign
+    keyword :== _assign
+    keyword := _assign
+    keyword ::= _assign
+    keyword :: _assign
+    keyword : _assign
+    keyword => _assign
+    keyword = _assign
+    keyword <- _assign
+    keyword -> _assign
+    keyword <= _assign
+    keyword ← _assign
+    keyword → _assign
+    keyword ⇐ _assign
+    keyword ⇒ _assign
+    keyword ≜ _assign
+    # combinators
+    keyword | _comb
+    keyword / _comb
+    keyword \\ _comb
+    keyword - _comb
+    keyword , _comb
+    # operators
+    keyword ! _oper
+    keyword # _oper
+    keyword $ _oper
+#    keyword % _oper
+    keyword & _oper
+    keyword \* _oper
+    keyword \+ _oper
+    keyword ? _oper
+    keyword @ _oper
+    keyword ^ _oper
+    keyword ~ _oper
+    # grouping
+    keyword ( _group
+    keyword ) _group
+    keyword < _group
+    keyword > _group
+    keyword [ _group
+    keyword ] _group
+    keyword { _group
+    keyword } _group
+    # concatenator,separator,terminator
+    keyword \{.;\} _sep
+
+# strings
+
+context ' ' _str
+    keyword \\' _esc
+    keyword \\\\ _esc
+    keyword \\\{abtnvfr\} _esc
+    keyword \\x\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\} _esc
+    keyword \\u\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\} _esc
+    keyword \\U\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\} _esc
+
+context " " _str
+    keyword \\" _esc
+    keyword \\\\ _esc
+    keyword \\\{abtnvfr\} _esc
+    keyword \\x\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\} _esc
+    keyword \\u\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\} _esc
+    keyword \\U\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\}\{0123456789abcdefABCDEF\} _esc
+
+# special sequence
+
+context ` ` _special
+    keyword \\` _special
+
+# comments
+
+context % % _comment
+    keyword \\% _comment
+    keyword whole BUG        _alerthi
+    keyword whole DEPRECATED _alertmi
+    keyword whole FIXME      _alerthi
+    keyword whole NOTE       _alertlo
+    keyword whole TEST       _alertlo
+    keyword whole TODO       _alertmi
+    keyword whole WARN       _alertmi
+    spellcheck

--- a/misc/syntax/bnf.syntax
+++ b/misc/syntax/bnf.syntax
@@ -1,5 +1,5 @@
 # BNF family (BNF, EBNF, ABNF, WBNF etc.) Syntax Highlighting Definition
-# Version 3.0.0 2026-03-23
+# Version 3.0.1 2026-03-25
 # See updates and changelog at https://github.com/jip/syntax-highlighting
 #
 # Backus-Naur form (BNF) is a notation technique for context-free grammars
@@ -23,7 +23,7 @@ define _lbl     lightgray blue underline
 define _num     brightgreen
 define _oper    yellow
 define _sep     brightmagenta
-define _special lightgray black
+define _special gray
 define _str     green
 define _var     lightgray
 

--- a/misc/syntax/j.syntax
+++ b/misc/syntax/j.syntax
@@ -1,42 +1,120 @@
-# J syntax highlighting
+# J language Syntax highlighting Definition
+# Version 3.0.0 2026-03-18
+# See updates and changelog at https://github.com/jip/syntax-highlighting
+#
+# J is a high-level, general-purpose programming language
+# https://www.jsoftware.com
+#
+# This file is part of GNU Midnight Commander
+# https://midnight-commander.org/
+#
+# SPDX-FileCopyrightText: 2009,2026 Igor Zhuravlov <zhuravlov.ip@ya.ru>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# for the default (lightgray on blue)
+define _adverb  green blue bold
+define _alerthi lightgray red
+define _alertmi gray yellow
+define _alertlo gray cyan
+define _copulag white
+define _copulal brown
+define _comment gray
+define _conj    yellow blue bold
+define _control brightred
+define _noun    cyan blue bold
+define _nounblk lightgray brightblue
+define _num     green
+define _paren   brightgreen
+define _str     brightcyan
+define _verb    magenta blue bold
 
 context default
+    # controls
+    wholechars {}
+    keyword {{ _control
+    keyword }} _control
+    wholechars abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._
+    keyword wholeleft assert. _control
+    keyword wholeleft break. _control
+    keyword wholeleft case. _control
+    keyword wholeleft catch. _control
+    keyword wholeleft catch\{dt\}. _control
+    keyword wholeleft continue. _control
+    keyword wholeleft do. _control
+    keyword wholeleft else. _control
+    keyword wholeleft elseif. _control
+    keyword wholeleft end. _control
+    keyword wholeleft fcase. _control
+    keyword wholeleft for. _control
+    keyword wholeleft for_\{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\]. _control
+    keyword wholeleft goto_\{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\]. _control
+    keyword wholeleft if. _control
+    keyword wholeleft label_\{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\]. _control
+    keyword wholeleft return. _control
+    keyword wholeleft select. _control
+    keyword wholeleft throw. _control
+    keyword wholeleft try. _control
+    keyword wholeleft while. _control
+    keyword wholeleft whilst. _control
+    # comments
+    keyword wholeleft NB. _comment
+    # copula
+    keyword =: _copulag
+    keyword =. _copulal
+    # parenthesis
+    keyword \{()\} _paren
+    # actors
+    keyword {:: _verb
+    keyword &.: _conj
+    keyword __: _verb
+    keyword /.. _adverb
+    keyword \{<>\+\*-%$~|,#{}"\}\{.:\} _verb
+    keyword \{_;/\\[\}: _verb
+    keyword \{^?\}. _verb
+    keyword \{^`\}: _conj
+    keyword \{;[]\}. _conj
+    keyword \{!:@&\}\{.:\} _conj
+    keyword \{/\\\}. _adverb
+    keyword ]: _adverb
+    keyword \{=<>\+\*-%^$|,;#![]{?\} _verb
+    keyword \{~/\\}\} _adverb
+    keyword \{".:`@&\} _conj
+    keyword wholeleft \{AcCeEIjLorv\}. _verb
+    keyword wholeleft \{bfM\}. _adverb
+    keyword wholeleft \{Hmt\}. _conj
+    keyword wholeleft p.. _verb
+    keyword wholeleft \{ipu\}\{.:\} _verb
+    keyword wholeleft \{LS\}: _conj
+    keyword wholeleft \{qsxZ\}: _verb
+    keyword whole     \{uv\} _verb
+    keyword wholeleft _\{123456789\}: _verb
+    keyword wholeleft \{0123456789\}: _verb
+    # numbers
+    keyword whole \{0123456789_\}\[abcdefghijklmnopqrstuvwxyz0123456789_.\] _num
+    # nouns
+    keyword whole a\{.:\} _noun
+    keyword whole \{mnxy\} _noun
 
-    keyword assert. brightred
-    keyword break. brightred
-    keyword case. brightred
-    keyword catch. brightred
-    keyword catchd. brightred
-    keyword catcht. brightred
-    keyword continue. brightred
-    keyword do. brightred
-    keyword else. brightred
-    keyword elseif. brightred
-    keyword end. brightred
-    keyword fcase. brightred
-    keyword for. brightred
-    keyword for_\{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\]. brightred
-    keyword goto_\{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\]. brightred
-    keyword if. brightred
-    keyword label_\{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\]. brightred
-    keyword return. brightred
-    keyword select. brightred
-    keyword throw. brightred
-    keyword trap. brightred
-    keyword try. brightred
-    keyword while. brightred
-    keyword whilst. brightred
+# strings
 
-    keyword NB. green
+context ' ' _str
 
-    keyword \{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\]\[\s\]=: white
-    keyword '\{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\s\]'\[\s\]=: white
+# block nouns
 
-context ' ' brightcyan
-#    spellcheck
+context exclusive 0\s\[\s\t\]:\[\s\t\]0\[)\s\t\]\n linestart ) _nounblk
 
-context exclusive linestart NB.\s\*\s \n brightgreen
-#    spellcheck
+context exclusive whole Note linestart ) _nounblk
 
-context exclusive NB. \n green
-#    spellcheck
+# comments
+
+context exclusive linestart NB.\s\*\s \n _comment blue underline
+
+context exclusive NB. \n _comment
+    keyword whole BUG        _alerthi
+    keyword whole DEPRECATED _alertmi
+    keyword whole FIXME      _alerthi
+    keyword whole NOTE       _alertlo
+    keyword whole TEST       _alertlo
+    keyword whole TODO       _alertmi
+    keyword whole WARN       _alertmi
+    spellcheck

--- a/misc/syntax/meta-ii.syntax
+++ b/misc/syntax/meta-ii.syntax
@@ -1,0 +1,145 @@
+# META II (both source and object code) Syntax Highlighting Definition
+# Version 1.0.0 2026-03-19
+# See updates and changelog at https://github.com/jip/syntax-highlighting
+#
+# META II is a metacompiler developed by D.V. Schorre in the 1964
+# http://doi.acm.org/10.1145/800257.808896
+#
+# This file is part of GNU Midnight Commander
+# https://midnight-commander.org/
+#
+# SPDX-FileCopyrightText: 2026 Igor Zhuravlov <zhuravlov.ip@ya.ru>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+caseinsensitive
+
+# for the default (lightgray on blue)
+define _alerthi lightgray red
+define _alertmi gray yellow
+define _alertlo gray cyan
+define _asm     cyan
+define _assign  white
+define _comb    yellow
+define _comment brown
+define _id      lightgray
+define _lbl     white
+define _num     brightgreen
+define _oper    yellow
+define _paren   yellow
+define _sep     brightmagenta
+define _src     cyan
+define _str     brightcyan
+
+context default
+    # object code
+    # - input
+    keyword whole TST _asm
+    keyword whole ID _asm
+    keyword whole NUM _asm
+    keyword whole SR _asm
+    # - procedures
+    keyword whole CLL _asm
+    keyword whole R _asm
+    # - branch flag
+    keyword whole SET _asm
+    # - execution flow
+    keyword whole BT _asm
+    keyword whole BF _asm
+    keyword whole BE _asm
+    keyword whole B _asm
+    # - output recognized information
+    keyword whole CL _asm
+    keyword whole CI _asm
+    # - generate labels
+    keyword whole GN1 _asm
+    keyword whole GN2 _asm
+    # - control the output
+    keyword whole LB _asm
+    # - output
+    keyword whole OUT _asm
+    # - pseudo: begin, end
+    keyword whole ADR _asm
+    keyword whole END _asm
+    # - extensions
+    keyword whole GN _asm
+    keyword whole NL _asm
+    keyword whole TB _asm
+    keyword whole LMI _asm
+    keyword whole LMD _asm
+    keyword whole CC _asm
+    keyword whole CGE _asm
+    keyword whole CLE _asm
+    keyword whole CE _asm
+    keyword whole LCH _asm
+    keyword whole NOT _asm
+    keyword whole TFT _asm
+    keyword whole TFF _asm
+    keyword whole RF _asm
+    keyword whole SCN _asm
+    # - label
+    keyword whole linestart \{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\]\n _lbl
+    # source
+    # - built-in keywords
+    wholechars abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.
+    keyword whole .SYNTAX _src
+    keyword whole .END _src
+    keyword whole .ID _src
+    keyword whole .STRING _src
+    keyword whole .NUMBER _src
+    keyword whole .LB _src
+    keyword whole .OUT _src
+    keyword whole .EMPTY _src
+    keyword whole .LABEL _src
+    # - extensions
+    keyword whole .RESERVED _src
+    keyword whole .INCLUDE _src
+    keyword whole .CON _src
+    keyword whole .FILE _src
+    keyword whole .NL _src
+    keyword whole .TB _src
+    keyword whole .LM\+ _src
+    keyword whole .LM- _src
+    keyword whole .TOKEN _src
+    keyword whole .DELTOK _src
+    keyword whole .ANY _src
+    # - metalinguistic variables
+    keyword \*\{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\] _id
+    keyword #\{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\] _id
+    keyword \{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\] _id
+    # - natural decimal integer numbers
+    keyword whole 0 _num
+    keyword whole \{123456789_\}\[0123456789_\] _num
+    # - assignment
+    keyword \{:=\} _assign
+    # - operators
+    keyword \{$:\*#!\} _oper
+    # - alternation
+    keyword / _comb
+    # - parentheses
+    keyword ( _paren
+    keyword ) _paren
+    keyword < _paren
+    keyword > _paren
+    keyword [ _paren
+    keyword ] _paren
+    # - terminators
+    keyword ., _sep
+    keyword ; _sep
+
+# strings
+
+context ' ' _str
+
+context " " _str
+
+# comments
+
+context % % _comment
+    keyword whole BUG        _alerthi
+    keyword whole DEPRECATED _alertmi
+    keyword whole FIXME      _alerthi
+    keyword whole NOTE       _alertlo
+    keyword whole TEST       _alertlo
+    keyword whole TODO       _alertmi
+    keyword whole WARN       _alertmi
+    spellcheck

--- a/misc/syntax/tree-meta.syntax
+++ b/misc/syntax/tree-meta.syntax
@@ -1,0 +1,210 @@
+# TREE-META (both source and object code) Syntax Highlighting Definition
+# Version 1.0.0 2026-03-19
+# See updates and changelog at https://github.com/jip/syntax-highlighting
+#
+# TREE-META is a metacompiler developed by D. Andrews and J. Rulifson in
+# the 1967, see:
+# Andrews, D. I., Rulifson, J. F. (1967). Tree Meta (Working Draft):
+# A Meta Compiler for the SDS 940. Stanford Research Institute, Menlo
+# Park, CA. Engelbart Collection, Stanford University Archive.
+#
+# This file is part of GNU Midnight Commander
+# https://midnight-commander.org/
+#
+# SPDX-FileCopyrightText: 2026 Igor Zhuravlov <zhuravlov.ip@ya.ru>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+caseinsensitive
+
+# for the default (lightgray on blue)
+define _alerthi lightgray red
+define _alertmi gray yellow
+define _alertlo gray cyan
+define _asm     cyan
+define _assign  white
+define _comb    yellow
+define _comment brown
+define _func    brightred
+define _id      lightgray
+define _lbl     white
+define _num     brightgreen
+define _oper    yellow
+define _paren   yellow
+define _sep     brightmagenta
+define _src     cyan
+define _str     brightcyan
+
+context default
+    # object code
+    keyword whole ADD _asm
+    keyword whole AND _asm
+    keyword whole BF _asm
+    keyword whole BRARG _asm
+    keyword whole BR _asm
+    keyword whole BT _asm
+    keyword whole CALL _asm
+    keyword whole CBTP _asm
+    keyword whole CELL _asm
+    keyword whole CGER _asm
+    keyword whole CHASE _asm
+    keyword whole CHRCODE _asm
+    keyword whole CHR _asm
+    keyword whole CKBR _asm
+    keyword whole CKCHR _asm
+    keyword whole CKDIG _asm
+    keyword whole CKHEX _asm
+    keyword whole CKID _asm
+    keyword whole CKLAB _asm
+    keyword whole CKLET _asm
+    keyword whole CKNDNAM _asm
+    keyword whole CKNUM _asm
+    keyword whole CKOCT _asm
+    keyword whole CKSR _asm
+    keyword whole CKTXT _asm
+    keyword whole CLABS _asm
+    keyword whole CMPEQ _asm
+    keyword whole CMPL _asm
+    keyword whole CMPNEQ _asm
+    keyword whole CMPSGET _asm
+    keyword whole CMPSGT _asm
+    keyword whole CMPSLET _asm
+    keyword whole CMPSLT _asm
+    keyword whole CMPUGET _asm
+    keyword whole CMPUGT _asm
+    keyword whole CMPULET _asm
+    keyword whole CMPULT _asm
+    keyword whole CNTCK _asm
+    keyword whole DIG _asm
+    keyword whole DUMP _asm
+    keyword whole EOR _asm
+    keyword whole ERCHK _asm
+    keyword whole ERSTR _asm
+    keyword whole FUNC _asm
+    keyword whole GNLB _asm
+    keyword whole HEX _asm
+    keyword whole ID _asm
+    keyword whole LBARG _asm
+    keyword whole LET _asm
+    keyword whole LNEG _asm
+    keyword whole LOADI _asm
+    keyword whole LOAD _asm
+    keyword whole LSH _asm
+    keyword whole MOVTO _asm
+    keyword whole MUL _asm
+    keyword whole NDLBL _asm
+    keyword whole NDMK _asm
+    keyword whole NEG _asm
+    keyword whole NUM _asm
+    keyword whole NXTBR _asm
+    keyword whole OCT _asm
+    keyword whole OER _asm
+    keyword whole ONL _asm
+    keyword whole OR _asm
+    keyword whole OUTCH _asm
+    keyword whole OUTCL _asm
+    keyword whole OUTRE _asm
+    keyword whole OUTSR _asm
+    keyword whole RC _asm
+    keyword whole RSTBR _asm
+    keyword whole RSTRP _asm
+    keyword whole R _asm
+    keyword whole SAVEP _asm
+    keyword whole SBTP _asm
+    keyword whole SDIV _asm
+    keyword whole SET _asm
+    keyword whole SMOD _asm
+    keyword whole SRARG _asm
+    keyword whole SRCHECK _asm
+    keyword whole SRINIT _asm
+    keyword whole SRP _asm
+    keyword whole SRSH _asm
+    keyword whole SR _asm
+    keyword whole STORE _asm
+    keyword whole SUB _asm
+    keyword whole TST _asm
+    keyword whole UDIV _asm
+    keyword whole UMOD _asm
+    keyword whole URSH _asm
+    # - label
+    keyword whole linestart %\{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\]: _lbl
+    keyword whole linestart \{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\]: _lbl
+    # source
+    # - keywords
+    wholechars abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.
+    keyword whole .CHR _src
+    keyword whole .DELIM _src
+    keyword whole .DIG _src
+    keyword whole .EMPTY _src
+    keyword whole .END _src
+    keyword whole .HEX _src
+    keyword whole .ID _src
+    keyword whole .LET _src
+    keyword whole .LIST _src
+    keyword whole .META _src
+    keyword whole .NUM _src
+    keyword whole .OCT _src
+    keyword whole .SR _src
+    wholechars abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
+    # - functions
+    keyword whole CLEAR _func
+    keyword whole CODE _func
+    keyword whole CONV _func
+    keyword whole ENTER _func
+    keyword whole LEN _func
+    keyword whole LOOK _func
+    keyword whole OUTC _func
+    keyword whole OUTL _func
+    keyword whole OUTS _func
+    keyword whole OUT _func
+    keyword whole POP _func
+    keyword whole PUSH _func
+    keyword whole XCONV _func
+    # - identifier
+    keyword whole \{abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\}\[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_\] _id
+    # - natural decimal integer numbers
+    keyword whole 0 _num
+    keyword whole \{123456789_\}\[0123456789_\] _num
+    # - label
+    keyword whole #\{1234\} _src
+    # - assignment
+    keyword := _assign
+    keyword => _assign
+    keyword = _assign
+    # - operators
+    keyword %% _oper
+    keyword // _oper
+    keyword <- _oper
+    keyword << _oper
+    keyword >>> _oper
+    keyword >> _oper
+    keyword <= _oper
+    keyword >= _oper
+    keyword \{!#$%&\*\+-.<=>?@^~\} _oper
+    # - alternation
+    keyword / _comb
+    keyword | _comb
+    # - parentheses
+    keyword ( _paren
+    keyword ) _paren
+    keyword [ _paren
+    keyword ] _paren
+    # - separators,terminator
+    keyword \{,:;\} _sep
+
+# strings
+
+context ' ' _str
+
+context " " _str
+
+# comments
+
+context £ £ _comment
+    keyword whole BUG        _alerthi
+    keyword whole DEPRECATED _alertmi
+    keyword whole FIXME      _alerthi
+    keyword whole NOTE       _alertlo
+    keyword whole TEST       _alertlo
+    keyword whole TODO       _alertmi
+    keyword whole WARN       _alertmi
+    spellcheck


### PR DESCRIPTION
## Proposed changes

1. Update syntax highlighting definition for J language.
2. Add syntax highlighting definition for BNF/EBNF/ABNF/WBNF metasyntax.
3. Add syntax highlighting definition for META II metasyntax
4. Add syntax highlighting definition for TREE-META metasyntax.

## Checklist

- [ ] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)

## Notes

1. I'm the author of original j.syntax added by #1491.
2. Test files and demo screenshots are located in  [jip/syntax-highlighting/mc](https://github.com/jip/syntax-highlighting/tree/master/mc).