### PR TITLE
Ticket #5103: fix parse-mode error format mismatch in viewer

### DIFF
--- a/src/viewer/mcviewer.c
+++ b/src/viewer/mcviewer.c
@@ -399,7 +399,7 @@ mcview_load (WView *view, const char *command, const char *file, int start_line,
                     if (fd1 == -1)
                     {
                         mcview_close_datasource (view);
-                        mcview_show_error (view, _ ("Cannot open\n%s\nin parse mode\n%s"), file);
+                        mcview_show_error (view, _ ("Cannot open\n%s\nin parse mode"), file);
                     }
                     else
                     {


### PR DESCRIPTION
This fixes a segfault in viewer parse-mode error handling.

- Root cause: format string expected two `%s` arguments, but only one was passed.

Fixes #5103.
Relates to #5058.