### PR TITLE
Added mtime and file size in "Find file" results

### DIFF
--- a/doc/man/mc.1.in
+++ b/doc/man/mc.1.in
@@ -1421,6 +1421,9 @@ You can start the search by pressing the OK button.
 During the search you can stop from the Stop button and continue from
 the Start button.
 .PP
+The list of found files shows the modification time of each file at the
+right edge, unless the window is too narrow to display it.
+.PP
 You can browse the filelist with the up and down arrow keys. The Chdir
 button will change to the directory of the currently selected
 file. The Again button will ask for the parameters for a new

--- a/doc/man/mc.1.in
+++ b/doc/man/mc.1.in
@@ -1421,8 +1421,8 @@ You can start the search by pressing the OK button.
 During the search you can stop from the Stop button and continue from
 the Start button.
 .PP
-The list of found files shows the modification time of each file at the
-right edge, unless the window is too narrow to display it.
+The list of found files shows the modification time and the size of each
+file at the right edge, unless the window is too narrow to display them.
 .PP
 You can browse the filelist with the up and down arrow keys. The Chdir
 button will change to the directory of the currently selected

--- a/lib/widget/listbox.c
+++ b/lib/widget/listbox.c
@@ -53,6 +53,9 @@ const global_keymap_t *listbox_map = NULL;
 /* Gives the position of the last item. */
 #define LISTBOX_LAST(l) (listbox_is_empty (l) ? 0 : (int) g_queue_get_length ((l)->list) - 1)
 
+/* Minimal width of the entry text left when the right text is shown. */
+#define LISTBOX_MIN_TEXT_WIDTH 16
+
 /*** file scope type declarations ****************************************************************/
 
 /*** forward declarations (file scope functions) *************************************************/
@@ -82,6 +85,7 @@ listbox_entry_free (void *data)
     WLEntry *e = data;
 
     g_free (e->text);
+    g_free (e->rtext);
     if (e->free_data)
         g_free (e->data);
     g_free (e);
@@ -138,6 +142,7 @@ listbox_draw (WListbox *l, gboolean focused)
     const int *colors;
     gboolean disabled;
     int normalc, selc, scrollbarc;
+    const int width = w->cols - 2;
     int length = 0;
     GList *le = NULL;
     int pos;
@@ -164,6 +169,8 @@ listbox_draw (WListbox *l, gboolean focused)
     for (i = 0; i < w->lines; i++)
     {
         const char *text = "";
+        const char *rtext = NULL;
+        int rwidth = 0;
 
         // Display the entry
         if (pos == l->current && sel_line == -1)
@@ -181,11 +188,26 @@ listbox_draw (WListbox *l, gboolean focused)
             WLEntry *e = LENTRY (le->data);
 
             text = e->text;
+            rtext = e->rtext;
             le = g_list_next (le);
             pos++;
         }
 
-        tty_print_string (str_fit_to_term (text, w->cols - 2, J_LEFT_FIT));
+        if (rtext != NULL && *rtext != '\0')
+        {
+            rwidth = str_term_width1 (rtext) + 1;  // + 1 space between the texts
+
+            // show the right text only if a reasonable part of the entry remains visible
+            if (width - rwidth < LISTBOX_MIN_TEXT_WIDTH)
+                rwidth = 0;
+        }
+
+        tty_print_string (str_fit_to_term (text, width - rwidth, J_LEFT_FIT));
+        if (rwidth != 0)
+        {
+            tty_print_char (' ');
+            tty_print_string (rtext);
+        }
     }
 
     l->cursor_y = sel_line;
@@ -849,6 +871,31 @@ char *
 listbox_add_item_take (WListbox *l, listbox_append_t pos, int hotkey, char *text, void *data,
                        gboolean free_data)
 {
+    return listbox_add_item_take_rtext (l, pos, hotkey, text, NULL, data, free_data);
+}
+
+/* --------------------------------------------------------------------------------------------- */
+
+/**
+ * Add new item with additional right aligned text to the listbox.
+ *
+ * @param l WListbox object
+ * @param pos position of the item
+ * @param hotkey position of the item
+ * @param text item text. Ownership of the text is transferred to the @l.
+ * @param rtext text shown at the right edge of the @l, or NULL. Ownership of the text is
+ *              transferred to the @l.
+ * @param data item data
+ * @param free_data if TRUE free the @data when @l is destroyed,
+ *
+ * After this call, @text and @rtext belong to the @l and may no longer be modified by the caller.
+ *
+ * @return pointer to @text.
+ */
+char *
+listbox_add_item_take_rtext (WListbox *l, listbox_append_t pos, int hotkey, char *text, char *rtext,
+                             void *data, gboolean free_data)
+{
     WLEntry *entry;
 
     if (l == NULL)
@@ -859,6 +906,7 @@ listbox_add_item_take (WListbox *l, listbox_append_t pos, int hotkey, char *text
 
     entry = g_new (WLEntry, 1);
     entry->text = text;
+    entry->rtext = rtext;
     entry->data = data;
     entry->free_data = free_data;
     entry->hotkey = hotkey;

--- a/lib/widget/listbox.h
+++ b/lib/widget/listbox.h
@@ -35,7 +35,8 @@ typedef lcback_ret_t (*lcback_fn) (struct WListbox *l);
 
 typedef struct WLEntry
 {
-    char *text;  // Text to display
+    char *text;   // Text to display
+    char *rtext;  // Optional text to display at the right edge of the widget
     int hotkey;
     void *data;          // Client information
     gboolean free_data;  // Whether to free the data on entry's removal
@@ -78,6 +79,8 @@ char *listbox_add_item (WListbox *l, listbox_append_t pos, int hotkey, const cha
                         gboolean free_data);
 char *listbox_add_item_take (WListbox *l, listbox_append_t pos, int hotkey, char *text, void *data,
                              gboolean free_data);
+char *listbox_add_item_take_rtext (WListbox *l, listbox_append_t pos, int hotkey, char *text,
+                                   char *rtext, void *data, gboolean free_data);
 
 /*** inline functions ****************************************************************************/
 

--- a/src/filemanager/find.c
+++ b/src/filemanager/find.c
@@ -46,11 +46,11 @@
 #include "lib/mcconfig.h"
 #include "lib/vfs/vfs.h"
 #include "lib/strutil.h"
-#include "lib/timefmt.h"  // file_date()
+#include "lib/timefmt.h"  // file_date(), i18n_checktimelength()
 #include "lib/widget.h"
-#include "lib/util.h"  // canonicalize_pathname()
+#include "lib/util.h"  // canonicalize_pathname(), size_trunc_len()
 
-#include "src/setup.h"    // verbose
+#include "src/setup.h"    // verbose, panels_options
 #include "src/history.h"  // MC_HISTORY_SHARED_SEARCH
 
 #include "dir.h"
@@ -64,6 +64,9 @@
 
 #define MAX_REFRESH_INTERVAL  (G_USEC_PER_SEC / 20)  // 50 ms
 #define MIN_REFRESH_FILE_SIZE (256 * 1024)           // 256 KB
+
+// Width of the file size shown in the result list: up to 3 digits and a unit suffix
+#define FIND_SIZE_WIDTH 4
 
 /*** file scope type declarations ****************************************************************/
 
@@ -864,29 +867,50 @@ clear_stack (void)
 /* --------------------------------------------------------------------------------------------- */
 
 /**
- * Get the modification time of DIRECTORY/FILE formatted as in the file panels,
- * or NULL if it cannot be obtained.
+ * Format the modification time and the size of the file described by @st the way the file
+ * panels do.
+ *
+ * @return newly allocated string
  */
 
 static char *
-get_file_date (const char *dir, const char *file)
+format_file_info (const struct stat *st)
+{
+    char size[BUF_TINY];
+
+    size_trunc_len (size, FIND_SIZE_WIDTH, (uintmax_t) st->st_size, 0, panels_options.kilobyte_si);
+
+    return g_strdup_printf (
+        "%s %*s", str_fit_to_term (file_date (st->st_mtime), (int) i18n_checktimelength (), J_LEFT),
+        FIND_SIZE_WIDTH, size);
+}
+
+/* --------------------------------------------------------------------------------------------- */
+
+/**
+ * Get the modification time and the size of DIRECTORY/FILE formatted as in the file panels,
+ * or NULL if they cannot be obtained.
+ */
+
+static char *
+get_file_info (const char *dir, const char *file)
 {
     vfs_path_t *vpath;
     struct stat st;
-    char *date = NULL;
+    char *info = NULL;
 
     vpath = vfs_path_build_filename (dir, file, (char *) NULL);
     if ((options.follow_symlinks ? mc_stat (vpath, &st) : mc_lstat (vpath, &st)) == 0)
-        date = g_strdup (file_date (st.st_mtime));
+        info = format_file_info (&st);
     vfs_path_free (vpath, TRUE);
 
-    return date;
+    return info;
 }
 
 /* --------------------------------------------------------------------------------------------- */
 
 static void
-insert_file (const char *dir, const char *file, gsize start, gsize end, char *date)
+insert_file (const char *dir, const char *file, gsize start, gsize end, char *info)
 {
     char *tmp_name;
     static char *dirname = NULL;
@@ -915,20 +939,20 @@ insert_file (const char *dir, const char *file, gsize start, gsize end, char *da
     location->dir = dirname;
     location->start = start;
     location->end = end;
-    add_to_list_take (tmp_name, date, location);
+    add_to_list_take (tmp_name, info, location);
 }
 
 /* --------------------------------------------------------------------------------------------- */
 
 /**
- * Add a match to the list. Ownership of @date, the modification time of the found file,
- * is transferred to the list.
+ * Add a match to the list. Ownership of @info, the modification time and the size of the
+ * found file, is transferred to the list.
  */
 
 static void
-find_add_match (const char *dir, const char *file, gsize start, gsize end, char *date)
+find_add_match (const char *dir, const char *file, gsize start, gsize end, char *info)
 {
-    insert_file (dir, file, start, end, date);
+    insert_file (dir, file, start, end, info);
 
     // Don't scroll
     if (matches == 0)
@@ -1111,7 +1135,7 @@ search_content (WDialog *h, const char *directory, const char *filename)
                 found_start =
                     off + search_content_handle->normal_offset + 1;  // off by one: ticket 3280
                 find_add_match (directory, result, found_start, found_start + found_len,
-                                g_strdup (file_date (s.st_mtime)));
+                                format_file_info (&s));
                 found = TRUE;
             }
 
@@ -1395,7 +1419,7 @@ do_search (WDialog *h)
             {
                 if (content_pattern == NULL)
                     find_add_match (directory, dp->d_name, 0, 0,
-                                    get_file_date (directory, dp->d_name));
+                                    get_file_info (directory, dp->d_name));
                 else if (search_content (h, directory, dp->d_name))
                     return 1;
             }

--- a/src/filemanager/find.c
+++ b/src/filemanager/find.c
@@ -46,6 +46,7 @@
 #include "lib/mcconfig.h"
 #include "lib/vfs/vfs.h"
 #include "lib/strutil.h"
+#include "lib/timefmt.h"  // file_date()
 #include "lib/widget.h"
 #include "lib/util.h"  // canonicalize_pathname()
 
@@ -348,9 +349,10 @@ add_to_list (const char *text, void *data)
 /* --------------------------------------------------------------------------------------------- */
 
 static inline char *
-add_to_list_take (char *text, void *data)
+add_to_list_take (char *text, char *rtext, void *data)
 {
-    return listbox_add_item_take (find_list, LISTBOX_APPEND_AT_END, 0, text, data, TRUE);
+    return listbox_add_item_take_rtext (find_list, LISTBOX_APPEND_AT_END, 0, text, rtext, data,
+                                        TRUE);
 }
 
 /* --------------------------------------------------------------------------------------------- */
@@ -861,8 +863,30 @@ clear_stack (void)
 
 /* --------------------------------------------------------------------------------------------- */
 
+/**
+ * Get the modification time of DIRECTORY/FILE formatted as in the file panels,
+ * or NULL if it cannot be obtained.
+ */
+
+static char *
+get_file_date (const char *dir, const char *file)
+{
+    vfs_path_t *vpath;
+    struct stat st;
+    char *date = NULL;
+
+    vpath = vfs_path_build_filename (dir, file, (char *) NULL);
+    if ((options.follow_symlinks ? mc_stat (vpath, &st) : mc_lstat (vpath, &st)) == 0)
+        date = g_strdup (file_date (st.st_mtime));
+    vfs_path_free (vpath, TRUE);
+
+    return date;
+}
+
+/* --------------------------------------------------------------------------------------------- */
+
 static void
-insert_file (const char *dir, const char *file, gsize start, gsize end)
+insert_file (const char *dir, const char *file, gsize start, gsize end, char *date)
 {
     char *tmp_name;
     static char *dirname = NULL;
@@ -891,15 +915,20 @@ insert_file (const char *dir, const char *file, gsize start, gsize end)
     location->dir = dirname;
     location->start = start;
     location->end = end;
-    add_to_list_take (tmp_name, location);
+    add_to_list_take (tmp_name, date, location);
 }
 
 /* --------------------------------------------------------------------------------------------- */
 
+/**
+ * Add a match to the list. Ownership of @date, the modification time of the found file,
+ * is transferred to the list.
+ */
+
 static void
-find_add_match (const char *dir, const char *file, gsize start, gsize end)
+find_add_match (const char *dir, const char *file, gsize start, gsize end, char *date)
 {
-    insert_file (dir, file, start, end);
+    insert_file (dir, file, start, end, date);
 
     // Don't scroll
     if (matches == 0)
@@ -1081,7 +1110,8 @@ search_content (WDialog *h, const char *directory, const char *filename)
                 g_snprintf (result, sizeof (result), "%d:%s", line, filename);
                 found_start =
                     off + search_content_handle->normal_offset + 1;  // off by one: ticket 3280
-                find_add_match (directory, result, found_start, found_start + found_len);
+                find_add_match (directory, result, found_start, found_start + found_len,
+                                g_strdup (file_date (s.st_mtime)));
                 found = TRUE;
             }
 
@@ -1364,7 +1394,8 @@ do_search (WDialog *h)
             if (search_ok)
             {
                 if (content_pattern == NULL)
-                    find_add_match (directory, dp->d_name, 0, 0);
+                    find_add_match (directory, dp->d_name, 0, 0,
+                                    get_file_date (directory, dp->d_name));
                 else if (search_content (h, directory, dp->d_name))
                     return 1;
             }


### PR DESCRIPTION
Hi,

I started in the mid 80's with the Norton Commander under MS-DOS 3. Then in 1996 I started using Linux with Midnight Commander. I also use Free Commander under Windows. I just can't away from this two panel tools. One thing always missed in mc was this: When using the "Find file" function, I got files with same name results in different directories but was missing meta data of the files found at this place. I wanted to know if it is the same (same date and size) or if it is a newer/different version of the file. Now I added this feature for myself.

Your pull request form I tried filling out:

- [no] I have referenced the issue(s) resolved by this PR (if any)
No PR found for this.
- [yes ] I have signed-off my contribution with `git commit --amend -s`
- [ yes] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [no] I have added tests that prove my fix is effective or that my feature works
How to implement testing for this? I tested it visually with several terminal resolutions (cols, rows) and IMHO it always looks good.
- [no ] I have added the necessary documentation (if appropriate)
Not sure if documentation is even needed for this additional information the upgrade provides.

I hope you and the vast majority of mc find this patch useful. 

Best regards
Tobias
