### PR TITLE
skins: add Tokyo Night truecolor skin

### DIFF
--- a/misc/skins/Makefile.am
+++ b/misc/skins/Makefile.am
@@ -36,6 +36,7 @@ SKINS = \
 	seasons-spring16M.ini \
 	seasons-summer16M.ini \
 	seasons-winter16M.ini \
+	tokyo-night-16M.ini \
 	xoria256-thin.ini \
 	xoria256.ini \
 	xoria256root-thin.ini \

--- a/misc/skins/tokyo-night-16M.ini
+++ b/misc/skins/tokyo-night-16M.ini
@@ -1,0 +1,191 @@
+# Tokyo Night — truecolor skin based on the Tokyo Night palette by enkia
+# (https://github.com/enkia/tokyo-night-vscode-theme).
+
+[skin]
+    description = Tokyo Night
+    truecolors = true
+
+[lines]
+    horiz = ─
+    vert = │
+    lefttop = ┌
+    righttop = ┐
+    leftbottom = └
+    rightbottom = ┘
+    topmiddle = ┬
+    bottommiddle = ┴
+    leftmiddle = ├
+    rightmiddle = ┤
+    cross = ┼
+    dhoriz = ─
+    dvert = │
+    dlefttop = ┌
+    drighttop = ┐
+    dleftbottom = └
+    drightbottom = ┘
+    dtopmiddle = ┬
+    dbottommiddle = ┴
+    dleftmiddle = ├
+    drightmiddle = ┤
+
+[aliases]
+    # Tokyo Night palette
+    Bg = #1a1b26
+    BgDark = #16161e
+    Surface = #32344a
+    SelBg = #283457
+    Fg = #a9b1d6
+    FgBright = #c0caf5
+    FgDark = #787c99
+    Comment = #444b6a
+    Blue = #7aa2f7
+    Cyan = #0db9d7
+    LightCyan = #7dcfff
+    Teal = #449dab
+    Yellow = #e0af68
+    Green = #9ece6a
+    Red = #f7768e
+    BrightRed = #ff7a93
+    Purple = #bb9af7
+    Magenta = #ad8ee6
+    DarkRed = #6f3a3f
+    DarkGreen = #2d4a3a
+    DarkRedTint = #4d2d3a
+
+[core]
+    _default_ = Fg;Bg
+    selected = FgBright;SelBg
+    marked = Yellow;;bold
+    markselect = Yellow;SelBg;bold
+    gauge = ;SelBg
+    input = Fg;Surface
+    inputunchanged = FgDark;Surface
+    inputmark = Bg;Blue
+    disabled = Comment;Surface
+    reverse = Bg;Fg
+    hintbar = default;default
+    shellprompt = default;default
+    commandline = default;default
+    commandlinemark = Bg;Blue
+    header = Blue;Bg
+    shadow = Comment;BgDark
+    frame = Fg;Bg
+
+[dialog]
+    _default_ = Fg;Comment
+    dfocus = FgBright;SelBg
+    dhotnormal = ;;underline
+    dhotfocus = FgBright;SelBg;underline
+    dselnormal = ;SelBg
+    dselfocus = ;SelBg
+    dtitle = ;;bold
+    dframe = Fg;Comment
+
+[error]
+    _default_ = Red;BgDark;bold
+    errdfocus = BgDark;Red;bold
+    errdhotnormal = Yellow;BgDark;bold+underline
+    errdhotfocus = BgDark;Red;bold+underline
+    errdtitle = FgBright;BgDark;bold
+    errdframe = Red;BgDark
+
+[filehighlight]
+    _default_ =
+    directory = Blue
+    executable = Green
+    symlink = Cyan
+    hardlink = LightCyan
+    stalelink = Red
+    device = Magenta
+    special = Yellow
+    core = Red
+    temp = FgDark
+    archive = Yellow
+    doc = Purple
+    source = Teal
+    media = Green
+    graph = Cyan
+    database = BrightRed
+
+[menu]
+    _default_ = Fg;Comment
+    menusel = FgBright;SelBg
+    menuhot = Yellow;Comment
+    menuhotsel = Yellow;SelBg;underline
+    menuinactive = FgDark;Surface
+    menuframe = Fg;Comment
+
+[popupmenu]
+    _default_ = Fg;Comment
+    menusel = FgBright;SelBg
+    menutitle = FgBright;Comment;bold
+    menuframe = Fg;Comment
+
+[buttonbar]
+    hotkey = Red;Surface
+    button = Fg;Surface
+
+[statusbar]
+    _default_ = FgBright;SelBg
+
+[help]
+    _default_ = Fg;Surface
+    helpbold = Blue;Surface;bold
+    helpitalic = Yellow;Surface;italic
+    helplink = Cyan;Surface;underline
+    helpslink = Bg;Cyan
+    helpframe = Fg;Surface
+
+[editor]
+    _default_ = Fg;Bg
+    editbold = Yellow;Bg;bold
+    editmarked = FgBright;SelBg
+    editwhitespace = Comment;Bg
+    editnonprintable = Red;Bg
+    editlinestate = FgDark;Surface
+    bookmark = Bg;Yellow
+    bookmarkfound = Bg;Green
+    editrightmargin = Comment;Surface
+    editbg = ;BgDark
+    editframe = Comment
+    editframeactive = Blue
+    editframedrag = FgBright
+
+[viewer]
+    _default_ = Fg;Bg
+    viewbold = FgBright;Bg;bold
+    viewunderline = Cyan;Bg;underline
+    viewboldunderline = FgBright;Bg;bold+underline
+    viewselected = Bg;Yellow
+    viewframe = Fg;Bg
+
+[diffviewer]
+    added = ;DarkGreen
+    changedline = ;Surface
+    changednew = ;DarkGreen
+    changed = ;DarkRedTint
+    removed = ;DarkRedTint
+    error = FgBright;DarkRed
+
+[widget-panel]
+    sort-up-char = ▴
+    sort-down-char = ▾
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ◂
+    history-next-item-char = ▸
+    history-show-list-char = ▾
+    filename-scroll-left-char = ◂
+    filename-scroll-right-char = ▸
+
+[widget-scrollbar]
+    up-char = ▲
+    down-char = ▼
+    left-char = ◀
+    right-char = ▶
+    thumb-char = ■
+    track-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕


### PR DESCRIPTION
## Summary

Adds a Tokyo Night skin for Midnight Commander using truecolor (`#rrggbb`) values.

Tokyo Night is a widely-used dark color scheme originally created by [enkia](https://github.com/enkia/tokyo-night-vscode-theme) for VS Code. It has since been ported to many editors and terminal tools. This skin brings the same palette to mc.

### Color palette used

| Role | Color |
|------|-------|
| Background | `#1a1b26` |
| Foreground | `#a9b1d6` |
| Accent blue | `#7aa2f7` |
| Accent cyan | `#0db9d7` |
| Yellow | `#e0af68` |
| Green | `#9ece6a` |
| Red | `#f7768e` |
| Purple | `#bb9af7` |
| Comment | `#444b6a` |

### Requirements

A truecolor-capable terminal emulator. The skin sets `truecolors = true` in its `[skin]` header per the convention described in `misc/skins/README.txt`.

## Test plan

- [ ] Load skin with `mc -S tokyo-night-16M`
- [ ] Verify panels, dialogs, editor, viewer and diffviewer all render correctly
- [ ] Confirm on a non-truecolor terminal that mc falls back gracefully