### PR TITLE
doc: update a doubtful description of Preallocate space in the Spanish man page

### DIFF
--- a/doc/man/es/mc.1.in
+++ b/doc/man/es/mc.1.in
@@ -1119,9 +1119,11 @@ Sobreimpresiona una ventana de entrada con destino por defecto al directorio del
 panel no seleccionado y copia el archivo actualmente seleccionado (o
 los archivos marcados, si hay al menos uno marcado) al directorio especificado
 por el usuario en la ventana.
-El espacio de archivo de destino se puede preasignar en relación con la opción
-de configuración preallocate_space.
-Durante este proceso, podemos pulsar
+Si la opción
+.I Reservar espacio
+(preallocate_space) está activada, Midnight Commander intentará preasignar
+espacio para todo el archivo de destino antes de copiarlo.
+Durante el proceso de copia, podemos pulsar
 .IR Ctrl\-c " o " Esc
 para anular la operación. Para más detalles sobre la máscara de origen
 (que será normalmente * o ^\e(.*\e)$ dependiendo


### PR DESCRIPTION
## Proposed changes

This patch updates the Spanish translation of a doubtful sentence in the man page, see https://github.com/MidnightCommander/mc/pull/5096#pullrequestreview-4136392542

I'm sorry I have changed the sentence twice in an hour...

## Checklist

- [ ] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
