### PR TITLE
Ticket #5112: highlight OpenSSH ssh_config / sshd_config files

### DIFF
--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -357,6 +357,9 @@ include toml.syntax
 file .\*\\.(mch|ref|imp)$ B\sFile
 include b.syntax
 
+file (.\*/)?ssh(d)?_config(\\..\*)?$ OpenSSH\sconfig\sfile
+include conf.syntax
+
 file ..\*\\.(?i:cfg|cnf|conf)$ Config\sfile
 include conf.syntax
 


### PR DESCRIPTION
## Proposed changes

Map extensionless OpenSSH client and server config filenames (`ssh_config`, `sshd_config`, and dotted backups such as `sshd_config.bak`) to the existing `conf.syntax` highlighter so mcedit no longer reports them as `unknown`.

Drop-ins under `*.d/*.conf` were already covered by the generic `*.conf` rule.

* Resolves: #5112

## Checklist
- [x] I have referenced the issue(s) resolved by this PR (if any)
- [x] I have signed-off my contribution with `git commit --amend -s`
- [ ] Lint and unit tests pass locally with my changes (`make indent && make check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)


