### PR TITLE
Ticket #5113: fix build due to C23 string function prototype changes

### DIFF
--- a/lib/serialize.c
+++ b/lib/serialize.c
@@ -80,10 +80,10 @@ static const char *
 go_to_end_of_serialized_string (const char *non_serialized_data,
                                 const char *already_serialized_part, size_t *offset)
 {
-    size_t calculated_offset;
     const char *semi_ptr = strchr (non_serialized_data + 1, SRLZ_DELIM_C);
+    const size_t calculated_offset =
+        (semi_ptr - non_serialized_data) + 1 + strlen (already_serialized_part);
 
-    calculated_offset = (semi_ptr - non_serialized_data) + 1 + strlen (already_serialized_part);
     if (calculated_offset >= strlen (non_serialized_data))
         return NULL;
 
@@ -149,17 +149,16 @@ mc_deserialize_str (const char prefix, const char *data, GError **error)
 
     {
         char buffer[BUF_TINY];
-        char *semi_ptr;
-        size_t semi_offset;
 
-        semi_ptr = strchr (data + 1, SRLZ_DELIM_C);
+        const char *semi_ptr = strchr (data + 1, SRLZ_DELIM_C);
         if (semi_ptr == NULL)
         {
             g_set_error (error, MC_ERROR, 0, FUNC_NAME ": Length delimiter '%c' doesn't exists",
                          SRLZ_DELIM_C);
             return NULL;
         }
-        semi_offset = semi_ptr - (data + 1);
+
+        const size_t semi_offset = semi_ptr - (data + 1);
         if (semi_offset >= BUF_TINY)
         {
             g_set_error (error, MC_ERROR, 0, FUNC_NAME ": Too big string length");

--- a/lib/strutil/replace.c
+++ b/lib/strutil/replace.c
@@ -61,7 +61,7 @@ str_replace_all (const char *haystack, const char *needle, const char *replaceme
 {
     size_t needle_len, replacement_len;
     GString *return_str = NULL;
-    char *needle_in_str;
+    const char *needle_in_str;
 
     needle_len = strlen (needle);
     replacement_len = strlen (replacement);
@@ -73,7 +73,7 @@ str_replace_all (const char *haystack, const char *needle, const char *replaceme
 
         if (str_is_char_escaped (haystack, needle_in_str))
         {
-            char *backslash = needle_in_str - 1;
+            const char *backslash = needle_in_str - 1;
 
             if (haystack != backslash)
                 g_string_append_len (return_str, haystack, backslash - haystack);

--- a/lib/vfs/path.c
+++ b/lib/vfs/path.c
@@ -346,7 +346,6 @@ vfs_path_from_str_deprecated_parser (char *path)
 
     while ((class = _vfs_split_with_semi_skip_count (path, &local, &op, 0)) != NULL)
     {
-        char *url_params;
         element = g_new0 (vfs_path_element_t, 1);
         element->class = class;
         if (local == NULL)
@@ -357,10 +356,10 @@ vfs_path_from_str_deprecated_parser (char *path)
         element->dir.converter =
             (element->encoding != NULL) ? str_crt_conv_from (element->encoding) : INVALID_CONV;
 
-        url_params = strchr (op, ':');  // skip VFS prefix
+        const char *url_params = strchr (op, ':');  // skip VFS prefix
         if (url_params != NULL)
         {
-            *url_params = '\0';
+            path[url_params - path] = '\0';  // truncate the path
             url_params++;
             vfs_path_url_split (element, url_params);
         }

--- a/src/filemanager/find.c
+++ b/src/filemanager/find.c
@@ -1169,9 +1169,7 @@ find_ignore_dir_search (const char *dir, size_t len)
                 break;
             case 1:  // dir is absolute, ignore_dir is relative
             {
-                char *d;
-
-                d = strstr (dir, *ignore_dir);
+                const char *d = strstr (dir, *ignore_dir);
                 if (d != NULL && IS_PATH_SEP (d[-1]) && (d[ilen] == '\0' || IS_PATH_SEP (d[ilen])))
                     return TRUE;
             }
@@ -1179,7 +1177,7 @@ find_ignore_dir_search (const char *dir, size_t len)
             case 2:  // dir is relative, ignore_dir is absolute
                 // FIXME: skip this case
                 break;
-            default:  // this cannot occurs
+            default:  // this cannot occur
                 return FALSE;
             }
         }

--- a/src/filemanager/panel.c
+++ b/src/filemanager/panel.c
@@ -2958,7 +2958,7 @@ chdir_other_panel (WPanel *panel)
 {
     const file_entry_t *entry;
     vfs_path_t *new_dir_vpath;
-    char *curr_entry = NULL;
+    const char *curr_entry = NULL;
     WPanel *p;
 
     entry = panel_current_entry (panel);

--- a/src/vfs/extfs/extfs.c
+++ b/src/vfs/extfs/extfs.c
@@ -233,7 +233,7 @@ extfs_find_entry_int (struct vfs_s_inode *dir, const char *name, GSList *list, i
 {
     struct vfs_s_entry *pent, *pdir;
     const char *p, *name_end;
-    char *q;
+    char *name_copy;
     char c = PATH_SEP;
     struct extfs_super_t *super;
 
@@ -246,17 +246,21 @@ extfs_find_entry_int (struct vfs_s_inode *dir, const char *name, GSList *list, i
 
     super = EXTFS_SUPER (dir->super);
     pent = dir->ent;
-    p = name;
-    name_end = name + strlen (name);
+
+    const size_t name_len = strlen (name);
+
+    name_copy = g_strndup (name, name_len);
+    p = name_copy;
+    name_end = name_copy + name_len;
 
     while ((pent != NULL) && (c != '\0') && (*p != '\0'))
     {
-        q = strchr (p, PATH_SEP);
+        const char *q = strchr (p, PATH_SEP);
         if (q == NULL)
-            q = (char *) name_end;
+            q = name_end;
 
         c = *q;
-        *q = '\0';
+        name_copy[q - name_copy] = '\0';
 
         if (DIR_IS_DOTDOT (p))
             pent = pent->dir != NULL ? pent->dir->ent : NULL;
@@ -267,14 +271,14 @@ extfs_find_entry_int (struct vfs_s_inode *dir, const char *name, GSList *list, i
             pent = extfs_resolve_symlinks_int (pent, list);
             if (pent == NULL)
             {
-                *q = c;
+                g_free (name_copy);
                 return NULL;
             }
 
             if (!S_ISDIR (pent->ino->st.st_mode))
             {
-                *q = c;
                 notadir = TRUE;
+                g_free (name_copy);
                 return NULL;
             }
 
@@ -283,9 +287,9 @@ extfs_find_entry_int (struct vfs_s_inode *dir, const char *name, GSList *list, i
             pent = pl != NULL ? VFS_ENTRY (pl->data) : NULL;
             if (pent != NULL && q + 1 > name_end)
             {
-                // Hack: I keep the original semanthic unless q+1 would break in the strchr
-                *q = c;
+                // Hack: I keep the original semantic unless q+1 would break in the strchr
                 notadir = !S_ISDIR (pent->ino->st.st_mode);
+                g_free (name_copy);
                 return pent;
             }
 
@@ -297,12 +301,16 @@ extfs_find_entry_int (struct vfs_s_inode *dir, const char *name, GSList *list, i
         }
 
         // Next iteration
-        *q = c;
+        name_copy[q - name_copy] = c;
         if (c != '\0')
             p = q + 1;
     }
+
+    g_free (name_copy);
+
     if (pent == NULL)
         my_errno = ENOENT;
+
     return pent;
 }
 


### PR DESCRIPTION
I just want to unblock the CI, so that I can merge PRs. Therefore, I'm not rewriting the code to make it better, but just trying to make sure that it remains correct and functions like it was before.

The part about `extfs_find_entry_int` I find particularly disgusting. Apparently, this function was modifying strings passed to it through pointer trickery without the callers even knowing. I don't know of a simple way to fix this without rewriting other than just making a copy of the incoming string. The whole logic of this function doesn't make sense to me.

Blocking:

* #5114
* #5111
* #5110
* #5109
* #5089
