### PR TITLE
viewer: fix parse-mode error format mismatch (Fixes #5103)

### DIFF
--- a/src/viewer/mcviewer.c
+++ b/src/viewer/mcviewer.c
@@ -399,7 +399,7 @@ mcview_load (WView *view, const char *command, const char *file, int start_line,
                     if (fd1 == -1)
                     {
                         mcview_close_datasource (view);
-                        mcview_show_error (view, _ ("Cannot open\n%s\nin parse mode\n%s"), file);
+                        mcview_show_error (view, _ ("Cannot open\n%s\nin parse mode"), file);
                     }
                     else
                     {


### PR DESCRIPTION
This fixes a segfault in viewer parse-mode error handling.

Root cause: format string expected two %s arguments, but only one was passed.

Fix: in [mcviewer.c](vscode-file://vscode-app/snap/code/235/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), change the parse-mode error format to a single %s so it matches file_error_message() usage.

Regression introduced by d69da19 (mcviewer: use file_error_message()).

Fixes #5103.