### PR TITLE
Hot-reload the active skin when its file changes on disk

### DIFF
--- a/src/filemanager/boxes.c
+++ b/src/filemanager/boxes.c
@@ -485,6 +485,16 @@ task_cb (WButton *button, int action)
 /*** public functions ****************************************************************************/
 /* --------------------------------------------------------------------------------------------- */
 
+/* Re-read the currently configured skin from disk and redraw. Used to hot-reload
+   the skin file when it changes on disk (see the skin_watch_* functions in main.c). */
+void
+mc_skin_reload (void)
+{
+    skin_apply (NULL);
+}
+
+/* --------------------------------------------------------------------------------------------- */
+
 void
 about_box (void)
 {

--- a/src/filemanager/boxes.h
+++ b/src/filemanager/boxes.h
@@ -18,6 +18,7 @@
 
 /*** declarations of public functions ************************************************************/
 
+void mc_skin_reload (void);
 void about_box (void);
 void configure_box (void);
 void appearance_box (void);

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,7 @@
 
 #include <config.h>
 
+#include <errno.h>
 #include <locale.h>
 #include <pwd.h>  // for username in xterm title
 #include <stdio.h>
@@ -40,6 +41,9 @@
 #include <sys/wait.h>
 #include <signal.h>
 #include <unistd.h>  // getsid()
+#ifdef __linux__
+#include <sys/inotify.h>  // skin hot-reload watch
+#endif
 
 #include "lib/global.h"
 
@@ -60,6 +64,7 @@
 #include "filemanager/ext.h"      // flush_extension_file()
 #include "filemanager/command.h"  // cmdline
 #include "filemanager/panel.h"    // panalized_panel
+#include "filemanager/boxes.h"    // mc_skin_reload()
 
 #ifdef USE_INTERNAL_EDIT
 #include "editor/edit.h"  // edit_arg_free()
@@ -90,8 +95,80 @@
 
 /*** file scope variables ************************************************************************/
 
+#ifdef __linux__
+// Hot-reload: watch the active skin file and re-apply it on change.
+static int skin_watch_fd = -1;
+#endif
+
 /* --------------------------------------------------------------------------------------------- */
 /*** file scope functions ************************************************************************/
+/* --------------------------------------------------------------------------------------------- */
+
+#ifdef __linux__
+
+/* Arm the watch on whatever skin file is currently loaded. Only called once,
+   at startup: our write pattern (in-place truncate+write, not rename) never
+   invalidates the watch descriptor, so there is nothing to re-arm on reload.
+   (Calling inotify_rm_watch() from the event callback would itself raise
+   IN_IGNORED on the same fd, which the next select() sees immediately --
+   an infinite self-triggering loop.) */
+static void
+skin_watch_arm (void)
+{
+    if (mc_skin__default.config == NULL || mc_skin__default.config->ini_path == NULL)
+        return;
+
+    inotify_add_watch (skin_watch_fd, mc_skin__default.config->ini_path,
+                       IN_MODIFY | IN_CLOSE_WRITE);
+}
+
+/* --------------------------------------------------------------------------------------------- */
+
+static int
+skin_watch_callback (int fd, void *info)
+{
+    char buf[4096] __attribute__ ((aligned (__alignof__ (struct inotify_event))));
+
+    (void) info;
+
+    // Drain all pending events before acting; a plain "w" rewrite of the skin
+    // file typically raises both IN_MODIFY and IN_CLOSE_WRITE for one save.
+    while (read (fd, buf, sizeof (buf)) > 0)
+        ;
+
+    mc_skin_reload ();
+
+    return 0;
+}
+
+/* --------------------------------------------------------------------------------------------- */
+
+static void
+skin_watch_init (void)
+{
+    skin_watch_fd = inotify_init1 (IN_NONBLOCK | IN_CLOEXEC);
+    if (skin_watch_fd < 0)
+        return;
+
+    skin_watch_arm ();
+    add_select_channel (skin_watch_fd, skin_watch_callback, NULL);
+}
+
+/* --------------------------------------------------------------------------------------------- */
+
+static void
+skin_watch_deinit (void)
+{
+    if (skin_watch_fd < 0)
+        return;
+
+    delete_select_channel (skin_watch_fd);
+    close (skin_watch_fd);
+    skin_watch_fd = -1;
+}
+
+#endif  // __linux__
+
 /* --------------------------------------------------------------------------------------------- */
 
 /** POSIX version.  The only version we support.  */
@@ -372,6 +449,10 @@ main (int argc, char *argv[])
 
     mc_error_message (&mcerror, NULL);
 
+#ifdef __linux__
+    skin_watch_init ();
+#endif
+
 #ifdef ENABLE_SUBSHELL
     // Done here to ensure that the subshell doesn't
     // inherit the file descriptors opened below, etc
@@ -449,6 +530,10 @@ main (int argc, char *argv[])
     vfs_shut ();
 
     flush_extension_file ();  // does only free memory
+
+#ifdef __linux__
+    skin_watch_deinit ();
+#endif
 
     mc_skin_deinit ();
     tty_colors_done ();


### PR DESCRIPTION
This is a prerequisite for mc following live theme-switches on Omarchy (something I've wanted for a while).

Made with Claude.

Notes from Claude:

## Proposed changes

Currently, picking up a change to the current skin's `.ini` file requires restarting mc, or re-selecting the same skin from Options > Appearance. This is inconvenient for skins that are regenerated by an external process — e.g. a script that derives an mc skin from the desktop theme and wants it to apply live, without the user closing and reopening mc.

On Linux, this watches the active skin file with `inotify` and re-applies it automatically on change, reusing the same reload path (`mc_skin_deinit` + `mc_skin_init` + panel/filehighlight refresh + `repaint_screen`) already used by the interactive skin picker in the Appearance dialog (`src/filemanager/boxes.c`'s `skin_apply`), now exposed as `mc_skin_reload()`. The watch fd is integrated into the existing `select()` loop via `add_select_channel()`/`delete_select_channel()`, the same generic mechanism already used for background job and subshell pipes — no new event-loop machinery.

The watch is armed once at startup and intentionally never re-armed on each event: the expected write pattern is an in-place truncate+write, which never invalidates the original watch descriptor. Re-arming from within the event callback was tried first and found to self-trigger forever, since `inotify_rm_watch()` itself raises `IN_IGNORED` on the same fd, which the next `select()` sees immediately — worth calling out in case it comes up in review.

This is Linux-only (`inotify` has no equivalent on the other platforms mc supports), guarded with `#ifdef __linux__`, matching existing precedent elsewhere in the tree (`cons.handler.c`, `key.c`, `subshell/proxyfunc.c`).

Manually verified: launched mc, edited the active skin file's colors on disk, and confirmed the running instance recolors in place with no restart, no keypress, and no measurable CPU overhead at idle or after reload.

## Checklist

- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — this changes runtime behavior at the process/event-loop level (verified manually as described above); happy to add coverage if there's a preferred pattern for this kind of thing in the existing test suite
- [ ] I have added the necessary documentation — didn't see an obvious place to document this in the man pages; pointers welcome