### PR TITLE
u7z should canonicalize 7-Zip binary path returned by command -v

### DIFF
--- a/src/vfs/extfs/helpers/u7z
+++ b/src/vfs/extfs/helpers/u7z
@@ -24,10 +24,33 @@
 # 7za    | Version that supports major formats only, has no plugins, and is smaller than the full version
 # 7zr    | Most limited version, which only supports the LZMA and related formats and cannot handle encrypted archives
 
-P7ZIP=`command -v 7z 2>/dev/null` \
-    || P7ZIP=`command -v 7zz 2>/dev/null` \
-    || P7ZIP=`command -v 7za 2>/dev/null` \
-    || P7ZIP=`command -v 7zr 2>/dev/null` \
+mcu7zip_find_binary ()
+{
+    cmd=$1
+    path=`command -v "$cmd" 2>/dev/null` || return 1
+
+    case $path in
+        */*)
+            dir=${path%/*}
+            base=${path##*/}
+
+            # Canonicalize the directory component. Some systems have
+            # compatibility symlinks such as /usr/sbin -> /usr/bin, and
+            # modular 7-Zip builds may derive the location of 7z.so from
+            # the invoked pathname.
+            dir=`cd -P "$dir" 2>/dev/null && pwd -P` || return 1
+            printf '%s\n' "$dir/$base"
+            ;;
+        *)
+            printf '%s\n' "$path"
+            ;;
+    esac
+}
+
+P7ZIP=`mcu7zip_find_binary 7z` \
+    || P7ZIP=`mcu7zip_find_binary 7zz` \
+    || P7ZIP=`mcu7zip_find_binary 7za` \
+    || P7ZIP=`mcu7zip_find_binary 7zr` \
     || P7ZIP=""
 
 # Let the test framework hook in:


### PR DESCRIPTION
Midnight Commander's `u7z` extfs helper currently selects the 7-Zip backend using `command -v`, preferring `7z`, then `7zz`, `7za`, and `7zr`.

On Fedora Linux 44, this can break archive browsing when MC is started as root. Fedora has `/usr/sbin` as a symlink to `/usr/bin`:

```text
/bin -> usr/bin
/sbin -> usr/sbin
/usr/sbin -> bin
```

A root login shell commonly has `/usr/sbin` before `/usr/bin` in `PATH`. As a result, `command -v 7z` returns:

```text
/usr/sbin/7z
```

even though this is only another pathname for the same file as:

```text
/usr/bin/7z
```

This can be verified with:

```sh
type -a 7z
stat -c '%d:%i %h %n' /usr/bin/7z /usr/sbin/7z
namei -l /usr/sbin/7z /usr/bin/7z
```

On my Fedora system:

```text
type -a 7z
7z is /usr/sbin/7z
7z is /usr/bin/7z

stat -c '%d:%i %h %n' /usr/bin/7z /usr/sbin/7z
64512:1048855 1 /usr/bin/7z
64512:1048855 1 /usr/sbin/7z
```

`/usr/sbin/7z` and `/usr/bin/7z` are the same inode reached through a directory symlink.

However, invoking 7-Zip through `/usr/sbin/7z` fails:

```sh
/usr/sbin/7z l /tmp/test.7z
```

Result:

```text
Codec Load Error: /usr/sbin/7z.so : errno=2 : No such file or directory

ERROR: /tmp/test.7z : Cannot open the file as archive
```

Invoking the same binary as `/usr/bin/7z` works:

```sh
/usr/bin/7z l /tmp/test.7z
```

Starting MC as root with `/usr/bin` before `/usr/sbin` also makes archive browsing work:

```sh
PATH=/usr/bin:/usr/sbin:/bin:/sbin mc
```

So MC is not directly responsible for 7-Zip's fragile module lookup, but `u7z` currently preserves the non-canonical path returned by `command -v`, which exposes the problem.

A distro-neutral workaround inside `u7z` is to canonicalize the directory component of the path returned by `command -v`. This keeps the existing backend preference order intact — `7z`, `7zz`, `7za`, `7zr` — but avoids invoking `7z` through compatibility symlink paths such as `/usr/sbin/7z`.

This PR avoids hardcoding `/usr/bin/7z`, does not reorder the supported 7-Zip variants, does not depend on non-POSIX utilities such as `realpath` or `readlink -f`, and preserves the existing `MC_TEST_EXTFS_LIST_CMD` test hook.

Yes, this is ultimately a 7-Zip/Fedora issue. However, extfs helpers already sit at the boundary between MC and external tools, and canonicalizing the selected executable path is a low-risk defensive measure. It preserves the existing 7z/7zz/7za/7zr preference order, does not hardcode Fedora paths, and avoids invoking helper binaries through compatibility directory symlinks.
