### PR TITLE
Add Brotli (`br`) extension to `filehighlight.ini`

### DIFF
--- a/misc/filehighlight.ini
+++ b/misc/filehighlight.ini
@@ -27,7 +27,7 @@
     regexp=(^#.*|.*~$)
 
 [archive]
-    extensions=7z;Z;aab;aar;ace;apk;arc;arj;ark;bz2;cab;cpio;deb;gz;lha;lz;lz4;lzh;lzma;lzo;rar;rpm;tar;tbz;tbz2;tgz;tlz;txz;tzo;tzst;vsix;xapk;xz;zip;zoo;zst
+    extensions=7z;Z;aab;aar;ace;apk;arc;arj;ark;br;bz2;cab;cpio;deb;gz;lha;lz;lz4;lzh;lzma;lzo;rar;rpm;tar;tbz;tbz2;tgz;tlz;txz;tzo;tzst;vsix;xapk;xz;zip;zoo;zst
 
 [doc]
     extensions=chm;css;ctl;diz;doc;docm;docx;dtd;fodg;fodp;fods;fodt;htm;html;json;letter;lsm;mail;man;markdown;md;me;mkd;msg;nroff;odg;odp;ods;odt;pdf;po;ppt;pptm;pptx;ps;rtf;sgml;shtml;tex;text;txt;xls;xlsm;xlsx;xml;xsd;xslt


### PR DESCRIPTION
Missing brotli extension

## Proposed changes

Miss .br highlights 

* Resolves: #5100 

## Checklist

<!-- _Put an `x` in the boxes that apply:_ -->

👉 Our coding style can be found here: https://midnight-commander.org/coding-style/ 👈

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [ ] I have signed-off my contribution with `git commit --amend -s`
- [ ] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)

