### PR TITLE
Fix bad fd mode error in Reget when file cloning has failed

### DIFF
--- a/src/filemanager/file.c
+++ b/src/filemanager/file.c
@@ -2621,7 +2621,7 @@ copy_file_file (file_op_context_t *ctx, const char *src_path, const char *dst_pa
         // FICLONERANGE on Linux and copy_file_range(2) on FreeBSD support block-aligned ranges for
         // cloning, but for not in O_APPEND mode. Use O_WRONLY + mc_lseek instead as we don't care
         // about atomicity in our use cases.
-        open_flags |= mc_global.vfs.file_cloning ? O_WRONLY : O_APPEND;
+        open_flags |= mc_global.vfs.file_cloning ? 0 : O_APPEND;
 #else
         open_flags |= O_APPEND;
 #endif
@@ -2674,7 +2674,7 @@ open_dest:
             ctx->do_append = TRUE;
             mc_close (dest_desc);
             dst_status = DEST_NONE;
-            open_flags = (open_flags & ~O_WRONLY) | O_APPEND;
+            open_flags |= O_APPEND;
             goto open_dest;
         }
     }


### PR DESCRIPTION
## Proposed changes

- Don't clear O_WRONLY flag when reopening the destination file in O_APPEND mode.
- Remove misleading duplicate O_WRONLY setting.

* Resolves: https://github.com/MidnightCommander/mc/issues/5082#issuecomment-5301570058

## Checklist

- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)

