### PR TITLE
Fix clipboard settings being overwritten with empty values on exit

### DIFF
--- a/src/setup.c
+++ b/src/setup.c
@@ -1020,10 +1020,12 @@ save_setup (gboolean save_options, gboolean save_panel_options)
                               spell_language);
 #endif
 
-        mc_config_set_string (mc_global.main_config, CONFIG_MISC_SECTION, "clipboard_store",
-                              clipboard_store_path);
-        mc_config_set_string (mc_global.main_config, CONFIG_MISC_SECTION, "clipboard_paste",
-                              clipboard_paste_path);
+        if (clipboard_store_path[0] != '\0')
+            mc_config_set_string (mc_global.main_config, CONFIG_MISC_SECTION, "clipboard_store",
+                                  clipboard_store_path);
+        if (clipboard_paste_path[0] != '\0')
+            mc_config_set_string (mc_global.main_config, CONFIG_MISC_SECTION, "clipboard_paste",
+                                  clipboard_paste_path);
 
         tmp_profile = mc_config_get_full_path (MC_CONFIG_FILE);
         ret = mc_config_save_to_file (mc_global.main_config, tmp_profile, NULL);


### PR DESCRIPTION
## Proposed changes

When multiple mc instances are running, clipboard_store and clipboard_paste settings in the ini file get reset to empty strings.

Steps to reproduce:
1. Set clipboard_store and clipboard_paste in ~/.config/mc/ini
2. Open multiple mc instances in different terminals
3. Close one mc instance — it saves the config with the correct values
4. Close another mc instance that was started before the config was edited — it reads the OLD ini (before edits were made), loads empty strings for clipboard_store/clipboard_paste, and overwrites the config, erasing the user's settings

The root cause is that save_setup() unconditionally writes clipboard_store_path and clipboard_paste_path to the ini file, even when they are empty strings (which is the default when no clipboard utility is configured through mc's UI). This means any mc instance that started before the user edited the ini will overwrite the settings with empty values when it exits.

Fix: only write clipboard_store and clipboard_paste to the ini when the values are non-empty, preserving user-configured values.

## Checklist

- [ ] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [x] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
